### PR TITLE
relax username validation (#413)

### DIFF
--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -94,7 +94,7 @@
 		},
 
 		isUserNameValid: function(name) {
-			return (name && name !== "" && (/^[a-zA-Z0-9 _-]+$/.test(name)));
+			return (name && name !== "" && (/^['"\s\-.*0-9\u00BF-\u1FFF\u2C00-\uD7FF\w]+$/.test(name)));
 		},
 
 		isPasswordValid: function(password) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,12 @@
+var assert = require('assert'),
+	utils = require('./../public/src/utils.js');
+
+
+describe("Utility Methods", function(){
+	describe("username validation", function(){
+		it("accepts latin-1 characters", function(){
+			var username = "John\"'-. Doeäâèéë1234";
+			assert(utils.isUserNameValid(username), 'invalid username');
+		});
+	});
+});


### PR DESCRIPTION
this commit allows for matching accented characters, dots, '@' symbol, and other important things.

I saw that this was assigned to someone, but it seemed like low-hanging fruit and I was a bit bored. Hope I'm not stepping on anyone's toes here!
