### PR TITLE
Corrected node.js version requirement.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "url": "https://github.com/NodeBB/NodeBB/issues"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   },
   "maintainers": [
     {


### PR DESCRIPTION
package.json was being told that nodebb only required version >=0.8.x of node. Per documentation and communication with developers this should be >=0.10.x
Changing this should help users who accidentally run nodebb on node.js 0.8 to run it on a supported version of 0.10.x or highter.
