### PR TITLE
Send the callback to the retry

### DIFF
--- a/public/src/forum/admin/settings.js
+++ b/public/src/forum/admin/settings.js
@@ -9,7 +9,7 @@ define(['uploader'], function(uploader) {
 		// Come back in 125ms if the config isn't ready yet
 		if (!app.config) {
 			setTimeout(function() {
-				Settings.prepare();
+				Settings.prepare(callback);
 			}, 125);
 			return;
 		}


### PR DESCRIPTION
Was wondering why sometimes my callback wasn't called. Turns out it's ignored on the retry :)
