### PR TITLE
filter:register.build now returns what it was passed, in order.

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -207,7 +207,7 @@ Controllers.register = function(req, res, next) {
 	data.minimumPasswordLength = meta.config.minimumPasswordLength;
 	data.termsOfUse = meta.config.termsOfUse;
 
-	plugins.fireHook('filter:register.build', req, res, data, function(err, data) {
+	plugins.fireHook('filter:register.build', req, res, data, function(err, req, res, data) {
 		if (err && process.env === 'development') {
 			winston.warn(JSON.stringify(err));
 		}


### PR DESCRIPTION
 fixes https://github.com/designcreateplay/NodeBB/issues/1540, we seriously need to consider standardizing the hooks arguments, maybe some ideas here https://github.com/designcreateplay/NodeBB/issues/1527
