### PR TITLE
Skip setTimeout if it doesn't exist (Node 0.10.x with SSL)

### DIFF
--- a/src/webserver.js
+++ b/src/webserver.js
@@ -110,7 +110,7 @@ if(nconf.get('ssl')) {
 		emitter.emit('nodebb:ready');
 	});
 
-	server.setTimeout(10000);
+	server.setTimout && server.setTimeout(10000);
 
 	module.exports.listen = function(callback) {
 		logger.init(app);


### PR DESCRIPTION
Make NodeBB work for Node 0.10.x if SSL is enabled and `https` is used, which doesn't have this method.