### PR TITLE
Fix relative path URL bugs in the plugin API.

### DIFF
--- a/src/routes/plugins.js
+++ b/src/routes/plugins.js
@@ -15,7 +15,7 @@ var	_ = require('underscore'),
 module.exports = function(app, middleware, controllers) {
 	// Static Assets
 	app.get('/plugins/:id/*', function(req, res) {
-		var	relPath = req._parsedUrl.pathname.replace(nconf.get('relative_path') + '/plugins/', ''),
+		var	relPath = req._parsedUrl.pathname.replace('/plugins/', ''),
 			matches = _.map(plugins.staticDirs, function(realPath, mappedPath) {
 				if (relPath.match(mappedPath)) {
 					return mappedPath;
@@ -44,11 +44,11 @@ module.exports = function(app, middleware, controllers) {
 				if (matches.length) {
 					res.sendfile(matches[0]);
 				} else {
-					res.redirect('/404');
+					res.redirect(nconf.get('relative_path') + '/404');
 				}
 			});
 		} else {
-			res.redirect('/404');
+			res.redirect(nconf.get('relative_path') + '/404');
 		}
 	});
 };


### PR DESCRIPTION
Fixes plugin-related 404 URLs, as well as the plugin directory URL
for installations which use a relative path.
