### PR TITLE
Make themes tab the default active tab again

### DIFF
--- a/public/templates/admin/themes.tpl
+++ b/public/templates/admin/themes.tpl
@@ -9,7 +9,7 @@
 	</ul>
 
 	<div class="tab-content">
-		<div class="tab-pane" id="themes">
+		<div class="tab-pane active" id="themes">
 			<h3>Installed Themes</h3>
 			<p>
 				The following themes are currently installed in this NodeBB instance.
@@ -50,7 +50,7 @@
 
 			<button class="btn btn-primary" id="save">Save</button>
 		</div>
-		<div class="tab-pane active" id="widgets">
+		<div class="tab-pane" id="widgets">
 			<h3>Widgets</h3>
 
 			<div class="row">


### PR DESCRIPTION
Widgets was the default open tab, but not the default active tab. I suppose for a themes page that the themes should be the default open tab.
