### PR TITLE
CORS Support

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -77,6 +77,11 @@ module.exports = function(app) {
 		} else {
 			res.setHeader('X-Frame-Options', 'SAMEORIGIN');
 		}
+		
+		// CORS Support
+		res.setHeader('Access-Control-Allow-Origin','*');
+		res.setHeader('Access-Control-Allow-Methods','GET,OPTIONS');
+		res.setHeader('Access-Control-Allow-Headers','X-Requested-With,Content-Type');
 
 		next();
 	});


### PR DESCRIPTION
Requests to `*.rss` and `/api/*` done by an `XMLHttpRequest` with jQuery's `$.ajax` or AngularJS's `$http` are being rejected due to missing CORS headers.

I've added the basics for the `Access-Control-Allow-*` headers to allow CORS. If more requests or headers are needed, more can be added.