### PR TITLE
Add callback to mongo.searchRemove, fixes infinite schema update

### DIFF
--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -145,11 +145,14 @@
 		});
 	}
 
-	module.searchRemove = function(key, id) {
+	module.searchRemove = function(key, id, callback) {
 		db.collection('search').remove({id:id, key:key}, function(err, result) {
 			if(err) {
 				winston.error('Error removing search ' + err.message);
 			}
+      if (typeof callback === 'function') {
+        callback()
+      }
 		});
 	}
 


### PR DESCRIPTION
db.searchRemove expects a callback, only the redis module had it, causing mongo users to be forever stuck in the schema update. This adds that callback so that the schema update can finish.
