### PR TITLE
Add topics.loaded event to be triggered when new topics are loaded by infinite scroll.

### DIFF
--- a/public/src/client/account/topics.js
+++ b/public/src/client/account/topics.js
@@ -36,6 +36,7 @@ define('forum/account/topics', ['forum/account/header', 'forum/infinitescroll'],
 			html.find('span.timeago').timeago();
 			app.createUserTooltips();
 			utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
+			$(window).trigger('action:topics.loaded');
 			callback();
 		});
 	}

--- a/public/src/client/recent.js
+++ b/public/src/client/recent.js
@@ -104,6 +104,7 @@ define('forum/recent', ['forum/infinitescroll'], function(infinitescroll) {
 			html.find('span.timeago').timeago();
 			app.createUserTooltips();
 			utils.makeNumbersHumanReadable(html.find('.human-readable-number'));
+			$(window).trigger('action:topics.loaded');
 			callback();
 		});
 	};


### PR DESCRIPTION
Similar to how `action.posts.loaded` is fired when posts are loaded, I needed an event for when topics are loaded in order to update a Masonry layout for topic pages.  This would be useful for themes that want to use Masonry layouts for topics.
