### PR TITLE
Utils.js cleanup

### DIFF
--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -3,9 +3,9 @@
 
 	var utils, fs;
 
-	try {
+	if ('undefined' === typeof window) {
 		fs = require('fs');
-	} catch (e) {}
+	}
 
 
 	module.exports = utils = {


### PR DESCRIPTION
For utils.js to shine even brighter - most of the changes are extremely minor, so there is a single pull request with 3 small commits
1. converted it to work in strict mode, fixed absent `var`, satisfied jshint
2. cleaned up unused code - around the whole system only `trim` was used. it should be easier to add other trims or use specific lib than keep bloated code
3. instead of silent try/catch now 'if' is used - confirmed and worked both on node and browser
