### PR TITLE
Remove relative_path when creating relPath

### DIFF
--- a/src/routes/plugins.js
+++ b/src/routes/plugins.js
@@ -15,7 +15,7 @@ var	_ = require('underscore'),
 module.exports = function(app, middleware, controllers) {
 	// Static Assets
 	app.get('/plugins/:id/*', function(req, res) {
-		var	relPath = req._parsedUrl.pathname.replace(/plugins/', ''),
+		var	relPath = req._parsedUrl.pathname.replace('/plugins/', ''),
 			matches = _.map(plugins.staticDirs, function(realPath, mappedPath) {
 				if (relPath.match(mappedPath)) {
 					return mappedPath;


### PR DESCRIPTION
`req._parsedUrl` does not contain `relative_path` so don't include `relative_path` when removing the prefix.

For example, I installed nodeBB in `/forum` and the value of `req._parsedUrl` is

``` javascript
{ protocol: null,
  slashes: null,
  auth: null,
  host: null,
  port: null,
  hostname: null,
  hash: null,
  search: null,
  query: null,
  pathname: '/plugins/nodebb-plugin-emoji-extended/images/+1.png',
  path: '/plugins/nodebb-plugin-emoji-extended/images/+1.png',
  href: '/plugins/nodebb-plugin-emoji-extended/images/+1.png' }
```
