### PR TITLE
Fix syntax error

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -290,14 +290,13 @@ var async = require('async'),
 				function (next) {
 					// Check if an administrator needs to be created
 					var Groups = require('./groups');
-						Groups.get('administrators', {}, function (err, groupObj) {
-							if (groupObj.memberCount > 0) {
-								winston.info('Administrator found, skipping Admin setup');
-								next();
-							} else {
-								install.createAdmin(next);
-							}
-						});
+					Groups.get('administrators', {}, function (err, groupObj) {
+						if (groupObj.memberCount > 0) {
+							winston.info('Administrator found, skipping Admin setup');
+							next();
+						} else {
+							install.createAdmin(next);
+						}
 					});
 				},
 				function (next) {


### PR DESCRIPTION
I was getting a syntax error when updating my schema about a rogue extra `});`. I think was accidentally introduced in 7b4f596aba78198385e478daafca261a74f9fecf
