### PR TITLE
add feature to define mongo client connect options via config.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "templates.js": "^0.2.3",
     "uglify-js": "git+https://github.com/julianlam/UglifyJS2.git",
     "underscore": "~1.8.3",
+    "underscore.deep": "^0.5.1",
     "validator": "^3.30.0",
     "winston": "^0.9.0",
     "xregexp": "~2.0.0"

--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -7,7 +7,10 @@
 		async = require('async'),
 		nconf = require('nconf'),
 		session = require('express-session'),
+		_ = require('underscore'),
 		db, mongoClient;
+
+	_.mixin(require('underscore.deep'));
 
 	module.questions = [
 		{
@@ -88,6 +91,9 @@
 				poolSize: parseInt(nconf.get('mongo:poolSize'), 10) || 10
 			}
 		};
+
+		connOptions = _.deepExtend((nconf.get('mongo:options') || {}), connOptions);
+
 		mongoClient.connect(connString, connOptions, function(err, _db) {
 			if (err) {
 				winston.error("NodeBB could not connect to your Mongo database. Mongo returned the following error: " + err.message);


### PR DESCRIPTION
This small change allows mongo client options to be defined in the mongo:options configuration in config.json.  The example snippet below is specifying the name of the replica set to be used in the connection.  Any existing connOptions values will overwrite the values provided via mongo:options.

```
{
...
    "mongo": {
...
        "options": {
            "replSet": {
                "rs_name": "set-1234567890"
            }
        }
...
```