### PR TITLE
Calculate age based on days instead of years

### DIFF
--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -539,7 +539,7 @@ var fs = require('fs'),
 						if (!data.birthday) {
 							data.age = '';
 						} else {
-							data.age = new Date().getFullYear() - new Date(data.birthday).getFullYear();
+							data.age = Math.floor((new Date().getTime() - new Date(data.birthday).getTime()) / 31536000000);
 						}
 
 						function canSeeEmail() {


### PR DESCRIPTION
Calculating the age based on the year only caused issues in the display of the age because it was off. Example: Person who was born in march of 1999 is displayed as 15 instead of 14 after the turn of the year.
