### PR TITLE
Fix settings save message

### DIFF
--- a/public/src/modules/settings.js
+++ b/public/src/modules/settings.js
@@ -298,6 +298,7 @@ define('settings', function () {
 						app.alert({
 							title: 'Settings Saved',
 							type: 'success',
+							message: "Settings have been successfully saved",
 							timeout: 2500
 						});
 					}


### PR DESCRIPTION
Was getting an error about `params.message` being undefined, turns out the settings framework doesn't use it! (@frissdiegurke!)
