### PR TITLE
Only use semver.satisfies on valid ranges

### DIFF
--- a/src/meta/dependencies.js
+++ b/src/meta/dependencies.js
@@ -27,7 +27,7 @@ module.exports = function(Meta) {
 
 				try {
 					var pkgData = JSON.parse(pkgData),
-						ok = semver.satisfies(pkgData.version, pkg.dependencies[module]);
+						ok = !semver.validRange(pkg.dependencies[module]) || semver.satisfies(pkgData.version, pkg.dependencies[module]);
 
 					if (ok || (pkgData._resolved && pkgData._resolved.indexOf('//github.com') !== -1)) {
 						next(true);


### PR DESCRIPTION
So it doesn't alarm when you use a package straight from git e.g.