### PR TITLE
default for missing post_index parameter when topic pagination is used

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -72,7 +72,7 @@ topicsController.get = function(req, res, next) {
 					postIndex = Math.max((req.params.post_index || 1) - (settings.postsPerPage + 1), 0);
 				}
 			} else if (!req.query.page) {
-				var index = Math.max(parseInt(req.params.post_index, 10), 0);
+				var index = Math.max(parseInt(req.params.post_index, 10), 0) || 0;
 				page = Math.ceil((index + 1) / settings.postsPerPage);
 			}
 


### PR DESCRIPTION
Avoid getting NaN if post_index param is not set (NaN is passed through to redis, redis complains, and the user ends up at /404).

Bug was created in ca90afd54478f8cb17df40ec46dfac02fb11163c

( I switched from 0.5.0-r4 to the 0.5.1 branch for the sake of having subcategories, and suddenly /topic/:tid/:slug gave me 404s  :D )
