### PR TITLE
Allow NodeBB version to be set via config

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,14 +54,6 @@ if(os.platform() === 'linux') {
 	});
 }
 
-if (!process.send) {
-	// If run using `node app`, log GNU copyright info along with server info
-	winston.info('NodeBB v' + pkg.version + ' Copyright (C) 2013-2014 NodeBB Inc.');
-	winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
-	winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
-	winston.info('');
-}
-
 // Alternate configuration file support
 var	configFile = path.join(__dirname, '/config.json'),
 	configExists;
@@ -89,7 +81,8 @@ function loadConfig() {
 	nconf.defaults({
 		base_dir: __dirname,
 		themes_path: path.join(__dirname, 'node_modules'),
-		views_dir: path.join(__dirname, 'public/templates')
+		views_dir: path.join(__dirname, 'public/templates'),
+		version: pkg.version
 	});
 
 	if (!nconf.get('isCluster')) {
@@ -101,6 +94,14 @@ function loadConfig() {
 	nconf.set('themes_path', path.resolve(__dirname, nconf.get('themes_path')));
 	nconf.set('core_templates_path', path.join(__dirname, 'src/views'));
 	nconf.set('base_templates_path', path.join(nconf.get('themes_path'), 'nodebb-theme-vanilla/templates'));
+
+	if (!process.send) {
+		// If run using `node app`, log GNU copyright info along with server info
+		winston.info('NodeBB v' + nconf.get('version') + ' Copyright (C) 2013-2014 NodeBB Inc.');
+		winston.info('This program comes with ABSOLUTELY NO WARRANTY.');
+		winston.info('This is free software, and you are welcome to redistribute it under certain conditions.');
+		winston.info('');
+	}
 }
 
 function start() {
@@ -120,7 +121,7 @@ function start() {
 
 	if (nconf.get('isPrimary') === 'true') {
 		winston.info('Time: %s', (new Date()).toString());
-		winston.info('Initializing NodeBB v%s', pkg.version);
+		winston.info('Initializing NodeBB v%s', nconf.get('version'));
 		winston.verbose('* using configuration stored in: %s', configFile);
 
 		var host = nconf.get(nconf.get('database') + ':host'),

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -3,6 +3,7 @@
 var async = require('async'),
 	fs = require('fs'),
 	path = require('path'),
+	nconf = require('nconf'),
 
 	user = require('../user'),
 	categories = require('../categories'),
@@ -16,7 +17,6 @@ var async = require('async'),
 	plugins = require('../plugins'),
 	widgets = require('../widgets'),
 	groups = require('../groups'),
-	pkg = require('../../package.json'),
 	validator = require('validator');
 
 
@@ -63,7 +63,7 @@ adminController.home = function(req, res, next) {
 			return next(err);
 		}
 		res.render('admin/general/dashboard', {
-			version: pkg.version,
+			version: nconf.get('version'),
 			notices: results.notices,
 			stats: results.stats
 		});

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -1,7 +1,6 @@
 "use strict";
 
-var pkg = require('./../../package.json'),
-	meta = require('./../meta'),
+var meta = require('./../meta'),
 	user = require('./../user'),
 	plugins = require('./../plugins'),
 	widgets = require('../widgets'),
@@ -26,7 +25,7 @@ apiController.getConfig = function(req, res, next) {
 	config.relative_path = nconf.get('relative_path');
 	config.socketioTransports = nconf.get('socket.io:transports') || ['polling', 'websocket'];
 	config.websocketAddress = nconf.get('socket.io:address') || '';
-	config.version = pkg.version;
+	config.version = nconf.get('version');
 	config.siteTitle = validator.escape(meta.config.title || meta.config.browserTitle || 'NodeBB');
 	config.showSiteTitle = parseInt(meta.config.showSiteTitle, 10) === 1;
 	config.postDelay = meta.config.postDelay;

--- a/src/meta/configs.js
+++ b/src/meta/configs.js
@@ -4,7 +4,7 @@
 var winston = require('winston'),
 	db = require('../database'),
 	pubsub = require('../pubsub'),
-	pkg = require('../../package.json');
+	nconf = require('nconf');
 
 module.exports = function(Meta) {
 
@@ -28,7 +28,7 @@ module.exports = function(Meta) {
 	Meta.configs.list = function (callback) {
 		db.getObject('config', function (err, config) {
 			config = config || {};
-			config.version = pkg.version;
+			config.version = nconf.get('version');
 			callback(err, config);
 		});
 	};

--- a/src/plugins/load.js
+++ b/src/plugins/load.js
@@ -5,7 +5,7 @@ var fs = require('fs'),
 	semver = require('semver'),
 	async = require('async'),
 	winston = require('winston'),
-	pkg = require('../../package.json'),
+	nconf = require('nconf'),
 	utils = require('../../public/src/utils');
 
 
@@ -62,7 +62,7 @@ module.exports = function(Plugins) {
 		}
 
 		if (pluginData.nbbpm && pluginData.nbbpm.compatibility && semver.validRange(pluginData.nbbpm.compatibility)) {
-			if (!semver.gtr(pkg.version, pluginData.nbbpm.compatibility)) {
+			if (!semver.gtr(nconf.get('version'), pluginData.nbbpm.compatibility)) {
 				display();
 			}
 		} else {


### PR DESCRIPTION
Our cloud hosting needs the package.json version to be incremented on every new publish. Doing this will trigger warnings in the admin Dashboard and plugin management because NodeBB uses this version to check for updates and compatibility.

I've made small change that will allow the version to be set via the config, while still defaulting to the version in package.json.