### PR TITLE
Made it easier to paste command in MongoDB console

### DIFF
--- a/docs/configuring/databases/mongo.rst
+++ b/docs/configuring/databases/mongo.rst
@@ -67,9 +67,7 @@ To add a user to access the `nodebb` database, type:
 
 .. code::
 
-    > db.createUser( { user: "nodebb",
-    ...       pwd: "<Enter in a secure password>",
-    ...       roles: [ "readWrite" ] } )
+    > db.createUser( { user: "nodebb", pwd: "<Enter in a secure password>", roles: [ "readWrite" ] } )
 
 **Note:** The role ``readWrite`` provides read or write any collection within a specific database to user.
 


### PR DESCRIPTION
It's a pain to paste MongoDB console commands with linebreaks, as the console adds its own linebreaks. I removed the linebreaks to make it easier.
