### PR TITLE
General-Purpose Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:0.10-onbuild
+
+ENV NODE_ENV=production \
+    daemon=false \
+    silent=false
+
+CMD node app --setup && npm start
+EXPOSE 4567


### PR DESCRIPTION
As opposed to the ones in https://github.com/NodeBB/docker-builds, this Dockerfile uses its build context instead of pulling NodeBB from GitHub, which is subjectively superior (though also, from another viewpoint, subjectively inferior) and allows it to just sit in the root of the repository and build whatever version of NodeBB is there without needing to alter the Dockerfile.
(Which would allow the Docker registry to just automagically build an image for the latest commit (or like any other tag) without needing to update the NodeBB/docker-builds repo every time you want a new image to be made... :wink: :wink: :nudge: :nudge: )

All `npm install`ing is handled automagically by dark forces in the [node-onbuild](https://registry.hub.docker.com/_/node/) image, save for the database-specific packages. This is because `node app --setup` is executed at runtime, allowing you to, like, set a database password without publishing it to the public registry.

#### Configuration
Configuration options can be set with the `-e` flag on `docker run`, i.e. `docker run --name nodebb -p 80:4567 --rm -e url=https://community.nodebb.org  -e redis__host=redis.example.com -e redis__password=CorrectHorseBatteryStaple`

#### Plugins & Themes
If you wish to install plugins or themes with this image, there would be two possible ways to go around that:
**1. (the poor man's way)** Add your desired plugins and themes to the `package.json` and do a `docker build`. This will build an image with all the themes and plugins you specified, but will take quite long, as the initial `npm install` and the installation of your plugins are saved as a single layer in Docker's cache, causing every single one of NodeBB's dependencies and NodeBB's dependencies' dependencies and NodeBB's dependencies' dependencies' dependencies to be fetched and installed again, which takes, well, ages.
**2. (the fancypants way)** Simply create the following Dockerfile (assuming the image build from the Dockerfile included in this commit is in the Docker repo as `example/nodebb`) and build it.
```
FROM example/nodebb

RUN npm install nodebb-plugin-imgur \
                nodebb-plugin-stagram \
                nodebb-theme-song

EXPOSE 4566
EXPOSE 4568
```
**Note: you can omit the backslashes and newlines and simply place all of the packages on one line*
***Note 2: depending on how you've got things set up you might want to put the EXPOSE commands before the RUN command, or put every `npm install` in its own RUN*

This example would install two plugins and one theme on top of the regular NodeBB image and exposes two more ports, allowing you to use NodeBB's inbuilt vertical scaling (along with an `-e port=[4566, 4567, 4568]`)
Due to the installation of plugins being on another layer than the initial `npm install`, Docker will just grab the underlying images from its cache and only install the images provided in the RUN command, drastically reducing build time.