### PR TITLE
Update events.js

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -32,7 +32,8 @@ define('forum/topic/events', [
 
 		'event:post_edited': onPostEdited,
 		'event:post_purged': onPostPurged,
-
+		'event:post_moved': onPostPurged,
+		
 		'event:post_deleted': togglePostDeleteState,
 		'event:post_restored': togglePostDeleteState,
 


### PR DESCRIPTION
Added `event:post_moved` event so when you move a post you have top and bottom post counters updated.
No new function needed, linked to `onPostPurged` function, because it do the same work for `event:topic_purged`.