### PR TITLE
Add 'action:request.earlyProcessing' hook

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -3,6 +3,7 @@
 var meta = require('../meta'),
 	db = require('../database'),
 	auth = require('../routes/authentication'),
+	plugins = require('../plugins'),
 
 	path = require('path'),
 	fs = require('fs'),
@@ -80,6 +81,18 @@ module.exports = function(app) {
 
 	app.use(middleware.processRender);
 	auth.initialize(app, middleware);
+	
+	app.use(function(req, res, next) {
+        	if (plugins.hasListeners('action:request.earlyProcessing')) {
+            		return plugins.fireHook('action:request.earlyProcessing', {
+                		req: req,
+                		res: res,
+                		next: next
+            		});
+        	} else {
+            		next();
+        	}
+    	});
 
 	return middleware;
 };


### PR DESCRIPTION
Add a new hook in order to allow early request modifications. Will be useful in case if someone wants to modify request from inside a plugin before it will be processed by any other middleware. (For example it can be used for programmatic login, so `req.user` will be exposed to other middlewares)