### PR TITLE
don't display "Leave Group" button for admin in administrators system group on groups details page

### DIFF
--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -115,21 +115,21 @@
 
 	// Groups helpers
 	helpers.membershipBtn = function(groupObj) {
-		if (groupObj.isMember) {
-			if (groupObj.name==='administrators') {
+		if (groupObj.name==='administrators') {
                 		return '';
-            		} else {
+            	} else {
+			if (groupObj.isMember) {
 				return '<button class="btn btn-danger" data-action="leave" data-group="' + groupObj.displayName + '"><i class="fa fa-times"></i> Leave Group</button>';
-            		}
-		} else {
-			if (groupObj.isPending) {
-				return '<button class="btn btn-warning disabled"><i class="fa fa-clock-o"></i> Invitation Pending</button>';
-			} else if (groupObj.isInvited) {
-				return '<button class="btn btn-link" data-action="rejectInvite" data-group="' + groupObj.displayName + '">Reject</button><button class="btn btn-success" data-action="acceptInvite" data-group="' + groupObj.name + '"><i class="fa fa-plus"></i> Accept Invitation</button>';
 			} else {
-				return '<button class="btn btn-success" data-action="join" data-group="' + groupObj.displayName + '"><i class="fa fa-plus"></i> Join Group</button>';
+				if (groupObj.isPending) {
+					return '<button class="btn btn-warning disabled"><i class="fa fa-clock-o"></i> Invitation Pending</button>';
+				} else if (groupObj.isInvited) {
+					return '<button class="btn btn-link" data-action="rejectInvite" data-group="' + groupObj.displayName + '">Reject</button><button class="btn btn-success" data-action="acceptInvite" data-group="' + groupObj.name + '"><i class="fa fa-plus"></i> Accept Invitation</button>';
+				} else {
+					return '<button class="btn btn-success" data-action="join" data-group="' + groupObj.displayName + '"><i class="fa fa-plus"></i> Join Group</button>';
+				}
 			}
-		}
+            	}
 	};
 
 	helpers.spawnPrivilegeStates = function(member, privileges) {

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -116,7 +116,11 @@
 	// Groups helpers
 	helpers.membershipBtn = function(groupObj) {
 		if (groupObj.isMember) {
-			return '<button class="btn btn-danger" data-action="leave" data-group="' + groupObj.displayName + '"><i class="fa fa-times"></i> Leave Group</button>';
+			if (groupObj.name==='administrators') {
+                		return '';
+            		} else {
+				return '<button class="btn btn-danger" data-action="leave" data-group="' + groupObj.displayName + '"><i class="fa fa-times"></i> Leave Group</button>';
+            		}
 		} else {
 			if (groupObj.isPending) {
 				return '<button class="btn btn-warning disabled"><i class="fa fa-clock-o"></i> Invitation Pending</button>';


### PR DESCRIPTION
clicking the button by accident will leave the forum with no administrator if there is only one admin.