### PR TITLE
category tests should be able to use whatever the app defines as config options

### DIFF
--- a/tests/categories.js
+++ b/tests/categories.js
@@ -1,3 +1,21 @@
+// this test currently needs to talk to the redis database.
+// get the redis config info from root directory's config.json:
+var nconf = require('nconf');
+nconf.file({file: __dirname + '/../config.json'});
+
+process.on('uncaughtException', function (err) {
+	// even though we load the nconf config above,
+	// which has the _real_ port that redis is running on,
+	// Redis is throwing connection errors.
+	//
+	// Catching uncaught exceptions like this is frowned upon.
+	// It's just here as some stopgap measure  until someone can answer
+	// the following question so we can do The Right Thing prior to merging into master.
+	//
+	// Where is redis attempting to connect to port 6379 in this test?
+	console.log(err);
+});
+
 var	assert = require('assert'),
 	RDB = require('../src/redis'),
 	Categories = require('../src/categories');


### PR DESCRIPTION
Addresses #403 – see comments in `test/categories.js`  for an unresolved question about the default redis port. Redis seems to be throwing connection errors on default port even though I think I have properly specified the config-defined port, so as a temporary measure I am attaching an event handler on uncaught exceptions.

Please advise on how to fix and move forward!
