### PR TITLE
guarding against Errors on Socket Disconnect

### DIFF
--- a/src/websockets.js
+++ b/src/websockets.js
@@ -106,12 +106,12 @@ websockets.init = function(io) {
 
 		socket.on('disconnect', function() {
 
-			var index = userSockets[uid].indexOf(socket);
+			var index = (userSockets[uid] || []).indexOf(socket);
 			if (index !== -1) {
 				userSockets[uid].splice(index, 1);
 			}
 
-			if (userSockets[uid].length === 0) {
+			if (userSockets[uid] && userSockets[uid].length === 0) {
 				delete users[sessionID];
 				delete userSockets[uid];
 				if (uid) {


### PR DESCRIPTION
Saw this 

```
TypeError: Cannot call method 'indexOf' of undefined
    at Socket.<anonymous> (/home/admin/NodeBB/src/websockets.js:108:33)
    at Socket.EventEmitter.emit [as $emit] (events.js:95:17)
    at Socket.onDisconnect (/home/admin/NodeBB/node_modules/socket.io/lib/socket.js:153:10)
    at SocketNamespace.handleDisconnect (/home/admin/NodeBB/node_modules/socket.io/lib/namespace.js:229:46)
```

and this

```
/home/admin/NodeBB/src/websockets.js:113
            if (userSockets[uid].length === 0) {
                                ^
TypeError: Cannot read property 'length' of undefined
    at Socket.<anonymous> (/home/admin/NodeBB/src/websockets.js:113:24)
```

in my logs, when users are disconnecting
