### PR TITLE
Make widget headers clickable anywhere.

### DIFF
--- a/public/src/admin/extend/widgets.js
+++ b/public/src/admin/extend/widgets.js
@@ -46,8 +46,6 @@ define('admin/extend/widgets', function() {
 				appendToggle(ui.item);
 			},
 			connectWith: "div"
-		}).on('click', '.toggle-widget', function() {
-			$(this).parents('.widget-panel').children('.panel-body').toggleClass('hidden');
 		}).on('click', '.delete-widget', function() {
 			var panel = $(this).parents('.widget-panel');
 
@@ -56,8 +54,10 @@ define('admin/extend/widgets', function() {
 					panel.remove();
 				}
 			});
-		}).on('dblclick', '.panel-heading', function() {
-			$(this).parents('.widget-panel').children('.panel-body').toggleClass('hidden');
+		}).on('mouseup', '.panel-heading', function(evt) {
+			if ( !( $(this).parents('.widget-panel').is('.ui-sortable-helper') || $(evt.target).closest('.delete-widget').length ) ) {
+				$(this).parents('.widget-panel').children('.panel-body').toggleClass('hidden');
+			}
 		});
 
 		$('#widgets .save').on('click', saveWidgets);


### PR DESCRIPTION
Allows single-click anywhere on the widget header to open/close, while not opening/closing if the widget is being dragged or the delete button was clicked.