### PR TITLE
Enabling cluster, sticky-sessions, level 4 based hash balancing

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -5,9 +5,9 @@ var	nconf = require('nconf'),
 	fs = require('fs'),
 	url = require('url'),
 	path = require('path'),
-	fork = require('child_process').fork,
-
+	cluster = require('cluster'),
 	async = require('async'),
+	Random = require('random-js'),
 	logrotate = require('logrotate-stream'),
 
 	pkg = require('./package.json'),
@@ -16,8 +16,9 @@ var	nconf = require('nconf'),
 	output = logrotate({ file: __dirname + '/logs/output.log', size: '1m', keep: 3, compress: true }),
 	silent = process.env.NODE_ENV !== 'development',
 	numProcs,
-
-	workers = [],
+	handles = {},
+	handleIndex = 0,
+	server,
 
 	Loader = {
 		timesStarted: 0,
@@ -29,9 +30,30 @@ var	nconf = require('nconf'),
 			cache: undefined,
 			acpCache: undefined
 		}
+	},
+	internals = {
+	  workers: [],
+	  seed: 0,
+	  header: 'x-forwarded-for',
+	  version: {
+	    major: 0,
+	    sub: 1.0
+	  },
+	  republishPacket: node96Republish,
+	  sync: {
+	    isSynced: false,
+	    event: 'sticky-sessions:syn'
+	  },
+	  random: new Random(Random.engines.mt19937().autoSeed())
+
 	};
 
 Loader.init = function(callback) {
+	cluster.setupMaster({
+		exec: "app.js",
+		silent: silent
+	});
+	Loader.primaryWorker = 1;
 
 	if (silent) {
 		console.log = function(value) {
@@ -55,9 +77,84 @@ Loader.displayStartupMessages = function(callback) {
 	callback();
 };
 
-Loader.addWorkerEvents = function(worker) {
+Loader.addClusterEvents = function(callback) {
+	cluster.on('fork', function(worker) {
+		worker.on('message', function(message, msgData) {
+			if (message && typeof message === 'object' && message.action) {
+				var otherWorkers;
 
-	worker.on('exit', function(code, signal) {
+				switch (message.action) {
+					case 'ready':
+						if (Loader.js.cache) {
+							worker.send({
+								action: 'js-propagate',
+								cache: Loader.js.cache,
+								map: Loader.js.map,
+								hash: Loader.js.hash
+							});
+						}
+
+						if (Loader.css.cache) {
+							worker.send({
+								action: 'css-propagate',
+								cache: Loader.css.cache,
+								acpCache: Loader.css.acpCache,
+								hash: Loader.css.hash
+							});
+						}
+					break;
+					case 'restart':
+						console.log('[cluster] Restarting...');
+						Loader.restart(function(err) {
+							console.log('[cluster] Restarting...');
+						});
+					break;
+					case 'reload':
+						console.log('[cluster] Reloading...');
+						Loader.reload();
+					break;
+					case 'js-propagate':
+						Loader.js.cache = message.cache;
+						Loader.js.map = message.map;
+						Loader.js.hash = message.hash;
+
+						Loader.notifyWorkers({
+							action: 'js-propagate',
+							cache: message.cache,
+							map: message.map,
+							hash: message.hash
+						}, worker.id);
+					break;
+					case 'css-propagate':
+						Loader.css.cache = message.cache;
+						Loader.css.acpCache = message.acpCache;
+						Loader.css.hash = message.hash;
+
+						Loader.notifyWorkers({
+							action: 'css-propagate',
+							cache: message.cache,
+							acpCache: message.acpCache,
+							hash: message.hash
+						}, worker.id);
+					break;
+					case 'listening':
+						if (message.primary) {
+							Loader.primaryWorker = parseInt(worker.id, 10);
+						}
+					break;
+					case 'config:update':
+						Loader.notifyWorkers(message);
+					break;
+				}
+			}
+		});
+	});
+
+	cluster.on('listening', function(worker) {
+		console.log('[cluster] Child Process (' + worker.process.pid + ') listening for connections.');
+	});
+
+	cluster.on('exit', function(worker, code, signal) {
 		if (code !== 0) {
 			if (Loader.timesStarted < numProcs*3) {
 				Loader.timesStarted++;
@@ -73,131 +170,204 @@ Loader.addWorkerEvents = function(worker) {
 			}
 		}
 
-		console.log('[cluster] Child Process (' + worker.pid + ') has exited (code: ' + code + ', signal: ' + signal +')');
-		if (!(worker.suicide || code === 0)) {
+		console.log('[cluster] Child Process (' + worker.process.pid + ') has exited (code: ' + code + ', signal: ' + signal +')');
+		if (!worker.suicide) {
 			console.log('[cluster] Spinning up another process...');
 
-			forkWorker(worker.index, worker.isPrimary);
+			var wasPrimary = parseInt(worker.id, 10) === Loader.primaryWorker;
+			forkWorker(wasPrimary);
 		}
 	});
 
-	worker.on('message', function(message) {
-		if (message && typeof message === 'object' && message.action) {
-			var otherWorkers;
-
-			switch (message.action) {
-				case 'ready':
-					if (Loader.js.cache) {
-						worker.send({
-							action: 'js-propagate',
-							cache: Loader.js.cache,
-							map: Loader.js.map,
-							hash: Loader.js.hash
-						});
-					}
-
-					if (Loader.css.cache) {
-						worker.send({
-							action: 'css-propagate',
-							cache: Loader.css.cache,
-							acpCache: Loader.css.acpCache,
-							hash: Loader.css.hash
-						});
-					}
-				break;
-				case 'restart':
-					console.log('[cluster] Restarting...');
-					Loader.restart();
-				break;
-				case 'reload':
-					console.log('[cluster] Reloading...');
-					Loader.reload();
-				break;
-				case 'js-propagate':
-					Loader.js.cache = message.cache;
-					Loader.js.map = message.map;
-					Loader.js.hash = message.hash;
-
-					Loader.notifyWorkers({
-						action: 'js-propagate',
-						cache: message.cache,
-						map: message.map,
-						hash: message.hash
-					}, worker.pid);
-				break;
-				case 'css-propagate':
-					Loader.css.cache = message.cache;
-					Loader.css.acpCache = message.acpCache;
-					Loader.css.hash = message.hash;
-
-					Loader.notifyWorkers({
-						action: 'css-propagate',
-						cache: message.cache,
-						acpCache: message.acpCache,
-						hash: message.hash
-					}, worker.pid);
-				break;
-				case 'listening':
-					if (message.primary) {
-						Loader.primaryWorker = parseInt(worker.pid, 10);
-					}
-				break;
-				case 'config:update':
-					Loader.notifyWorkers(message);
-				break;
-			}
-		}
+	cluster.on('disconnect', function(worker) {
+		console.log('[cluster] Child Process (' + worker.process.pid + ') has disconnected');
 	});
+
+	callback();
 };
 
 Loader.start = function(callback) {
 	console.log('Clustering enabled: Spinning up ' + numProcs + ' process(es).\n');
 
-	for (var x=0; x<numProcs; ++x) {
-		forkWorker(x, x === 0);
+	var version = process.version.substr(1);
+	var index =version.indexOf('.');
+
+	//Writing version to internals.version
+	internals.version.sub = Number( version.substr( index + 1 ) );
+	internals.version.major = Number( version.substr( 0, index ) );
+
+	internals.header = nconf.get('proxy_header');
+
+	for(var x=0; x<numProcs; ++x) {
+		forkWorker(x === 0);
 	}
+
+	internals.seed = internals.random.integer(0x0, 0x80000000);
+
+	var urlObject = url.parse(nconf.get('url'));
+	var port = urlObject.port || nconf.get('port') || nconf.get('PORT') || 4567;
+	var proxy = nconf.get('proxy');
+	var connectionListener;	
+
+	nconf.set('port', port);
+
+	if( proxy )
+		connectionListener = layer4HashBalancedConnectionListener;
+	else
+		connectionListener = layer3HashBalancedConnectionListener;
+
+	server = net.createServer(connectionListener).listen(port);
 
 	if (callback) {
 		callback();
 	}
 };
 
-function forkWorker(index, isPrimary) {
-	var urlObject = url.parse(nconf.get('url'));
-	var port = urlObject.port || nconf.get('port') || nconf.get('PORT') || 4567;
+/**
+  * Access 'private' object _handle of file decriptor to republish the read packet.
+  */ 
+function node96Republish( fd, data )
+{
+  fd._handle.onread( new Buffer( data ), 0, data.length );
+}
 
-	var worker = fork('app.js', [], {
-		silent: silent,
-		env: {
-			isPrimary: isPrimary,
-			isCluster: true,
-			port: parseInt(port, 10) + index
-		}
-	});
 
-	worker.index = index;
-	worker.isPrimary = isPrimary;
+/**
+  * Hash balanced layer 3 connection listener.
+  */
+function layer3HashBalancedConnectionListener(c) {
 
-	workers[index] = worker;
+  c._handle.readStop();
+  // Get int31 hash of ip
+  var worker,
+      ipHash = hash((c.remoteAddress || '').split(/\./g), internals.seed);
 
-	Loader.addWorkerEvents(worker);
+  clusterWorkers();
+  // Pass connection to worker
+  worker = internals.workers[ipHash % internals.workers.length];
+  worker.send({ action: 'sticky-session:connection' }, c);
+}
+
+/**
+  * Hash balanced layer 4 connection listener.
+  *
+  * The node is choosed randomly initial and gets hash balanced later in patchConnection.
+  */
+function layer4HashBalancedConnectionListener(c) {
+  c._handle.readStop();
+  // Get int31 hash of ip
+  var worker;
+
+  clusterWorkers();
+  // Pass connection to worker
+  worker = internals.workers[ internals.random.integer( 0, internals.workers.length - 1 ) ];
+  worker.send( { action: 'sticky-session:sync' }, c);
+}
+
+/**
+  * Hash balance on the real ip and send data + file decriptor to final node.
+  */
+function patchConnection( c, fd )
+{
+  // Get int31 hash of ip
+  var worker,
+      ipHash = hash((c.realIP || '').split(/\./g), internals.seed);
+
+  clusterWorkers();
+  // Pass connection to worker
+  worker = internals.workers[ipHash % internals.workers.length];
+  worker.send( { action: 'sticky-session:syncconnection', data: c.data }, fd );
+}
+
+function hash(ip, seed) {
+  var hash = ip.reduce(function(r, num) {
+    r += parseInt(num, 10);
+    r %= 2147483648;
+    r += (r << 10)
+    r %= 2147483648;
+    r ^= r >> 6;
+    return r;
+  }, seed);
+
+  hash += hash << 3;
+  hash %= 2147483648;
+  hash ^= hash >> 11;
+  hash += hash << 15;
+  hash %= 2147483648;
+
+  return hash >>> 0;
+}
+
+function forkWorker(isPrimary) {
+	var worker = cluster.fork({
+			cluster_setup: isPrimary,
+			handle_jobs: isPrimary,
+			proxy_header: internals.header
+		}),
+		output = logrotate({ file: __dirname + '/logs/output.log', size: '1m', keep: 3, compress: true });
 
 	if (silent) {
-		var output = logrotate({ file: __dirname + '/logs/output.log', size: '1m', keep: 3, compress: true });
-		worker.stdout.pipe(output);
-		worker.stderr.pipe(output);
+		worker.process.stdout.pipe(output);
+		worker.process.stderr.pipe(output);
+	}
+
+	worker.on('message', function(message, c) {
+		if(!message)
+			return;
+
+		if(message.action === 'sticky-session:ack' )
+		{
+			patchConnection( message, c );
+		}
+		else if (message.action !== 'sticky-session:accept') {
+			return;
+		}
+
+		var _handle = handles[message.handleIndex];
+
+		if (_handle) {
+			_handle.close();
+
+			delete handles[message.handleIndex];
+		}
+	});
+}
+
+function workerIndex(ip, numProcs) {
+	var s = '';
+	for (var i = 0, _len = ip.length; i < _len; i++) {
+		if (parseInt(ip[i], 10)) {
+			s += ip[i];
+		}
+	}
+	return Number(s) % numProcs || 0;
+}
+
+function clusterWorkers() {
+	var o = 0;
+
+	for( var i in cluster.workers )
+	{
+		internals.workers[o++] = cluster.workers[i];
 	}
 }
 
-Loader.restart = function() {
+Loader.restart = function(callback) {
+	console.log('[cluster] closing server');
+
 	killWorkers();
 
-	Loader.start();
+	closeHandles();
+
+	server.close(function() {
+		console.log('[cluster] server closed');
+		Loader.start();
+	});
 };
 
 Loader.reload = function() {
-	workers.forEach(function(worker) {
-		worker.send({
+	Object.keys(cluster.workers).forEach(function(worker_id) {
+		cluster.workers[worker_id].send({
 			action: 'reload'
 		});
 	});
@@ -208,20 +378,31 @@ Loader.stop = function() {
 
 	// Clean up the pidfile
 	fs.unlinkSync(__dirname + '/pidfile');
+
+	server.close();
 };
 
 function killWorkers() {
-	workers.forEach(function(worker) {
-		worker.suicide = true;
-		worker.kill();
+	Object.keys(cluster.workers).forEach(function(id) {
+		cluster.workers[id].kill();
 	});
 }
 
-Loader.notifyWorkers = function (msg, worker_pid) {
-	worker_pid = parseInt(worker_pid, 10);
-	workers.forEach(function(worker) {
-		if (parseInt(worker.pid, 10) !== worker_pid) {
-			worker.send(msg);
+function closeHandles() {
+	for(var h in handles) {
+		var handle = handles[h];
+		if (handle) {
+			handle.close();
+			delete handles[h];
+		}
+	}
+}
+
+Loader.notifyWorkers = function (msg, worker_id) {
+	worker_id = parseInt(worker_id, 10);
+	Object.keys(cluster.workers).forEach(function(id) {
+		if (parseInt(id, 10) !== worker_id) {
+			cluster.workers[id].send(msg);
 		}
 	});
 };
@@ -252,6 +433,7 @@ if (nconf.get('daemon') !== false) {
 async.series([
 	Loader.init,
 	Loader.displayStartupMessages,
+	Loader.addClusterEvents,
 	Loader.start
 ], function(err) {
 	if (err) {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "passport": "^0.2.1",
     "passport-local": "1.0.0",
     "prompt": "^0.2.14",
+    "random-js": "^1.0.4",
     "request": "^2.44.0",
     "rimraf": "~2.2.6",
     "rss": "^1.0.0",

--- a/src/meta/sounds.js
+++ b/src/meta/sounds.js
@@ -7,6 +7,7 @@ var path = require('path'),
 	rimraf = require('rimraf'),
 	mkdirp = require('mkdirp'),
 	async = require('async'),
+	cluster = require('cluster'),
 
 	plugins = require('../plugins'),
 	db = require('../database');
@@ -16,7 +17,7 @@ module.exports = function(Meta) {
 	Meta.sounds = {};
 
 	Meta.sounds.init = function(callback) {
-		if (nconf.get('isPrimary') === 'true') {
+		if (cluster.isWorker && process.env.cluster_setup === 'true') {
 			var	soundsPath = path.join(__dirname, '../../public/sounds');
 
 			plugins.fireHook('filter:sounds.get', [], function(err, filePaths) {

--- a/src/meta/templates.js
+++ b/src/meta/templates.js
@@ -7,6 +7,7 @@ var mkdirp = require('mkdirp'),
 	path = require('path'),
 	fs = require('fs'),
 	nconf = require('nconf'),
+	cluster = require('cluster'),
 
 	emitter = require('../emitter'),
 	plugins = require('../plugins'),
@@ -15,7 +16,7 @@ var mkdirp = require('mkdirp'),
 	Templates = {};
 
 Templates.compile = function(callback) {
-	if (nconf.get('isPrimary') === 'false') {
+	if (cluster.isWorker && process.env.cluster_setup !== 'true') {
 		emitter.emit('templates:compiled');
 		if (callback) {
 			callback();
@@ -30,8 +31,8 @@ Templates.compile = function(callback) {
 		themeConfig = require(nconf.get('theme_config'));
 
 	if (themeConfig.baseTheme) {
-		var pathToBaseTheme = path.join(nconf.get('themes_path'), themeConfig.baseTheme);
-		baseTemplatesPath = require(path.join(pathToBaseTheme, 'theme.json')).templates;
+		var pathToBaseTheme = path.join(nconf.get('themes_path'), themeConfig.baseTheme),
+			baseTemplatesPath = require(path.join(pathToBaseTheme, 'theme.json')).templates;
 
 		if (!baseTemplatesPath){
 			baseTemplatesPath = path.join(pathToBaseTheme, 'templates');

--- a/src/socket.io/admin.js
+++ b/src/socket.io/admin.js
@@ -2,6 +2,7 @@
 
 var	async = require('async'),
 	winston = require('winston'),
+	cluster = require('cluster'),
 	fs = require('fs'),
 	path = require('path'),
 
@@ -50,7 +51,7 @@ SocketAdmin.before = function(socket, method, next) {
 
 SocketAdmin.reload = function(socket, data, callback) {
 	events.logWithUser(socket.uid, ' is reloading NodeBB');
-	if (process.send) {
+	if (cluster.isWorker) {
 		process.send({
 			action: 'reload'
 		});


### PR DESCRIPTION
This enables the old cluster again, the problem described here:
https://community.nodebb.org/topic/3406/config-json-cluster-change

Will get fixed with this. The problem was that we can't rely on the ip anymore if any node component is behind a proxy. The fix enables hashing of values that are parsed from the header, after this it pushs the packet back to the read queue.

**Note:** I have reverted the cluster changes and the port thing, as I don't wanted to go get a deep dive into your code right now. This pull request maybe more a template to build the whole thing. But you must decide yourself what to do ;)

For additional information see also:
https://github.com/indutny/sticky-session/pull/17
https://github.com/wzrdtales/sticky-session/blob/master/README.md

P.S.: The most things are just copy pasted from the work I've done on the sticky-sessions already. This is a bit chaotic, but I have not the time today anymore to make it beatiful. 
