### PR TITLE
mongo.getObjects potential optimization

### DIFF
--- a/src/database/mongo/hash.js
+++ b/src/database/mongo/hash.js
@@ -38,20 +38,7 @@ module.exports = function(db, module) {
 		if (!Array.isArray(keys) || !keys.length) {
 			return callback(null, []);
 		}
-		db.collection('objects').find({_key: {$in: keys}}, {_id: 0}).toArray(function(err, data) {
-			if (err) {
-				return callback(err);
-			}
-
-			var map = helpers.toMap(data);
-			var returnData = [];
-
-			for (var i=0; i<keys.length; ++i) {
-				returnData.push(map[keys[i]]);
-			}
-
-			callback(null, returnData);
-		});
+		db.collection('objects').find({_key: {$in: keys}}, {_id: 0, _key: 0}).toArray(callback);
 	};
 
 	module.getObjectField = function(key, field, callback) {


### PR DESCRIPTION
`mongo.getObjects` calls toArray, then converts to Map, then back to Array, all this to clean the `_key` field.

@barisusakli can you this of a condition where this wouldn't work. `getObject` does that already