### PR TITLE
Fix crash when there would be no widgets

### DIFF
--- a/src/widgets.js
+++ b/src/widgets.js
@@ -37,6 +37,9 @@ var async = require('async'),
 
 	Widgets.getArea = function(template, location, callback) {
 		db.getObjectField('widgets:' + template, location, function(err, widgets) {
+			if (!widgets) {
+				return callback(err, []);
+			}
 			callback(err, JSON.parse(widgets));
 		})
 	};


### PR DESCRIPTION
If no widgets are in the database, NodeBB would crash because `async.eachSeries` would receive `null`. If there are no widgets in the database, return an empty array.
