### PR TITLE
Upgrade script fails on some consoles

### DIFF
--- a/nodebb
+++ b/nodebb
@@ -144,8 +144,10 @@ switch(process.argv[2]) {
 			if (err) {
 				process.stdout.write('\nError'.red + ': ' + err.message + '\n');
 			} else {
-				var message = 'NodeBB Upgrade Complete!',
-					spaces = new Array(Math.floor(process.stdout.columns / 2) - (message.length / 2) + 1).join(' ');
+				var message = 'NodeBB Upgrade Complete!';
+				// some consoles will return undefined/zero columns, so just use 2 spaces in upgrade script if we can't get our column count
+				var columns = process.stdout.columns;
+				var spaces = columns ? new Array(Math.floor(columns / 2) - (message.length / 2) + 1).join(' ') : "  ";
 
 				process.stdout.write('OK\n'.green);
 				process.stdout.write('\n' + spaces + message.green.bold + '\n\n'.reset);


### PR DESCRIPTION
The upgrade script errors/fails on some consoles if the stdout.columns isn't set (my console did this when upgrading a Docker instance of NodeBB).
Checking for stdout.columns before using, falling back to a couple of spaces for slightly prettiness if we can't work out the console width.