### PR TITLE
Fix typo debian install doc

### DIFF
--- a/docs/installing/os/debian.rst
+++ b/docs/installing/os/debian.rst
@@ -143,6 +143,8 @@ Next clone this repository :
 
 Now we are going to install all dependencies for NodeBB via NPM :
 
+.. code:: bash
+
 	$ cd /path/to/nodebb/install/location/nodebb (or if you are on your install location directory run : cd nodebb)
 	$ npm install
 


### PR DESCRIPTION
Bash commands didn't appear as code
