### PR TITLE
Replace schemeless URLs for emails

### DIFF
--- a/src/topics/follow.js
+++ b/src/topics/follow.js
@@ -157,7 +157,7 @@ module.exports = function(Topics) {
 								pid: postData.pid,
 								subject: '[' + (meta.config.title || 'NodeBB') + '] ' + title,
 								intro: '[[notifications:user_posted_to, ' + postData.user.username + ', ' + title + ']]',
-								postBody: postData.content,
+								postBody: postData.content.replace(/"\/\//g, '"http://'),
 								site_title: meta.config.title || 'NodeBB',
 								username: data.userData.username,
 								userslug: data.userData.userslug,


### PR DESCRIPTION
In most email clients a schemeless image src won't show (Apple Mail ao) while this exactly what most plugins (Amazon S3 ao) use. So for email notifications we should replace `"//` by `"http://"`