### PR TITLE
Remove unneded type tags for scripts

### DIFF
--- a/public/templates/header.tpl
+++ b/public/templates/header.tpl
@@ -9,11 +9,11 @@
 	<script>
 		var RELATIVE_PATH = "{relative_path}";
 	</script>
-	<script type="text/javascript" src="http://code.jquery.com/jquery.js"></script>
-	<script type="text/javascript" src="{relative_path}/vendor/jquery/js/jquery-ui-1.10.3.custom.min.js"></script>
-	<script type="text/javascript" src="{relative_path}/vendor/bootstrap/js/bootstrap.min.js"></script>
-	<script type="text/javascript" src="{relative_path}/socket.io/socket.io.js"></script>
-	<script type="text/javascript" src="{relative_path}/src/app.js"></script>
+	<script src="http://code.jquery.com/jquery.js"></script>
+	<script src="{relative_path}/vendor/jquery/js/jquery-ui-1.10.3.custom.min.js"></script>
+	<script src="{relative_path}/vendor/bootstrap/js/bootstrap.min.js"></script>
+	<script src="{relative_path}/socket.io/socket.io.js"></script>
+	<script src="{relative_path}/src/app.js"></script>
 	<script src="{relative_path}/vendor/requirejs/require.js"></script>
 	<script src="{relative_path}/vendor/bootbox/bootbox.min.js"></script>
 	<script>
@@ -22,13 +22,12 @@
 			waitSeconds: 3
 		});
 	</script>
-	<script type="text/javascript" src="{relative_path}/src/templates.js"></script>
-	<script type="text/javascript" src="{relative_path}/src/ajaxify.js"></script>
-	<script type="text/javascript" src="{relative_path}/src/jquery.form.js"></script>
-	<script type="text/javascript" src="{relative_path}/src/utils.js"></script>
+	<script src="{relative_path}/src/templates.js"></script>
+	<script src="{relative_path}/src/ajaxify.js"></script>
+	<script src="{relative_path}/src/jquery.form.js"></script>
+	<script src="{relative_path}/src/utils.js"></script>
 
 	<link rel="stylesheet" type="text/css" href="{relative_path}/css/nodebb.css" />
-
 
 </head>
 


### PR DESCRIPTION
In HTML5 we can omit the type tag for scripts because it's useless to determine the type for javascript.

http://www.w3.org/html/wg/drafts/html/master/scripting-1.html#the-script
-element

"When used to include dynamic scripts, the scripts may either be
embedded inline or may be imported from an external file using the src
attribute. If the language is not that described by "text/javascript",
then the type attribute must be present, as described below. Whatever
language is used, the contents of the script element must conform with
the requirements of that language's specification."

PS: That's a test of a Pull Request. Firs time, sorry if I'm breaking something.
