### PR TITLE
Add MySQL dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "underscore": "~1.7.0",
     "validator": "~3.21.0",
     "winston": "^0.8.1",
-    "xregexp": "~2.0.0"
+    "xregexp": "~2.0.0",
+    "mysql": "2.5.3"
   },
   "devDependencies": {
     "mocha": "~1.13.0"


### PR DESCRIPTION
Add a mysql dependency to add support for mysql - I am working on adding MySQL support to NodeBB.

The mysql package can be found at: https://www.npmjs.org/package/mysql
