### PR TITLE
Few changes to the Ubuntu Installation Guide

### DIFF
--- a/docs/installing/os/ubuntu.rst
+++ b/docs/installing/os/ubuntu.rst
@@ -6,12 +6,12 @@ First, we install our base software stack:
 
 .. code:: bash
 
-	$ apt-get install git nodejs redis-server imagemagick npm
+	$ sudo apt-get install git nodejs redis-server imagemagick npm
 
 
 If you want to use MongoDB, LevelDB, or another database instead of Redis please look at the :doc:`Configuring Databases <../configuring/databases>` section.
 
-**If your package manager only installed a version of Node.js that is less than 0.8 (e.g. Ubuntu 12.10, 13.04):**
+**If your package manager only installed a version of Node.js that is less than 0.8 (e.g. Ubuntu 12.10, 13.04), use ``node --version`` to determine your version of Node.js:**
 
 
 .. code:: bash
@@ -25,7 +25,6 @@ Next, clone this repository:
 
 .. code:: bash
 
-	$ cd /path/to/nodebb/install/location
 	$ git clone git://github.com/NodeBB/NodeBB.git nodebb
 
 


### PR DESCRIPTION
Changes: 

Removed `cd/path/to/nodebb/install` as we haven't instructed how to create the directory before changing to it. The git pull will create the nodebb directory in their root/profile folder anyway, which is fine for most installs. 

Added sudo to the base stack install.

Added command for checking Node.js version. 

The guide at the minute might seem a bit daunting for newer users, so if psychobunny doesn't mind, I could create a post over on the community for an up to date noobs guide on how to install using digital ocean as an example. Then if it helps, add it to the docs. (Also, changes in this github aren't showing up in docs.nodebb, the update to sudo apt-get update && sudo apt-get dist-upgrade aren't displayed.

Hope this helps.
