### PR TITLE
Update windows8.rst

### DIFF
--- a/docs/installing/os/windows8.rst
+++ b/docs/installing/os/windows8.rst
@@ -21,7 +21,7 @@ Start Redis Server
 
 	The default location of Redis Server is
 
-	**C:\Program Files (x86)\Redis\StartRedisServer.cmd**
+	**C:\\Program Files (x86)\\Redis\\StartRedisServer.cmd**
 
 Open Git Shell, and type the following commands. Clone NodeBB repo:
 


### PR DESCRIPTION
missed double backslash (UTF-8 specifics shielded characters) at "The default location of Redis Server is" path
