### PR TITLE
Fix removeRelativePath

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -123,7 +123,7 @@ var ajaxify = ajaxify || {};
 	};
 
 	function removeRelativePath(url) {
-		if (url.indexOf(RELATIVE_PATH.slice(1)) !== -1) {
+		if (url.indexOf(RELATIVE_PATH.slice(1)) === 0) {
 			url = url.slice(RELATIVE_PATH.length);
 		}
 		return url;


### PR DESCRIPTION
Instead of checking the existence of relative_path (without /) anywhere on the url, it really should check that the url only starts with the relative_path.

Example

```
relative_path = /forum
without / = forum
url = /category/forum/5
removeRelativePath = ory/forum/5
```
