### PR TITLE
This adds more setup defaults from config.

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,7 +21,7 @@
 /*global require, global, process*/
 
 var nconf = require('nconf');
-nconf.argv().env();
+nconf.argv().env('__');
 
 var fs = require('fs'),
 	os = require('os'),

--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -22,12 +22,14 @@
 		},
 		{
 			name: 'mongo:username',
-			description: 'MongoDB username'
+			description: 'MongoDB username',
+			'default': nconf.get('mongo:username') || ''
 		},
 		{
 			name: 'mongo:password',
 			description: 'Password of your MongoDB database',
-			hidden: true
+			hidden: true,
+			before: function(value) { value = value || nconf.get('mongo:password') || ''; return value; }
 		},
 		{
 			name: "mongo:database",

--- a/src/database/redis.js
+++ b/src/database/redis.js
@@ -28,7 +28,8 @@
 		{
 			name: 'redis:password',
 			description: 'Password of your Redis database',
-			hidden: true
+			hidden: true,
+			before: function(value) { value = value || nconf.get('redis:password') || ''; return value; }
 		},
 		{
 			name: "redis:database",

--- a/src/install.js
+++ b/src/install.js
@@ -47,7 +47,7 @@ questions.main = [
 questions.optional = [
 	{
 		name: 'port',
-		default: 4567
+		default: nconf.get('port') || 4567
 	}
 ];
 


### PR DESCRIPTION
Hi,

While working on an easier way to install NodeBB in the OpenShift cloud, i noticed that there is no way to override configuration with values from the environment when running setup. Without that, things like URL or port have to be hardcoded into `config.json` file, which risks application crash/close when server owners decide to restart applications in different place, or database credentials change for some reason.

I tried to implement minimal set of changes to the NodeBB code, and keep the rest in a separate file.
This patch includes those minimal changes:

- Added support for using `mongo:password` and `redis:password` from config, when no password is entered at setup. This allows for having "default" password and overrides from config.
- Added using `mongo:username` and `port` from config when running setup.
- Added setting separator to `__` when loading configuration variables from environment.

There's a big chance i forgot or did not see something, but i installed NodeBB in OpenShift and it seems to work OK.
The only problem i can think of, that this patch may create is a situation in which NodeBB was configured before, there was password set up for accessing database, and (for whatever reason) someone tries to re-run setup to remove that password. In that case, answering with empty password to the setup question, will keep the old password. But that can be worked around easy way: just delete `config.json` before re-running setup.

Please let me know if i should modify changes, or if you simply don't want such change at all.