### PR TITLE
Respond with 404 when topic inside hidden category

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -119,6 +119,10 @@ topicsController.get = function(req, res, callback) {
 					return next(err);
 				}
 
+				if (topicData.category.disabled) {
+					return callback();
+				}
+
 				topics.modifyByPrivilege(topicData.posts, results.privileges);
 
 				plugins.fireHook('filter:controllers.topic.get', topicData, next);


### PR DESCRIPTION
When users requests a topic (bookmark, link) inside a disabled category, they will see the topic, but can't interact with it in any way. Every command gets replied with `You do not have enough privileges for this action.`

Looking into it, the categories controller replies with 404 when detecting the `disabled` (category:cid) flag set to 1. (https://github.com/NodeBB/NodeBB/blob/master/src/controllers/categories.js#L118-L120)

Added same behaviour to controllers/topics.