### PR TITLE
Adding support for restricting category read access based on user groups

### DIFF
--- a/public/templates/admin/categories.tpl
+++ b/public/templates/admin/categories.tpl
@@ -154,6 +154,12 @@
 						</div>
 					</form>
 					<ul class="search-results"></ul>
+					<form role="form">
+						<div class="form-group">
+							<label for="permission-group-pick">User Groups</label>
+						</div>
+					</form>
+					<ul class="groups-results"></ul>
 				</div>
 			</div>
 		</div>

--- a/src/categoryTools.js
+++ b/src/categoryTools.js
@@ -65,4 +65,56 @@ CategoryTools.privileges = function(cid, uid, callback) {
 	});
 };
 
+CategoryTools.groupPrivileges = function(cid, gid, callback) {
+	async.parallel({
+		"+gr": function(next) {
+			var	key = 'cid:' + cid + ':privileges:+gr';
+			Groups.exists(key, function(err, exists) {
+				if (exists) {
+					async.parallel({
+						isMember: function(next) {
+							Groups.isMemberByGroupName(gid, key, next);
+						},
+						isEmpty: function(next) {
+							Groups.isEmptyByGroupName(key, next);
+						}
+					}, next);
+				} else {
+					next(null, {
+						isMember: false,
+						isEmpty: true
+					});
+				}
+			});
+		},
+		"+gw": function(next) {
+			var	key = 'cid:' + cid + ':privileges:+gw';
+			Groups.exists(key, function(err, exists) {
+				if (exists) {
+					async.parallel({
+						isMember: function(next) {
+							Groups.isMemberByGroupName(gid, key, next);
+						},
+						isEmpty: function(next) {
+							Groups.isEmptyByGroupName(key, next);
+						}
+					}, next);
+				} else {
+					next(null, {
+						isMember: false,
+						isEmpty: true
+					});
+				}
+			});
+		}
+	}, function(err, privileges) {
+		callback(err, !privileges ? null : {
+			"+gr": privileges['+gr'].isMember,
+			"+gw": privileges['+gw'].isMember,
+			read: (privileges['+gr'].isMember || privileges['+gr'].isEmpty),
+			write: (privileges['+gw'].isMember || privileges['+gw'].isEmpty),
+		});
+	});
+};
+
 module.exports = CategoryTools;

--- a/src/groups.js
+++ b/src/groups.js
@@ -263,4 +263,40 @@
 		});
 	};
 
+	Groups.getCategoryAccess = function(cid, uid, callback){
+		var access = false;
+		// check user group read access level
+		async.series([function(callback){
+			// get groups with read permission
+			db.getObjectField('group:gid', 'cid:' + cid + ':privileges:+gr', function(err, gid){
+				// get the user groups that belong to this read group
+				db.getSetMembers('gid:' + gid + ':members', function (err, gids) {
+					// check if user belong to any of these user groups
+					var groups_check = new Array();
+					gids.forEach(function(cgid){
+						groups_check.push(function(callback){
+							Groups.isMember(uid, cgid, function(err, isMember){
+								if (isMember){
+									access = true;
+								}
+								callback(null, gids);
+							})
+						});
+					});
+					// do a series check. We want to make sure we check all the groups before determining if the user
+					// has access or not.
+					async.series(groups_check, function(err, results){
+						callback(null, results);
+					});								
+				});
+			});
+		
+		}],
+		function(err, results){
+			// if the read group is empty we will asume that read access has been granted to ALL
+			if (results[0].length == 0){ access = true; }
+			callback(false, access);
+		});
+	};
+
 }(module.exports));

--- a/src/websockets.js
+++ b/src/websockets.js
@@ -1084,6 +1084,37 @@ websockets.init = function(io) {
 			});
 		});
 
+		socket.on('api:admin.categories.setGroupPrivilege', function(cid, gid, privilege, set, callback) {
+			var	cb = function(err) {
+				CategoryTools.groupPrivileges(cid, gid, callback);
+			};
+
+			if (set) {
+				groups.joinByGroupName('cid:' + cid + ':privileges:' + privilege, gid, cb);
+			} else {
+				groups.leaveByGroupName('cid:' + cid + ':privileges:' + privilege, gid, cb);
+			}
+		});
+		
+		socket.on('api:admin.categories.groupsearch', function(cid, callback) {
+			groups.list({expand:false}, function(err, data){
+				async.map(data, function(groupObj, next) {
+					CategoryTools.groupPrivileges(cid, groupObj.gid, function(err, privileges) {
+						if (!err) {
+							groupObj.privileges = privileges;
+						} else {
+							winston.error('[socket api:admin.categories.groupsearch] Could not retrieve permissions');
+						}
+
+						next(null, groupObj);
+					});
+				}, function(err, data) {
+					if (!callback) socket.emit('api:admin.categories.groupsearch', data);
+					else callback(null, data);
+				});		
+			});
+		});
+
 		socket.on('api:admin.themes.getInstalled', function(callback) {
 			meta.themes.get(function(err, themeArr) {
 				callback(themeArr);


### PR DESCRIPTION
Added this functionality since it's a core feature for us as we are evaluating using NodeBB for a game forum. The most common use case:

Setup read access restrictions to a category in the forum based on user groups. i.e. if a user is part of a "test group" he will be able to access the "Testing Feedback" category. If the user is not part of the "test group" (or is anonymous) then access is denied for him. 

This first contribution accounts for read access only. I'm planning on adding write access next.
