### PR TITLE
Implement favourite tooltip to show who favourited a post

### DIFF
--- a/public/src/forum/topic.js
+++ b/public/src/forum/topic.js
@@ -342,7 +342,16 @@ define(['composer'], function(composer) {
 				}
 			})();
 
-			$('.favourite-tooltip').tooltip();
+			$('#post-container').on('mouseenter', '.favourite-tooltip', function(e) {
+				if (!$(this).data('users-loaded')) {
+					$(this).data('users-loaded', "true");
+					var pid = $(this).parents('.post-row').attr('data-pid');
+					var el = $(this).attr('title', "Loading...");
+					socket.emit('posts.getFavouritedUsers', pid, function(err, usernames) {
+						el.attr('title', usernames).tooltip('show');
+					});
+				}
+			});
 		});
 
 		function enableInfiniteLoading() {

--- a/public/templates/topic.tpl
+++ b/public/templates/topic.tpl
@@ -66,7 +66,7 @@
 							<!-- IF @first -->
 							<button class="btn btn-sm btn-default follow" type="button" title="Be notified of new replies in this topic"><i class="fa fa-eye"></i></button>
 							<!-- ENDIF @first -->
-							<button title="{posts.favourited_users}" data-favourited="{posts.favourited}" class="favourite favourite-tooltip btn btn-sm btn-default <!-- IF posts.favourited --> btn-warning <!-- ENDIF posts.favourited -->" type="button">
+							<button data-favourited="{posts.favourited}" class="favourite favourite-tooltip btn btn-sm btn-default <!-- IF posts.favourited --> btn-warning <!-- ENDIF posts.favourited -->" type="button">
 								<span class="favourite-text">[[topic:favourite]]</span>
 								<span class="post_rep_{posts.pid}">{posts.reputation} </span>
 								<!-- IF posts.favourited -->

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -3,6 +3,7 @@ var	posts = require('../posts'),
 	topics = require('../topics'),
 	favourites = require('../favourites'),
 	postTools = require('../postTools'),
+	user = require('../user'),
 	index = require('./index'),
 
 	SocketPosts = {};
@@ -165,6 +166,30 @@ SocketPosts.getPrivileges = function(socket, pid, callback) {
 		}
 		privileges.pid = parseInt(pid);
 		callback(null, privileges);
+	});
+};
+
+SocketPosts.getFavouritedUsers = function(socket, pid, callback) {
+	favourites.getFavouritedUidsByPids([pid], function(data) {
+		var max = 5; //hardcoded
+		var usernames = "";
+
+		var pid_uids = data[pid];
+		var rest_amount = 0;
+		if (data.hasOwnProperty(pid) && pid_uids.length > 0) {
+			if (pid_uids.length > max) {
+				rest_amount = pid_uids.length - max;
+				pid_uids = pid_uids.slice(0, max);
+			}
+			user.getUsernamesByUids(pid_uids, function(result) {
+				usernames = result.join(', ') + (rest_amount > 0
+					? " and " + rest_amount + (rest_amount > 1 ? " others" : " other")
+					: "");
+				callback(null, usernames);
+			});
+		} else {
+			callback(null, "");
+		}
 	});
 };
 


### PR DESCRIPTION
As per http://community.nodebb.org/topic/577/who-favorite-d-your-post.

Adds a `posts.favourited_users` field, easy for themers to use. Usernames are separated by comma. I've also added a `favourite-tooltip` class to easily select all the buttons that need a tooltip. Also for themers to use.

I swear I had a different implementation for `favourites.js` at first but then I thought "Why not copy their code, then I know for 100% that they'll accept it :D"
