### PR TITLE
Put user status in data attribute instead of CSS class

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -480,8 +480,8 @@ app.cacheBuster = null;
 		}
 
 		translator.translate('[[global:' + status + ']]', function(translated) {
-			el.removeClass('online offline dnd away')
-				.addClass(status)
+			el.removeAttr('data-user-status')
+				.attr('data-user-status', status)
 				.attr('title', translated)
 				.attr('data-original-title', translated);
 		});

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -468,7 +468,7 @@ app.cacheBuster = null;
 				if(err) {
 					return app.alertError(err.message);
 				}
-				$('#logged-in-menu #user_label #user-profile-link>i').attr('class', 'fa fa-circle status ' + status);
+				$('#logged-in-menu #user_label #user-profile-link>i').attr('class', 'fa fa-circle status'.attr('data-user-status', status);
 			});
 			e.preventDefault();
 		});


### PR DESCRIPTION
Seeing as a user can have only one status at a time, it makes more sense to just put it in a data attribute than to have a (potentially large) list of statuses (stati?) as classes.

This'd also make it easier for plugins to add custom statuses in the future, removing one of the two hardcoded lists of stati, the other being on line 481 of [src/socket.io/user.js](https://github.com/NodeBB/NodeBB/blob/a355fbfc81f451fab32d94d5e19625bccc259718/src/socket.io/user.js#L481).