### PR TITLE
Changing a little the way a plugin can add buttons to the composer

### DIFF
--- a/public/src/modules/composer.js
+++ b/public/src/modules/composer.js
@@ -94,8 +94,12 @@ define('composer', [
 		});
 	}
 
-	composer.addButton = function(iconClass, onClick) {
-		formatting.addButton(iconClass, onClick);
+	composer.addButton = function(button, onClick) {
+		if (typeof button !== 'object') {
+			/* Backward compatibility */
+			button = {id: button.replace('fa fa-', ''), icon: button, handler: onClick};
+		}
+		formatting.addButton(button);
 	};
 
 	composer.newTopic = function(cid) {


### PR DESCRIPTION
Now instead passing just the icon class and the click handler as arguments, now you can pass an
object with new properties:

    {
        id: 'Button identifier',
        title: 'Button title. Also accepts i18n keys, like [[global:bold]]. It would be nice if the vanilla theme updated including a title for the default buttons, and eventually all the plugins too',
        icon: 'Icon classname',
        before: 'ID of the button you want to place your button before',
        after: 'ID of the button you want to place your button after',
        handler: 'Button click handler'
    }

The main reason for this, is because I need (and so many plugins also) to add certain buttons in a certain order (for example, 'Underline' and 'Strikethrough' next to 'Bold' and 'Italic') but anyway, I think this way will be helpful for future developments.

I tried to keep backward compatibility for current plugins, so by default, the ID will be the icon classname without the fa- prefix (fa fa-bold > bold). And if you use the old addButton(String, Function) method, it will be wrapped into the new object.

P.S. Also, now, the help button always appears at the end.