### PR TITLE
completes fix for #3119

### DIFF
--- a/src/views/admin/extend/plugins.tpl
+++ b/src/views/admin/extend/plugins.tpl
@@ -73,7 +73,7 @@
 						<small>Latest <strong class="latestVersion">{plugins.latest}</strong></small>
 
 						<!-- IF plugins.url -->
-						<p>For more information: <a href="{plugins.url}">{plugins.url}</a></p>
+						<p>For more information: <a target="_blank" href="{plugins.url}">{plugins.url}</a></p>
 						<!-- ENDIF plugins.url -->
 					</li>
 					<!-- ENDIF !plugins.installed -->


### PR DESCRIPTION
Apply target="_blank" for plugin URL's in "Download Plugins" section