### PR TITLE
Add header.build back in as a useful hook

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -174,11 +174,16 @@ middleware.buildHeader = function(req, res, next) {
 			},
 			footer: function(next) {
 				app.render('footer', {loggedIn: (req.user ? parseInt(req.user.uid, 10) !== 0 : false)}, next);
+			},
+			plugins: function(next){
+				plugins.fireHook('filter:header.build', res.locals, next);
 			}
 		}, function(err, results) {
 			if (err) {
 				return next(err);
 			}
+			
+			res.locals = results.plugins;
 
 			res.locals.config = results.config;
 

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -176,14 +176,14 @@ middleware.buildHeader = function(req, res, next) {
 				app.render('footer', {loggedIn: (req.user ? parseInt(req.user.uid, 10) !== 0 : false)}, next);
 			},
 			plugins: function(next){
-				plugins.fireHook('filter:header.build', res.locals, next);
+				plugins.fireHook('filter:header.build', { locals: res.locals }, next);
 			}
 		}, function(err, results) {
 			if (err) {
 				return next(err);
 			}
 			
-			res.locals = results.plugins;
+			res.locals = results.plugins.locals;
 
 			res.locals.config = results.config;
 


### PR DESCRIPTION
`filter:header.build` can now be used to augment the header template variables. Since the header variables can be accessed by the whole page (I think?) this is a very useful feature.

Deprecation is [here](https://github.com/NodeBB/NodeBB/blob/a355fbfc81f451fab32d94d5e19625bccc259718/src/navigation/admin.js#L57)