### PR TITLE
add redis and redisearch to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "passport": "^0.3.0",
     "passport-local": "1.0.0",
     "prompt": "^0.2.14",
+    "redis" : "0.11.0",
+    "redisearch" : "0.0.6",
     "request": "^2.44.0",
     "rimraf": "~2.4.2",
     "rss": "^1.0.0",


### PR DESCRIPTION
add redis and redisearch to dependencies(because it need when install nodebb-0.9.3)