### PR TITLE
Update overrides.js

### DIFF
--- a/public/src/overrides.js
+++ b/public/src/overrides.js
@@ -110,6 +110,11 @@ if ('undefined' !== typeof window) {
 		var dialog = bootbox.dialog,
 			prompt = bootbox.prompt,
 			confirm = bootbox.confirm;
+			
+		var translator;
+		require(['translator'], function(_translator) {
+			translator = _translator;
+		});
 
 		function translate(modal) {
 			var header = modal.find('.modal-header'),


### PR DESCRIPTION
Inside **translate** function, **translator** refers to *global* genereting warnings. Added a **translator** variable refering to **translator** module.
This solves some problems using *bootbox* in my plugins and widgets