### PR TITLE
Allow absolute config paths

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,7 +66,7 @@ winston.info('');
 var	configFile = __dirname + '/config.json',
 	configExists;
 if (nconf.get('config')) {
-	configFile = path.join(__dirname, nconf.get('config'));
+	configFile = path.resolve(__dirname, nconf.get('config'));
 }
 configExists = fs.existsSync(configFile);
 

--- a/src/install.js
+++ b/src/install.js
@@ -445,7 +445,7 @@ var async = require('async'),
 		save: function (server_conf, callback) {
 			var	serverConfigPath = path.join(__dirname, '../config.json');
 			if (nconf.get('config')) {
-				serverConfigPath = path.join(__dirname, '../', nconf.get('config'));
+				serverConfigPath = path.resolve(__dirname, '../', nconf.get('config'));
 			}
 
 			fs.writeFile(serverConfigPath, JSON.stringify(server_conf, null, 4), function (err) {


### PR DESCRIPTION
I was trying to use nodebb with a custom config location. Relative paths, like so, worked fine:

```
node loader --config=../foo/conf.json
```

but absolute paths, like so, were not working:

```
node loader --config=/foo/bar/conf.json
```

This fix means both work.
