### PR TITLE
Allow Winston's log level to be set via nconf

### DIFF
--- a/app.js
+++ b/app.js
@@ -43,7 +43,7 @@ winston.add(winston.transports.Console, {
 		var date = new Date();
 		return date.getDate() + '/' + (date.getMonth() + 1) + ' ' + date.toTimeString().substr(0,5) + ' [' + global.process.pid + ']';
 	},
-	level: (global.env === 'production' || nconf.get('log-level') === 'info') ? 'info' : 'verbose'
+	level: nconf.get('log-level') || (global.env === 'production' ? 'info' : 'verbose')
 });
 
 if(os.platform() === 'linux') {


### PR DESCRIPTION
Defaults to `info` for `production` and `verbose` otherwise, like it used to.