### PR TITLE
Remove config.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 npm-debug.log
 node_modules/
 sftp-config.json
-config.json
 public/src/nodebb.min.js
 public/config.json
 public/css/*.css


### PR DESCRIPTION
This is useful so that you can check-in your configuration to a private git repository, without having to patch this file. Granted, if you have your forum as open source, then it could become an issue. Thoughts on the best solution?
