### PR TITLE
Change argument in action:posts.loaded

### DIFF
--- a/public/src/client/home.js
+++ b/public/src/client/home.js
@@ -59,7 +59,7 @@ define('forum/home', function() {
 				recentPosts.last().remove();
 			}
 
-			$(window).trigger('action:posts.loaded');
+			$(window).trigger('action:posts.loaded', {pids: [post.pid]});
 		});
 	}
 

--- a/public/src/client/home.js
+++ b/public/src/client/home.js
@@ -59,7 +59,7 @@ define('forum/home', function() {
 				recentPosts.last().remove();
 			}
 
-			$(window).trigger('action:posts.loaded', {pids: [post.pid]});
+			$(window).trigger('action:posts.loaded', {posts: [post]});
 		});
 	}
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -130,7 +130,7 @@ define('forum/topic/posts', [
 				pids.push(data.posts[i].pid);
 			}
 
-			$(window).trigger('action:posts.loaded', pids);
+			$(window).trigger('action:posts.loaded', {pids: pids});
 			onNewPostsLoaded(html, pids);
 			callback(true);
 		});

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -130,7 +130,7 @@ define('forum/topic/posts', [
 				pids.push(data.posts[i].pid);
 			}
 
-			$(window).trigger('action:posts.loaded', {pids: pids});
+			$(window).trigger('action:posts.loaded', {posts: data.posts});
 			onNewPostsLoaded(html, pids);
 			callback(true);
 		});


### PR DESCRIPTION
Related https://github.com/NodeBB/NodeBB/pull/2675
Consider http://api.jquery.com/trigger/ even if we pass to ` .trigger() ` an array, eventually it becomes as separate arguments.
So, right now in ` action:posts.loaded ` we get (typically) ` arguments.length === 11 `, the first one is jQuery event object, then 10 post ids, and for further work (typically :D) we have to do something like
```
var pids = Array.prototype.slice.call(arguments, 1);
      pids.forEach(function (pid) { ... });
```

As I see, there are two preferable ways to improve **` action:posts.loaded `** Which one will be better:
` {pids: 'an array of pids'} ` or ` {posts: 'an array of posts objects'} ` ?

If second one, whether it will be better to pass to **` action:posts.edited `**:
` {posts: 'an array with one post object'} ` or ` {'post object'} ` ?
