### PR TITLE
Filter: Category update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ public/css/*.css
 *.sublime-project
 *.sublime-workspace
 .project
-.idea
 *.swp
 Vagrantfile
 .vagrant
@@ -32,3 +31,13 @@ pidfile
 /public/admin.css
 /public/nodebb.min.js
 /public/nodebb.min.js.map
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+*.iml
+
+## Directory-based project format:
+.idea/
+
+## File-based project format:
+*.ipr
+*.iws

--- a/src/categories/update.js
+++ b/src/categories/update.js
@@ -23,7 +23,7 @@ module.exports = function(Categories) {
 				}
 
 				plugins.fireHook('filter:category.update', {category:modifiedFields}, function(err, categoryData) {
-                    var category = categoryData.category;
+					var category = categoryData.category;
 					var fields = Object.keys(category);
 					async.each(fields, function(key, next) {
 						updateCategoryField(cid, key, category[key], next);

--- a/src/categories/update.js
+++ b/src/categories/update.js
@@ -16,7 +16,14 @@ module.exports = function(Categories) {
 					return next(err);
 				}
 
-				plugins.fireHook('filter:category.update', modified[cid], function(err, category) {
+				var modifiedFields = modified[cid];
+
+				if(modifiedFields.hasOwnProperty('name')){
+					modifiedFields.slug = cid + '/' + utils.slugify(modifiedFields.name);
+				}
+
+				plugins.fireHook('filter:category.update', {category:modifiedFields}, function(err, categoryData) {
+                    var category = categoryData.category;
 					var fields = Object.keys(category);
 					async.each(fields, function(key, next) {
 						updateCategoryField(cid, key, category[key], next);
@@ -44,10 +51,7 @@ module.exports = function(Categories) {
 				return callback(err);
 			}
 
-			if (key === 'name') {
-				var slug = cid + '/' + utils.slugify(value);
-				db.setObjectField('category:' + cid, 'slug', slug, callback);
-			} else if (key === 'order') {
+			if (key === 'order') {
 				db.sortedSetAdd('categories:cid', value, cid, callback);
 			} else {
 				callback();


### PR DESCRIPTION
Hello guys,

Small changes needed in `filter:category.update`. It should expose `slug` earlier.
I did braking changes, and placed category fields under `category` property, as we have it for `filter:category.create`.

Motivation: need this change to update slugify plugin to handle also updates to categories. 

P.S.
And very small bonus: improved rules for JetBrains IDEs in gitignore.