### PR TITLE
Only alternate title when not focused

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -407,7 +407,7 @@ var socket,
 			return;
 		}
 
-		if (title.length > 0) {
+		if (title.length > 0 && !app.isFocused) {
 			titleObj.titles[1] = title;
 			if (titleObj.interval) {
 				clearInterval(titleObj.interval);


### PR DESCRIPTION
Right now when setting an alternating title it'll always alternate, whether you're focused or not. I find this really irritating because I have to unfocus and focus my tab to make it go away. 
This simple fix will only set the alternating title when the window is not focused.
