### PR TITLE
Fix editorconfig syntax

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 root = true
 
-[*.js, *.css, *.tpl, *.json]
+[{*.js, *.css, *.tpl, *.json}]
 indent_style = tab
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
As per http://editorconfig.org under "Wildcard patterns".

I had to make this change to make it work under Webstorm.