### PR TITLE
Reworked startup sequence to respect server.listen() failures and timings

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,8 +84,7 @@ function start() {
 	nconf.set('base_dir', __dirname);
 
 	winston.info('Time: ' + new Date());
-	winston.info('Initializing NodeBB v' + pkg.version + ', on port ' + nconf.get('port') + ', using ' + nconf.get('database') +' store at ' + nconf.get(nconf.get('database') + ':host') + ':' + nconf.get(nconf.get('database') + ':port') + '.');
-	winston.info('NodeBB instance bound to: ' + ((nconf.get('bind_address') === "0.0.0.0" || !nconf.get('bind_address')) ? 'Any address (0.0.0.0)' : nconf.get('bind_address')));
+	winston.info('Initializing NodeBB v' + pkg.version + ', using ' + nconf./**/get('database') +' store at ' + nconf.get(nconf.get('database') + ':host') + ':' + nconf.get(nconf.get('database') + ':port') + '.');
 
 	if (process.env.NODE_ENV === 'development') {
 		winston.info('Base Configuration OK.');

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -415,8 +415,20 @@ module.exports.server = server;
 			templates.logout = parsedTemplate;
 		});
 
-		winston.info('NodeBB Ready');
-		server.listen(nconf.get('PORT') || nconf.get('port'), nconf.get('bind_address'));
+		server.on("error", function(e){
+			if (e.code === 'EADDRINUSE') {
+				winston.error('NodeBB address in use, exiting...');
+				process.exit(1);
+			} else {
+				throw e;
+			}
+		});
+
+		var port = nconf.get('PORT') || nconf.get('port');
+		winston.info('NodeBB attempting to listen on: ' + ((nconf.get('bind_address') === "0.0.0.0" || !nconf.get('bind_address')) ? '0.0.0.0' : nconf.get('bind_address')) + ':' + port);
+		server.listen(port, nconf.get('bind_address'), function(){
+			winston.info('NodeBB Ready');
+		});
 	};
 
 	app.create_route = function (url, tpl) { // to remove


### PR DESCRIPTION
Previously we had the following errors:
- if the port was already in use, the startup silently failed.
- the message saying NodeBB was ready and bound to a socket came before it was really listening on the socket

This changeset fixes #982, as it finally annoyed me enough.
