### PR TITLE
cloning widgets Elements is dropping all events handlers

### DIFF
--- a/public/src/forum/admin/themes.js
+++ b/public/src/forum/admin/themes.js
@@ -288,7 +288,7 @@ define('forum/admin/themes', ['forum/admin/settings'], function(Settings) {
 
 				for (var k=0; k<area.data.length; ++k) {
 					var widgetData = area.data[k],
-						widgetEl = $('.available-widgets [data-widget="' + widgetData.widget + '"]').clone();
+						widgetEl = $('.available-widgets [data-widget="' + widgetData.widget + '"]').clone(true);
 
 					widgetArea.append(populateWidget(widgetEl, widgetData.data));
 					appendToggle(widgetEl);


### PR DESCRIPTION
Adding true will clone the handlers.

You might want to do the same for L150 and L161 's clone() usage, but I'll let you decide on that :)
