### PR TITLE
Leave the chat window within the screen

### DIFF
--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -249,7 +249,7 @@ define('chat', ['taskbar', 'string', 'sounds', 'forum/chats'], function(taskbar,
 
 	module.center = function(chatModal) {
 		chatModal.css("left", Math.max(0, (($(window).width() - $(chatModal).outerWidth()) / 2) + $(window).scrollLeft()) + "px");
-		chatModal.css("top", $(window).height() / 4 - $(chatModal).outerHeight() / 2);
+		chatModal.css("top", Math.max(0, $(window).height() / 4 - $(chatModal).outerHeight() / 2));
 		chatModal.css("zIndex", 2000);
 		chatModal.find('#chat-message-input').focus();
 		return chatModal;


### PR DESCRIPTION
On smaller screens, the top of the chat window can appear so high that it is outside the screen, this fixes that.
