### PR TITLE
clear message after send to websocket

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -198,7 +198,6 @@ define('forum/chats', ['components', 'string', 'sounds', 'forum/infinitescroll',
 					return app.alertError(err.message);
 				}
 
-				inputEl.val('');
 				sounds.play('chat-outgoing');
 				Chats.notifyTyping(toUid, false);
 			});

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -202,6 +202,7 @@ define('forum/chats', ['components', 'string', 'sounds', 'forum/infinitescroll',
 				sounds.play('chat-outgoing');
 				Chats.notifyTyping(toUid, false);
 			});
+			inputEl.val('');
 		}
 	};
 


### PR DESCRIPTION
when internet is slow, and user send message to key "Enter" very quickly, it will trigger double message.
so we can clear message after user sent but not only in callback clear, move clear to outside.