### PR TITLE
Add 'action:request.earlyProcessing' hook

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -101,6 +101,18 @@ module.exports = function(app, middleware) {
 		pluginRouter = express.Router(),
 		authRouter = express.Router(),
 		relativePath = nconf.get('relative_path');
+		
+	app.use(function(req, res, next) {
+        	if (plugins.hasListeners('action:request.earlyProcessing')) {
+            		return plugins.fireHook('action:request.earlyProcessing', {
+                		req: req,
+                		res: res,
+                		next: next
+            		});
+        	} else {
+            		next();
+        	}
+    	});
 
 	pluginRouter.render = function() {
 		app.render.apply(app, arguments);


### PR DESCRIPTION
Add a new hook in order to allow early request modifications. Will be useful in case if someone wants to modify request from inside a plugin before it will be processed by any other middleware. (For example it can be used for programmatic login, so `req.user` will be exposed to other middlewares)