### PR TITLE
Change text colour when searching custom CSS or JS

### DIFF
--- a/public/less/admin/bootstrap/normalize.less
+++ b/public/less/admin/bootstrap/normalize.less
@@ -258,6 +258,13 @@ textarea {
 }
 
 //
+// Inherit color above doesn't work in the ACP when searching through custom CSS or JS.
+//
+.ace_search_field {
+    color: #000 !important;
+}
+
+//
 // Address `overflow` set to `hidden` in IE 8/9/10/11.
 //
 


### PR DESCRIPTION
Not sure if this is the right place for this, but it seemed to be where the inherit rule was coming from. If you search for some text in the custom CSS or JS fields with the new IDE, the text appears the same colour as the input field. Needed more blaaaaack.
