### PR TITLE
Fixed: Category pagination error; Check if first offset is NaN

### DIFF
--- a/public/src/forum/category.js
+++ b/public/src/forum/category.js
@@ -144,6 +144,9 @@ define(['composer', 'forum/pagination', 'share', 'navigator'], function(composer
 					} else {
 						el = $('#topics-container .category-item[data-tid]').first();
 						after = parseInt(el.attr('data-index'), 10);
+						if(isNaN(after)){
+							after = 0;
+						}
 						after -= config.topicsPerPage;
 						if(after < 0) {
 							after = 0;


### PR DESCRIPTION
This changeset resolves this error message: 
![error](https://cloud.githubusercontent.com/assets/30827/2636070/ce7689f6-be8c-11e3-8be3-15f939e27c10.png)

That message comes from something going wrong server side when calling category.loadMore, essential the error from Redis just gets sent all the way back to the client, not that we should be getting the error in the first place. You can see that here: 
![screen shot 2014-04-07 at 8 15 07 pm](https://cloud.githubusercontent.com/assets/30827/2636086/0a6f348a-be8d-11e3-8ab3-a5aed7c0a61a.png)

This error occurs after you've posted a new topic. The freshly created topic doesn't have a data-index attribute assigned to it (as it'd be either -1 or 0, but if it were 0, then you'd have two topics at index 0). Such that we try requesting more topics before after: null.
