### PR TITLE
Change user.delete hook from action to filter

### DIFF
--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -121,6 +121,9 @@ Executed when a post or signature needs to be parsed from raw text to HTML (for 
 ``filter:user.create``
 ^^^^^^^^^^^^^^^^^^^^^
 
+``filter:user.delete``
+^^^^^^^^^^^^^^^^^^^^^
+
 ``filter:user.profileLinks``
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -223,9 +226,6 @@ Executed whenever a notification is pushed to a user.
 ^^^^^^^^^^^^^^^^^^^^^
 
 ``action:user.create``
-^^^^^^^^^^^^^^^^^^^^^
-
-``action:user.delete``
 ^^^^^^^^^^^^^^^^^^^^^
 
 ``action:topic.delete``

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -106,13 +106,15 @@ module.exports = function(User) {
 				},
 				function(next) {
 					groups.leaveAllGroups(uid, next);
+				},
+				function(next) {
+					plugins.fireHook('filter:user.delete', uid, next);
 				}
 			], function(err) {
 				if (err) {
 					return callback(err);
 				}
 
-				plugins.fireHook('action:user.delete', uid);
 				async.parallel([
 					function(next) {
 						db.delete('followers:' + uid, next);


### PR DESCRIPTION
The user.delete hook is now a filter, giving plugins a chance to access
the user's data before it's deleted from Redis.

For further discussion, see the comments at julianlam/nodebb-plugin-sso-oauth#3.
