### PR TITLE
Don't fire click when closing an alert

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -231,8 +231,10 @@ var socket,
 			}
 
 			if (typeof params.clickfn === 'function') {
-				alert.on('click', function () {
-					params.clickfn();
+				alert.on('click', function (e) {
+					if(!$(e.target).is('.close')) {
+						params.clickfn();
+					}
 					fadeOut();
 				});
 			}


### PR DESCRIPTION
We noticed that the "go back" popup that appears when using pagination always navigates back, even when you click the "X" to close.  Looks like the clickFn fires no matter where you click in the alert box, so I added a guard condition to not fire clickFn when you click on the "X".
