### PR TITLE
A much faster findBootstrapEnvironment method

### DIFF
--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -238,21 +238,24 @@
 		},
 
 		findBootstrapEnvironment: function() {
-			//http://stackoverflow.com/questions/14441456/how-to-detect-which-device-view-youre-on-using-twitter-bootstrap-api
-			var envs = ['xs', 'sm', 'md', 'lg'],
-				$el = $('<div>');
+			var hash = {
+				xs: 768,
+				sm: 992,
+				md: 1200
+			};
 
-			$el.appendTo($('body'));
+			var width = window.innerWidth;
 
-			for (var i = envs.length - 1; i >= 0; i--) {
-				var env = envs[i];
-
-				$el.addClass('hidden-'+env);
-				if ($el.is(':hidden')) {
-					$el.remove();
-					return env;
-				}
+			if (width < hash.xs) {
+				return 'xs';
 			}
+			if (width < hash.sm) {
+				return 'sm';
+			}
+			if (width < hash.md) {
+				return 'md';
+			}
+			return 'lg';
 		},
 
 		// get all the url params in a single key/value hash


### PR DESCRIPTION
It might be a little less accurate in cases where the `min-nv-width` variables are overridden, but I think its worth it. People should not be overriding those variables in the first place.