### PR TITLE
Fix plugin CSS files on Windows

### DIFF
--- a/src/webserver.js
+++ b/src/webserver.js
@@ -95,7 +95,7 @@ if(nconf.get('ssl')) {
 				}],
 				templateValues = {
 					cssSrc: meta.config['theme:src'] || nconf.get('relative_path') + '/vendor/bootstrap/css/bootstrap.min.css',
-					pluginCSS: plugins.cssFiles.map(function(file) { return { path: nconf.get('relative_path') + file + (meta.config['cache-buster'] ? '?v=' + meta.config['cache-buster'] : '') }; }),
+					pluginCSS: plugins.cssFiles.map(function(file) { return { path: nconf.get('relative_path') + file.replace(/\\/g, '/') + (meta.config['cache-buster'] ? '?v=' + meta.config['cache-buster'] : '') }; }),
 					title: meta.config.title || '',
 					description: meta.config.description || '',
 					'brand:logo': meta.config['brand:logo'] || '',


### PR DESCRIPTION
On Windows, because of `path`, CSS file paths from plugins will be formatted using `\`. Browsers don't like this though, and won't be able to find the CSS files, resulting in all the plugin CSS files not being able to load.

This dirty but simple fix will allow CSS files to be loaded.
