### PR TITLE
fixed an issue with Logger.io_close, needed to check for undefined

### DIFF
--- a/public/templates/admin/logger.tpl
+++ b/public/templates/admin/logger.tpl
@@ -40,10 +40,7 @@
 <button class="btn btn-lg btn-primary" id="save">Save</button>
 
 <script>
-	var	loadDelay = setInterval(function() {
-		if (nodebb_admin) {
-			nodebb_admin.prepare();
-			clearInterval(loadDelay);
-		}
-	}, 500);
+	require(['forum/admin/settings'], function(Settings) {
+		Settings.prepare();
+	});
 </script>

--- a/src/logger.js
+++ b/src/logger.js
@@ -139,10 +139,10 @@ var opts = {
 		for(var v in clients) {
 			var client = clients[v];
 
-			if(client.oEmit != client.emit)
+			if(client.oEmit != undefined && client.oEmit != client.emit)
 				client.emit = client.oEmit;
 
-			if(client.$oEmit != client.$emit)
+			if(client.$oEmit != undefined && client.$oEmit != client.$emit)
 				client.$emit = client.$oEmit;
 		}
 	}


### PR DESCRIPTION
Small change needed in Logger.io_close. If client.oEmit or client.$oEmit are undefined, don't do anything. This means that we've never set/enabled socket.io event logging.
