### PR TITLE
Fix callback execution in redis search

### DIFF
--- a/src/database/redis/main.js
+++ b/src/database/redis/main.js
@@ -27,13 +27,9 @@ module.exports = function(redisClient, module) {
 
 	module.searchRemove = function(key, id, callback) {
 		if(key === 'post') {
-			module.postSearch.remove(id);
+			module.postSearch.remove(id, callback);
 		} else if(key === 'topic') {
-			module.topicSearch.remove(id);
-		}
-
-		if (typeof callback === 'function') {
-			callback();
+			module.topicSearch.remove(id, callback);
 		}
 	};
 


### PR DESCRIPTION
`callback` should be passed to `reds.search` otherwise the execution will be overlapped. 

For example in the plugin `nodebb-plugin-dbsearch':

``` javascript
db.searchRemove('topic', tid, function() {
    if (typeof title === 'string' && title.length) {
        db.searchIndex('topic', title, tid);
    }

    if (typeof callback === 'function') {
        callback();
    }
});
```

The actual execution is like this

```
1402387863.625553 [0 127.0.0.1:16660] "zrevrangebyscore" "nodebbtopicsearch:object:6" "+inf" "0"
1402387863.625891 [0 127.0.0.1:16660] "MULTI"
1402387863.626043 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:word:123" "1" "6"
1402387863.626052 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:object:6" "1" "123"
1402387863.626060 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:word:TST" "1" "6"
1402387863.626065 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:object:6" "1" "TST"
1402387863.626071 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:word:AN0" "1" "6"
1402387863.626076 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:object:6" "1" "AN0"
1402387863.626083 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:word:TPK" "1" "6"
1402387863.626092 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:object:6" "1" "TPK"
1402387863.626104 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:word:ETTT" "1" "6"
1402387863.626116 [0 127.0.0.1:16660] "zadd" "nodebbtopicsearch:object:6" "1" "ETTT"
1402387863.626130 [0 127.0.0.1:16660] "EXEC"
1402387863.626253 [0 127.0.0.1:16660] "del" "topic:6:tags"
1402387863.626281 [0 127.0.0.1:16660] "MULTI"
1402387863.626515 [0 127.0.0.1:16660] "del" "nodebbtopicsearch:object:6"
1402387863.626524 [0 127.0.0.1:16660] "EXEC"
```

The key nodebbtopicsearch:object is added and then just being deleted again.
