### PR TITLE
#161 - meta.js problem with empty config var

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -9,6 +9,7 @@ var utils = require('./../public/src/utils.js'),
 		get: function(callback) {
 			RDB.hgetall('config', function(err, config) {
 				if (!err) {
+					config = config || {};
 					config.status = 'ok';
 					callback(config);
 				} else {


### PR DESCRIPTION
If config is empty, give to it an empty object value.
