### PR TITLE
Swap out ImageMagick for lwip

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "daemon": "~1.1.0",
     "express": "^4.9.5",
     "express-session": "^1.8.2",
-    "gm": "1.17.0",
+    "lwip": "0.0.6",
     "gravatar": "^1.1.0",
     "heapdump": "^0.3.0",
     "less": "^2.0.0",

--- a/src/image.js
+++ b/src/image.js
@@ -1,38 +1,28 @@
 'use strict';
 
 var fs = require('fs'),
-	gm = require('gm').subClass({imageMagick: true});
+	lwip = require('lwip');
 
 var image = {};
 
 image.resizeImage = function(path, extension, width, height, callback) {
-	function done(err, stdout, stderr) {
-		callback(err);
-	}
-
-	if(extension === '.gif') {
-		gm().in(path)
-			.in('-coalesce')
-			.in('-resize')
-			.in(width+'x'+height+'^')
-			.write(path, done);
-	} else {
-		gm(path)
-			.in('-resize')
-			.in(width+'x'+height+'^')
-			.gravity('Center')
+	lwip.open(path, function(err, image) {
+		image.batch()
+			.cover(width, height)
 			.crop(width, height)
-			.write(path, done);
-	}
+			.writeFile(path, function(err) {
+				callback(err)
+			})
+		});
 };
 
 image.convertImageToPng = function(path, extension, callback) {
 	if(extension !== '.png') {
-		gm(path).toBuffer('png', function(err, buffer) {
+		lwip.open(path, function(err, image) {
 			if (err) {
 				return callback(err);
 			}
-			fs.writeFile(path, buffer, 'binary', callback);
+			image.writeFile(path, 'png', callback)
 		});
 	} else {
 		callback();


### PR DESCRIPTION
[lwip](https://www.npmjs.com/package/lwip) is pure Node alternative to ImageMagick, thus ridding us of the only external dependency. (not counting the db of course :stuck_out_tongue_winking_eye: )

Caveats:
* Doesn't support cropping/resizing of animated gifs. Gifs will lose their animation.

I've done some testing locally and thus far I haven't found any noticeable difference from the user's perspective - all avatars are cropped and resized exactly the same as before this commit.

*Note: There's probably a more efficient way to write `src/image.js`, I just wanted to swap things out one-to-one as much as possible for the sake of simplicity.*