### PR TITLE
Trycatch fix for development mode

### DIFF
--- a/src/plugins/hooks.js
+++ b/src/plugins/hooks.js
@@ -123,17 +123,26 @@ module.exports = function(Plugins) {
 					next();
 				}, 5000);
 
-				try {
+				if (global.env === 'development') {
 					hookObj.method(params, function() {
 						clearTimeout(timeoutId);
 						if (!timedOut) {
 							next.apply(null, arguments);
 						}
 					});
-				} catch(err) {
-					winston.error('[plugins] Error executing \'' + hook + '\' in plugin \'' + hookObj.id + '\'');
-					clearTimeout(timeoutId);
-					next();
+				} else {
+					try {
+						hookObj.method(params, function() {
+							clearTimeout(timeoutId);
+							if (!timedOut) {
+								next.apply(null, arguments);
+							}
+						});
+					} catch(err) {
+						winston.error('[plugins] Error executing \'' + hook + '\' in plugin \'' + hookObj.id + '\'');
+						clearTimeout(timeoutId);
+						next();
+					}
 				}
 			} else {
 				next();


### PR DESCRIPTION
You know guys, it should be that way...

Let's say if I have an error inside my ` plugin.init ` function what I see
Before:
![](http://i.imgur.com/FKrzMMU.png)
After:
![](http://i.imgur.com/DbKGfma.png)