### PR TITLE
Redirect incorrect slugs instead of 404

### DIFF
--- a/src/controllers/categories.js
+++ b/src/controllers/categories.js
@@ -189,7 +189,7 @@ categoriesController.get = function(req, res, next) {
 			}
 
 			if (req.params.slug && cid + '/' + req.params.slug !== results.categoryData.slug) {
-				return helpers.notFound(req, res);
+				return helpers.redirect('/category/' + results.categoryData.slug + (utils.isNumber(req.params.topic_index) ? '/' + req.params.topic_index : ''));
 			}
 
 			if (!results.privileges.read) {

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -43,8 +43,12 @@ topicsController.get = function(req, res, next) {
 		function (results, next) {
 			userPrivileges = results.privileges;
 
-			if (userPrivileges.disabled || (req.params.slug && tid + '/' + req.params.slug !== results.topic.slug)) {
+			if (userPrivileges.disabled) {
 				return helpers.notFound(req, res);
+			}
+
+			if (req.params.slug && tid + '/' + req.params.slug !== results.topic.slug) {
+				return helpers.redirect('/topic/' + results.topic.slug + (utils.isNumber(req.params.post_index) ? '/' + req.params.post_index : ''));
 			}
 
 			if (!userPrivileges.read || (parseInt(results.topic.deleted, 10) && !userPrivileges.view_deleted)) {


### PR DESCRIPTION
If you rename the title of a category or topic you want shared links to remain working and not 404