### PR TITLE
No point in having anonymous users as a link.

### DIFF
--- a/public/templates/users.tpl
+++ b/public/templates/users.tpl
@@ -41,9 +41,7 @@
 		</li>
 		<!-- END users -->
 		<li class="users-box {show_anon} anon-user">
-			<a href="#">
-				<img src="https://secure.gravatar.com/avatar/" class="img-thumbnail"/>
-			</a>
+			<img src="https://secure.gravatar.com/avatar/" class="img-thumbnail"/>
 			<br/>
 			<div class="user-info">
 				<span id="online_anon_count">{anonymousUserCount}</span>


### PR DESCRIPTION
Also fixes this ugly behaviour:
![2014-02-10_20-34-35](https://f.cloud.github.com/assets/330645/2129707/9e516e04-928a-11e3-9086-07d004f244d1.png)
Into this:
![2014-02-10_20-36-33](https://f.cloud.github.com/assets/330645/2129710/a8d01ed4-928a-11e3-9b3f-09867f99ee97.png)
