### PR TITLE
Bug fix - File upload broken due to api changes in 0.6.x.

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -57,7 +57,7 @@ function uploadPost(req, res, next) {
 		if(file.type.match(/image./)) {
 			uploadImage(req.user.uid, file, next);
 		} else {
-			uploadFile(req.user, file, next);
+			uploadFile(req.user.uid, file, next);
 		}
 	}, next);
 }


### PR DESCRIPTION
I found this bug when updating the S3 upload plugin for 0.6.0. `uploadFile` needs the `req.user.uid` as first argument.
