### PR TITLE
Install automated setup

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -254,6 +254,21 @@ var async = require('async'),
 					}, function (err) {
 						meta.configs.init(next);
 					});
+
+					if (install.values) {
+						if (install.values['social:twitter:key'] && install.values['social:twitter:secret']) {
+							meta.configs.setOnEmpty('social:twitter:key', install.values['social:twitter:key']);
+							meta.configs.setOnEmpty('social:twitter:secret', install.values['social:twitter:secret']);
+						}
+						if (install.values['social:google:id'] && install.values['social:google:secret']) {
+							meta.configs.setOnEmpty('social:google:id', install.values['social:google:id']);
+							meta.configs.setOnEmpty('social:google:secret', install.values['social:google:secret']);
+						}
+						if (install.values['social:facebook:key'] && install.values['social:facebook:secret']) {
+							meta.configs.setOnEmpty('social:facebook:app_id', install.values['social:facebook:app_id']);
+							meta.configs.setOnEmpty('social:facebook:secret', install.values['social:facebook:secret']);
+						}
+					}
 				},
 				function (next) {
 					// Check if an administrator needs to be created


### PR DESCRIPTION
1) I found a problem that when I run node app --setup='{ "admin:username": "xxx", "admin:password": "xxx", "admin:password:confirm": "xxx", "admin:email": "x" }', the default values below are appended to config.json.

```
"redis:host": "127.0.0.1",
"redis:port": 6379,
"redis:password": "",
"redis:database": "",
"mongo:host": "127.0.0.1",
"mongo:port": "27017",
"mongo:username": "",
"mongo:password": "",
"mongo:database": "nodebb",
```

2) I would like a way to set social network logins via automated setup. I am not sure if you currently have the way to do that.
