### PR TITLE
User.uploadFromUrl fix

### DIFF
--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -57,8 +57,8 @@
 				}
 
 				router.get(strategy.callbackURL, passport.authenticate(strategy.name, {
-					successReturnToOrRedirect: nconf.get('relative_path') + '/',
-					failureRedirect: nconf.get('relative_path') + '/login'
+					successReturnToOrRedirect: nconf.get('relative_path') + (strategy.successUrl !== undefined ? strategy.successUrl : '/'),
+					failureRedirect: nconf.get('relative_path') + (strategy.failureUrl !== undefined ? strategy.failureUrl : '/login')
 				}));
 			});
 

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -90,7 +90,11 @@ module.exports = function(User) {
 	};
 
 	User.uploadFromUrl = function(uid, url, callback) {
-		var filename = 'uid:' + uid + ':tmp-image';
+		var extension = url.substring(url.lastIndexOf('.') + 1);
+		if (['png', 'jpeg', 'jpg', 'gif'].indexOf(extension) == -1) {
+			return callback('This image type is not allowed');
+		}
+		var filename = 'uid_' + uid + '_tmp-image.' + extension;
 		downloadFromUrl(url, filename, function(err, downloadedImage) {
 			if (err) {
 				return callback(err);


### PR DESCRIPTION
Fixed two bugs:
1. filename cannot contain ':' (at least on windows), nodebb crashes with such filename
2. lwip cannot define image type without file extension (same, at least in my case)

Also added image extension check to prevent security issues