### PR TITLE
use icon for plugin entries

### DIFF
--- a/src/views/admin/partials/menu.tpl
+++ b/src/views/admin/partials/menu.tpl
@@ -79,7 +79,12 @@
 						<li class="nav-header"><i class="fa fa-fw fa-th"></i> Installed Plugins</li>
 						<!-- BEGIN plugins -->
 						<li>
-							<a href="{relative_path}/admin{plugins.route}">{plugins.name}</a>
+							<a href="{relative_path}/admin{plugins.route}">
+							<!-- IF plugins.icon -->
+							<i class="fa {plugins.icon}"></i>
+							<!-- ENDIF plugins.icon -->
+							{plugins.name}
+							</a>
 						</li>
 						<!-- END plugins -->
 						<li data-link="1">


### PR DESCRIPTION
Many plugins set the `icon` field in their `filter:admin.header.build` hook:
https://github.com/barisusakli/nodebb-plugin-dbsearch/blob/master/index.js#L363
https://github.com/psychobunny/nodebb-plugin-cash/blob/master/library.js#L13
https://github.com/frissdiegurke/nodebb-plugin-shortcuts/blob/master/coffee/00.variables.coffee#L15

but it's not used in the template.

Looks arguably crowded, though.
![nbb-adminmenu](https://cloud.githubusercontent.com/assets/3411649/8375104/c14857a6-1bfa-11e5-93d4-a395f5c2f36c.png)
