### PR TITLE
Missing call to action:admin.settingsLoaded

### DIFF
--- a/public/src/modules/settings.js
+++ b/public/src/modules/settings.js
@@ -393,6 +393,9 @@ define('settings', function () {
 					helper.whenReady(function () {
 						helper.use(values);
 						helper.initFields(wrapper || 'form');
+
+						$(window).trigger('action:admin.settingsLoaded');
+
 						if (typeof callback === 'function') {
 							callback();
 						}


### PR DESCRIPTION
Plugins using sync() instead of load() weren't getting the fancy checkboxes.