### PR TITLE
fix user full name for local user register

### DIFF
--- a/src/user/create.js
+++ b/src/user/create.js
@@ -33,7 +33,7 @@ module.exports = function(User) {
 				'joindate': timestamp,
 				'lastonline': timestamp,
 				'picture': '',
-				'fullname': data.fullname,
+				'fullname': data.fullname || '',
 				'location': '',
 				'birthday': '',
 				'website': '',


### PR DESCRIPTION
When registering, full name is getting saved as the word "undefined"