### PR TITLE
Hacky argv and env support for boolean config vars

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -17,7 +17,7 @@ nconf.argv().env().file({
 
 var	pidFilePath = __dirname + '/pidfile',
 	output = logrotate({ file: __dirname + '/logs/output.log', size: '1m', keep: 3, compress: true }),
-	silent = nconf.get('silent') !== false,
+	silent = toBool(nconf.get('silent')) !== false,
 	numProcs,
 	workers = [],
 
@@ -205,6 +205,12 @@ function getPorts() {
 	return port;
 }
 
+function toBool(param) {
+	return	(param === "false")
+		? false
+		: !!param
+}
+
 Loader.restart = function() {
 	killWorkers();
 
@@ -248,7 +254,7 @@ Loader.notifyWorkers = function(msg, worker_pid) {
 
 fs.open(path.join(__dirname, 'config.json'), 'r', function(err) {
 	if (!err) {
-		if (nconf.get('daemon') !== false) {
+		if (toBool(nconf.get('daemon')) !== false) {
 			if (fs.existsSync(pidFilePath)) {
 				try {
 					var	pid = fs.readFileSync(pidFilePath, { encoding: 'utf-8' });


### PR DESCRIPTION
`toBool(param)` = `false` if param is falsy or `=== "false"`, otherwise `true` if truthy

I think currently only the `daemon` and `silent` config vars seem to require bools, both of which are only used in `loader.js`, to this is just limited to that file.

This is especially useful in environments where you don't have control over the command used to run NodeBB (i.e. they just execute `npm start`), but that require NodeBB to remain in the foreground (i.e. some PaaS-es or other general tools that make use of the scripts defined in package.json).