### PR TITLE
Minor performance fix with css load order

### DIFF
--- a/public/templates/header.tpl
+++ b/public/templates/header.tpl
@@ -14,6 +14,12 @@
 	<!-- BEGIN pluginCSS -->
 	<link rel="stylesheet" href="{pluginCSS.path}?{cache-buster}">
 	<!-- END pluginCSS -->
+	<!-- TODO : this has to be refactored, maybe configured from ACP? -baris -->
+	<link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css">
+	<!-- IF useCustomCSS -->
+	<style type="text/css">{customCSS}</style>
+	<!-- ENDIF useCustomCSS -->
+
 	<script>
 		var RELATIVE_PATH = "{relative_path}";
 	</script>
@@ -31,12 +37,6 @@
 			}
 		});
 	</script>
-
-	<!-- TODO : this has to be refactored, maybe configured from ACP? -baris -->
-	<link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css">
-	<!-- IF useCustomCSS -->
-	<style type="text/css">{customCSS}</style>
-	<!-- ENDIF useCustomCSS -->
 </head>
 
 <body>


### PR DESCRIPTION
I'm currently looking at improving page load times for NodeBB. Chrome dev tools gave me the following:

```
Optimize the order of styles and scripts (3)
  The following external CSS files were included after an external JavaScript file in the document head. To ensure CSS files are downloaded in parallel, always include external CSS before external JavaScript.
    jquery-ui.css
  2 inline script blocks were found in the head between an external CSS file and another resource. To allow parallel downloading, move the inline script before the external CSS file, or after the next resource.
```

I simply moved the styles above the scripts, keeping the styles in order.
