### PR TITLE
Remove toString from mongo.listRemoveAll, add ability to remove array of items

### DIFF
--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -732,10 +732,11 @@
 	}
 
 	module.listRemoveAll = function(key, value, callback) {
-		if(value !== null && value !== undefined) {
-			value = value.toString();
+		var operator = { $pull: {array: value} };
+		if (typeof(value === 'array')) {
+			operator = { $pullAll: {array: value } };
 		}
-		db.collection('objects').update({_key: key }, { $pull: { array: value } }, function(err, result) {
+		db.collection('objects').update({_key: key }, operator, function(err, result) {
 			if(err) {
 				if(callback) {
 					return callback(err);


### PR DESCRIPTION
db.listRemoveAll only allowed the removal of strings in mongo. I've also added the ability to remove an array of items. 

I don't know anything about redis so I don't know if the current implementation already supports that or not, but it'd be nice if one of you can implement the redis side of this. (The removing of an array of items)
