### PR TITLE
Group.join() callback made optional

### DIFF
--- a/src/groups.js
+++ b/src/groups.js
@@ -261,7 +261,7 @@
 	Groups.join = function(groupName, uid, callback) {
 		callback = callback || function() {};
 
-        Groups.exists(groupName, function(err, exists) {
+		Groups.exists(groupName, function(err, exists) {
 			if (exists) {
 				db.setAdd('group:' + groupName + ':members', uid, callback);
 			} else {


### PR DESCRIPTION
because [User.create()](https://github.com/NodeBB/NodeBB/blob/master/src/user/create.js#L162) uses it without a callback, and it was barfing if there was an error.
