### PR TITLE
filter:auth.init strategy extension with custom urls

### DIFF
--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -57,8 +57,8 @@
 				}
 
 				router.get(strategy.callbackURL, passport.authenticate(strategy.name, {
-					successReturnToOrRedirect: nconf.get('relative_path') + '/',
-					failureRedirect: nconf.get('relative_path') + '/login'
+					successReturnToOrRedirect: nconf.get('relative_path') + (strategy.successUrl !== undefined ? strategy.successUrl : '/'),
+					failureRedirect: nconf.get('relative_path') + (strategy.failureUrl !== undefined ? strategy.failureUrl : '/login')
 				}));
 			});
 


### PR DESCRIPTION
This will allow to redirect user to custom route defined from plugin, in case of success/fail (for example i use this to fill additional required fields like email when authenticating via steam)