### PR TITLE
use replicaset if configured

### DIFF
--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -77,9 +77,9 @@
 		var ports = nconf.get('mongo:port').toString().split(',');
 		var servers = [];
 
-        for (var i = 0; i < hosts.length; i++) {
-            servers.push(hosts[i] + ':' + ports[i]);
-        }
+		for (var i = 0; i < hosts.length; i++) {
+			servers.push(hosts[i] + ':' + ports[i]);
+		}
 
 		var connString = 'mongodb://' + usernamePassword + servers.join() + '/' + nconf.get('mongo:database');
 

--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -74,7 +74,7 @@
 		}
 
 		var hosts = nconf.get('mongo:host').split(',');
-		var ports = nconf.get('mongo:port').split(',');
+		var ports = nconf.get('mongo:port').toString().split(',');
 		var servers = [];
 
         for (var i = 0; i < hosts.length; i++) {
@@ -161,4 +161,3 @@
 	};
 
 }(exports));
-

--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -73,7 +73,16 @@
 			nconf.set('mongo:database', '0');
 		}
 
-		var connString = 'mongodb://' + usernamePassword + nconf.get('mongo:host') + ':' + nconf.get('mongo:port') + '/' + nconf.get('mongo:database');
+		var hosts = nconf.get('mongo:host').split(',');
+		var ports = nconf.get('mongo:port').split(',');
+		var servers = [];
+
+        for (var i = 0; i < hosts.length; i++) {
+            servers.push(hosts[i] + ':' + ports[i]);
+        }
+
+		var connString = 'mongodb://' + usernamePassword + servers.join() + '/' + nconf.get('mongo:database');
+
 		var connOptions = {
 			server: {
 				poolSize: parseInt(nconf.get('mongo:poolSize'), 10) || 10

--- a/tests/mocks/databasemock.js
+++ b/tests/mocks/databasemock.js
@@ -45,6 +45,14 @@
 				'    "password": "",' + '\n' +
 				'    "database": "1"' + '\n' +
 			'}\n'+
+			' or (mongo) in a replicaset' + '\n' +
+			'"test_database": {' + '\n' +
+		    '    "host": "127.0.0.1,127.0.0.1,127.0.0.1",' + '\n' +
+		    '    "port": "27017,27018,27019",' + '\n' +
+		    '    "username": "",' + '\n' +
+		    '    "password": "",' + '\n' +
+		    '    "database": "nodebb_test"' + '\n' +
+		    '}\n'+
 			'==========================================================='
 		);
 		winston.error(errorText);


### PR DESCRIPTION
I use a replicaset. Here's a patch to use as well.

**config.json:**
```
{
    "url": "http://localhost:4567",
    "secret": "fae93eb7-f17b-429d-a614-4783d8466517",
    "database": "mongo",
    "mongo": {
        "host": "127.0.0.1,127.0.0.1,127.0.0.1",
        "port": "27017,27018,27019",
        "username": "",
        "password": "",
        "database": "nodebb"
    }
}
```