### PR TITLE
[minor] meta tag, content-type shouldnt be escaped

### DIFF
--- a/src/meta/tags.js
+++ b/src/meta/tags.js
@@ -17,7 +17,8 @@ module.exports = function(Meta) {
 					content: 'width=device-width, initial-scale=1.0, user-scalable=no'
 				}, {
 					name: 'content-type',
-					content: 'text/html; charset=UTF-8'
+					content: 'text/html; charset=UTF-8',
+					noEscape: true
 				}, {
 					name: 'apple-mobile-web-app-capable',
 					content: 'yes'


### PR DESCRIPTION
so `text/html; charset=UTF-8` and not `text&#x2F;html; charset=UTF-8`