### PR TITLE
Add custom templates to /api/get_templates_listing

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -23,7 +23,9 @@ var path = require('path'),
 		app.namespace('/api', function () {
 			app.get('/get_templates_listing', function (req, res) {
 				utils.walk(path.join(__dirname, '../../', 'public/templates'), function (err, data) {
-					res.json(data);
+					res.json(data.concat(app.get_custom_templates()).filter(function(value, index, self) {
+						return self.indexOf(value) === index;
+					}));
 				});
 			});
 

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -877,6 +877,12 @@ module.exports.server = server;
 			'templates': []
 		};
 
+		app.get_custom_templates = function() {
+			return custom_routes.templates.map(function(tpl) {
+				return tpl.template.split('.tpl')[0];
+			});
+		}
+
 		plugins.ready(function() {
 			plugins.fireHook('filter:server.create_routes', custom_routes, function(err, custom_routes) {
 				var routes = custom_routes.routes;


### PR DESCRIPTION
This has to do with https://github.com/designcreateplay/NodeBB/issues/849, https://github.com/designcreateplay/NodeBB/pull/846 and https://github.com/designcreateplay/NodeBB/issues/765

This adds custom_routes.templates to to /api/get_templates_listing. This allows plugins to ajaxify their pages (@psychobunny)
