### PR TITLE
Fix for Outgoing Links Warning page being displayed in IE for internal links

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -275,7 +275,7 @@ $(document).ready(function() {
 				}
 
 				if ((!e.ctrlKey && !e.shiftKey && !e.metaKey) && e.which === 1) {
-					if (this.host === window.location.host) {
+					if (this.host === '' || this.host === window.location.host) {
 						// Internal link
 						var url = this.href.replace(rootUrl + '/', '');
 


### PR DESCRIPTION
If the Use Outgoing Links Warning Page tick box is selected (in Settings > General) IE users appear to be constantly sent to the outgoing warning page when traversing internal links. 

Found on IE 10 & 11. Works fine on Safari, Chrome and Firefox.

IE appears to set the 'host' property of anchor tags to "" for internal links, this is causing all internal links to be treated as external and therefore being rewritten to point at the Outgoing Link Warning page at /outgoing/

This commit adds a check for the empty host property.
