### PR TITLE
Revised: Added req and res objects to the widget rendering process

### DIFF
--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -119,7 +119,7 @@ apiController.renderWidgets = function(req, res, next) {
 			template: areas.template,
 			url: areas.url,
 			locations: areas.locations,
-	  },
+		},
 		req,
 		res,
 		function(err, widgets) {

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -114,11 +114,15 @@ apiController.renderWidgets = function(req, res, next) {
 		return res.status(200).json({});
 	}
 
-	widgets.render(req.uid, {
-		template: areas.template,
-		url: areas.url,
-		locations: areas.locations
-	}, function(err, widgets) {
+	widgets.render(req.uid,
+		{
+			template: areas.template,
+			url: areas.url,
+			locations: areas.locations,
+	  },
+		req,
+		res,
+		function(err, widgets) {
 		if (err) {
 			return next(err);
 		}

--- a/src/widgets/index.js
+++ b/src/widgets/index.js
@@ -10,7 +10,7 @@ var async = require('async'),
 
 var widgets = {};
 
-widgets.render = function(uid, area, callback) {
+widgets.render = function(uid, area, req, res, callback) {
 	if (!area.locations || !area.template) {
 		return callback(new Error('[[error:invalid-data]]'));
 	}
@@ -37,7 +37,9 @@ widgets.render = function(uid, area, callback) {
 				plugins.fireHook('filter:widget.render:' + widget.widget, {
 					uid: uid,
 					area: area,
-					data: widget.data
+					data: widget.data,
+					req: req,
+					res: res
 				}, function(err, html) {
 					if (err) {
 						return next(err);


### PR DESCRIPTION
This pull request includes a slight change based on a comment from @barisusakli in this earlier thread:
https://github.com/NodeBB/NodeBB/pull/3555

Comments from earlier pull request:
=======================================================
Simply added req and res objects to the widget rendering process so that widgets can use this information from the hook: filter:widget.render:.*. This was discussed in https://community.nodebb.org/topic/6415/way-to-get-req-and-maybe-res-objects-during-a-widget-render/2

I made the additions and they worked for my new plugin. The req and res parameters are additive changes that shouldn't effect existing widgets. I tested against 0.8.1 and head by manually launching the app and making sure that widgets (both mine and a number of standard ones) rendered properly without errors in the logs.

Thank you! NodeBB is awesome!