### PR TITLE
Installation instructions CentOS 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ NodeBB requires the following software to be installed:
 * Redis, version 2.6 or greater **or** MongoDB, version 2.4 or greater
 * nginx, version 1.3.13 or greater (**only if** intending to use nginx to proxy requests to a NodeBB)
 
-## Installation
+## Installation Ubuntu
 
 First, we install our base software stack:
 
@@ -57,7 +57,42 @@ Next, clone this repository:
 Obtain all of the dependencies required by NodeBB:
 
     $ cd nodebb
+    $ npm config set strict-ssl false
     $ npm install
+    $ npm config set strict-ssl true
+
+Initiate the setup script by running the app with the `--setup` flag:
+
+    $ ./nodebb setup
+
+The default settings are for a local server running on the default port, with a redis store on the same machine/port.
+
+Lastly, we run the forum.
+
+    $ ./nodebb start
+
+NodeBB can also be started with helper programs, such as `supervisor` and `forever`. [Take a look at the options here](https://github.com/designcreateplay/NodeBB/wiki/How-to-run-NodeBB).
+
+
+## Installation CentOS 6.5
+
+First, we install our base software stack:
+
+	# yum update
+	# yum groupinstall "Development Tools" -y
+	# yum install nodejs git redis ImageMagick
+
+Next, clone this repository:
+
+	$ cd /path/to/nodebb/install/location
+	$ git clone git://github.com/designcreateplay/NodeBB.git nodebb
+
+Obtain all of the dependencies required by NodeBB:
+
+    $ cd nodebb
+    $ npm config set strict-ssl false
+    $ npm install
+    $ npm config set strict-ssl true
 
 Initiate the setup script by running the app with the `--setup` flag:
 


### PR DESCRIPTION
ReadME.MD Adding installation instructions for CentOS 6.5, also adding npm strict-ssl to false to allow some npm packages that have self signed certs.
