### PR TITLE
Add user home pages. Fixes #3616

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -15,6 +15,7 @@
     "allowLocalLogin": 1,
     "allowAccountDelete": 1,
     "allowFileUploads": 0,
+    "allowUserHomePage": 1,
     "maximumFileSize": 2048,
     "minimumTitleLength": 3,
     "maximumTitleLength": 255,

--- a/public/language/en_GB/user.json
+++ b/public/language/en_GB/user.json
@@ -107,6 +107,11 @@
 
 	"select-skin": "Select a Skin",
 
+	"select-homepage": "Select a Custom Homepage",
+	"homepage": "Homepage",
+	"homepage_description": "Select a page to use as the forum homepage or 'None' to use the default homepage.",
+	"custom_route": "Custom Homepage Route",
+
 	"sso.title": "Single Sign-on Services",
 	"sso.associated": "Associated with",
 	"sso.not-associated": "Click here to associate with"

--- a/public/src/client/account/settings.js
+++ b/public/src/client/account/settings.js
@@ -68,7 +68,20 @@ define('forum/account/settings', ['forum/account/header'], function(header) {
 
 			css.attr('href', val);
 		});
+
+		$('[data-property="homePageRoute"]').on('change', toggleCustomRoute);
+
+		toggleCustomRoute();
 	};
+
+	function toggleCustomRoute() {
+		$('[data-property="homePageCustom"]').val('');
+		if ($('[data-property="homePageRoute"]').val() === 'custom') {
+			$('#homePageCustom').show();
+		}else{
+			$('#homePageCustom').hide();
+		}
+	}
 
 	return AccountSettings;
 });

--- a/src/controllers/accounts.js
+++ b/src/controllers/accounts.js
@@ -11,5 +11,4 @@ var accountsController = {
 	chats: require('./accounts/chats')
 };
 
-
 module.exports = accountsController;

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -57,6 +57,7 @@ apiController.getConfig = function(req, res, next) {
 	config.allowProfileImageUploads = parseInt(meta.config.allowProfileImageUploads) === 1;
 	config.allowTopicsThumbnail = parseInt(meta.config.allowTopicsThumbnail, 10) === 1;
 	config.allowAccountDelete = parseInt(meta.config.allowAccountDelete, 10) === 1;
+	config.allowUserHomePage = parseInt(meta.config.allowUserHomePage, 10) === 1;
 	config.privateUserInfo = parseInt(meta.config.privateUserInfo, 10) === 1;
 	config.privateTagListing = parseInt(meta.config.privateTagListing, 10) === 1;
 	config.usePagination = parseInt(meta.config.usePagination, 10) === 1;

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -33,22 +33,27 @@ var Controllers = {
 
 
 Controllers.home = function(req, res, next) {
-	var route = meta.config.homePageRoute || meta.config.homePageCustom || 'categories',
-		hook = 'action:homepage.get:' + route;
+	var route = meta.config.homePageRoute || meta.config.homePageCustom || 'categories';
 
-	if (plugins.hasListeners(hook)) {
-		plugins.fireHook(hook, {req: req, res: res, next: next});
-	} else {
-		if (route === 'categories' || route === '/') {
-			Controllers.categories.list(req, res, next);
-		} else if (route === 'recent') {
-			Controllers.recent.get(req, res, next);
-		} else if (route === 'popular') {
-			Controllers.popular.get(req, res, next);
+	user.getSettings(req.uid, function(err, settings) {
+		if (!err) route = settings.homePageRoute || route;
+
+		var hook = 'action:homepage.get:' + route;
+
+		if (plugins.hasListeners(hook)) {
+			plugins.fireHook(hook, {req: req, res: res, next: next});
 		} else {
-			res.redirect(route);
+			if (route === 'categories' || route === '/') {
+				Controllers.categories.list(req, res, next);
+			} else if (route === 'recent') {
+				Controllers.recent.get(req, res, next);
+			} else if (route === 'popular') {
+				Controllers.popular.get(req, res, next);
+			} else {
+				res.redirect(route);
+			}
 		}
-	}
+	});
 };
 
 Controllers.reset = function(req, res, next) {

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -36,7 +36,7 @@ Controllers.home = function(req, res, next) {
 	var route = meta.config.homePageRoute || meta.config.homePageCustom || 'categories';
 
 	user.getSettings(req.uid, function(err, settings) {
-		if (!err) route = settings.homePageRoute || route;
+		if (!err && settings.homePageRoute !== 'undefined' && settings.homePageRoute !== 'none') route = settings.homePageRoute || route;
 
 		var hook = 'action:homepage.get:' + route;
 

--- a/src/user/settings.js
+++ b/src/user/settings.js
@@ -115,7 +115,8 @@ module.exports = function(User) {
 			sendPostNotifications: data.sendPostNotifications,
 			restrictChat: data.restrictChat,
 			topicSearchEnabled: data.topicSearchEnabled,
-			groupTitle: data.groupTitle
+			groupTitle: data.groupTitle,
+			homePageRoute: data.homePageCustom || data.homePageRoute
 		};
 
 		if (data.bootswatchSkin) {

--- a/src/views/admin/general/homepage.tpl
+++ b/src/views/admin/general/homepage.tpl
@@ -12,10 +12,17 @@
 					<option value="{routes.route}">{routes.name}</option>
 					<!-- END routes -->
 				</select>
-				<br>
 				<div id="homePageCustom" style="display: none;">
+					<br>
 					<label>Custom Route</label>
 					<input type="text" class="form-control" data-field="homePageCustom"/>
+				</div>
+				<br>
+				<div class="checkbox">
+					<label class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
+						<input class="mdl-switch__input" type="checkbox" data-field="allowUserHomePage">
+						<span class="mdl-switch__label"><strong>Allow User Home Pages</strong></span>
+					</label>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION
Issues:
- I'm repeating the exact same function to grab the default homepages for both the acp and user homepage lists, I'm not sure of the best place to define this function so that both controllers can use it.

- I've seen no ill effects from changing the default routes "categories", "recent", and "popular" to res.redirects, but I didn't change it because I wasn't sure if there was some advantage to using the controller directly.