### PR TITLE
Fix "require is not defined" js error when executing "node app"

### DIFF
--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -127,7 +127,9 @@ module.exports = function(Meta) {
 
 	Meta.js.minify = function(minify, callback) {
 		if (nconf.get('isPrimary') === 'true') {
-			var minifier = Meta.js.minifierProc = fork('minifier.js'),
+			var minifier = Meta.js.minifierProc = fork('minifier.js', [], {
+					execArgv: global.env === "development" ? ['--debug-brk=16001'] : []
+				}),
 				onComplete = function(err) {
 					if (err) {
 						winston.error('[meta/js] Minification failed: ' + err.message);

--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -177,11 +177,14 @@ module.exports = function(Meta) {
 			});
 
 			Meta.js.prepare(function() {
-				minifier.send({
-					action: 'js',
-					minify: global.env !== 'development',
-					scripts: Meta.js.scripts.all
-				});
+				setTimeout(
+					function() {
+						minifier.send({
+							action: 'js',
+							minify: global.env !== 'development',
+							scripts: Meta.js.scripts.all
+						});
+					}, 100);
 			});
 		} else {
 			if (typeof callback === 'function') {


### PR DESCRIPTION
When executing "node app", minifier.js never finish and caused "require is not defined" in the frontend. That was caused by 'message' never reach to minifier.js. Having setTimeout 100ms, should fix the issue. Would be good if anyone has a better fix than this (I am running node v0.10.29).

I also added debug break option in case somebody would like to debug minifier.js