### PR TITLE
Bug fix - Topic search broken due to encodeURIComponent being called too early

### DIFF
--- a/public/src/modules/search.js
+++ b/public/src/modules/search.js
@@ -7,17 +7,18 @@ define('search', ['navigator'], function(nav) {
 		};
 
 	Search.query = function(term, callback) {
-		try {
-			term = encodeURIComponent(term);
-		} catch(e) {
-			return app.alertError('[[error:invalid-search-term]]');
-		}
-
 		// Detect if a tid was specified
 		var topicSearch = term.match(/in:topic-([\d]+)/);
 
 		if (!topicSearch) {
 			term = term.replace(/^[ ?#]*/, '');
+
+			try {
+				term = encodeURIComponent(term);
+			} catch(e) {
+				return app.alertError('[[error:invalid-search-term]]');
+			}
+
 			ajaxify.go('search/' + term);
 			callback();
 		} else {


### PR DESCRIPTION
It looks like topic search was broken due to `encodeURIComponent` being called too early.  The `term` was being replaced with the URI-encoded version before the regexp check. So `in:topic-29` becomes `in%3Atopic-29`, which causes the regexp for matching a topic search to fail.
