### PR TITLE
add breadcrumb like context to favorites

### DIFF
--- a/public/templates/favourites.tpl
+++ b/public/templates/favourites.tpl
@@ -13,7 +13,8 @@
 			<!-- BEGIN posts -->
 			<div class="topic-row img-thumbnail clearfix" topic-url="topic/{posts.tid}/#{posts.pid}">
 				<span><strong>{posts.username}</strong> : </span>
-				<span>{posts.content}</span>
+				<span>{posts.category_name} >> {posts.title}</span>
+				<div>{posts.content}</div>
 				<div>
 					<span class="pull-right timeago" title="{posts.relativeTime}"></span>
 				</div>


### PR DESCRIPTION
Adding a little more info to data returned for the post summary, and using it for context on the favorites page.

Not a UI/UX guy, so feel free to ditch/tweak the favourites.tpl change.

Also thoughts on either Validating/sanitizing all data on the way in before storing, or moving sanitization more centrally like the get*Fields calls to avoid sanitization code everywhere (or worse forgotten)? 
