### PR TITLE
Replace Less variable that is undefined if Bootstrap is absent

### DIFF
--- a/public/less/generics.less
+++ b/public/less/generics.less
@@ -26,7 +26,7 @@
 		padding: 0.5rem 1rem;
 
 		&:hover {
-			background: @gray-lighter;
+			background: #eee;
 		}
 
 		img {


### PR DESCRIPTION
When Bootstrap isn't used (for example in the case of a custom theme being activated), `@gray-lighter` is undefined resulting in NodeBB not running. This PR replaces that variable with the default value assigned to it by Bootstrap.