### PR TITLE
Cumulative PR. Various for handle topic "post move"

### DIFF
--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -1,14 +1,15 @@
 
 'use strict';
 
-/* globals config, app, ajaxify, define, socket, templates, translator, utils */
+/* globals config, app, ajaxify, define, socket, templates, utils */
 
 define('forum/topic/events', [
 	'forum/topic/postTools',
 	'forum/topic/threadTools',
 	'forum/topic/posts',
-	'components'
-], function(postTools, threadTools, posts, components) {
+	'components',
+	'translator'
+], function(postTools, threadTools, posts, components, translator) {
 
 	var Events = {};
 
@@ -31,6 +32,7 @@ define('forum/topic/events', [
 
 		'event:post_edited': onPostEdited,
 		'event:post_purged': onPostPurged,
+		'event:post_moved': onPostPurged,
 
 		'event:post_deleted': togglePostDeleteState,
 		'event:post_restored': togglePostDeleteState,

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -390,7 +390,7 @@ define('forum/topic/postTools', ['share', 'navigator', 'components', 'translator
 	}
 
 	function movePost(post, pid, tid, callback) {
-		socket.emit('posts.movePost', {pid: pid, tid: tid}, function(err) {
+		socket.emit('posts.movePost', {pid: pid, tid: tid, from_tid: ajaxify.data.tid}, function(err) {
 			if (err) {
 				app.alertError(err.message);
 				return callback();

--- a/src/socket.io/posts/move.js
+++ b/src/socket.io/posts/move.js
@@ -4,6 +4,7 @@ var async = require('async');
 var privileges = require('../../privileges');
 var topics = require('../../topics');
 var socketHelpers = require('../helpers');
+var websockets = require('../index');
 
 module.exports = function(SocketPosts) {
 
@@ -12,7 +13,7 @@ module.exports = function(SocketPosts) {
 			return callback(new Error('[[error:not-logged-in]]'));
 		}
 
-		if (!data || !data.pid || !data.tid) {
+		if (!data || !data.pid || !data.tid || !data.from_tid) {
 			return callback(new Error('[[error:invalid-data]]'));
 		}
 
@@ -29,6 +30,8 @@ module.exports = function(SocketPosts) {
 			},
 			function (next) {
 				socketHelpers.sendNotificationToPostOwner(data.pid, socket.uid, 'notifications:moved_your_post');
+				websockets.in('topic_' + data.from_tid).emit('event:post_moved', data.pid);
+
 				next();
 			}
 		], callback);


### PR DESCRIPTION
Added `event:post_moved` event so when you move a post you have top and
bottom post counters updated.
No new function needed, linked to `onPostPurged` function, because it do
the same work for `event:topic_purged`.
Added `from_tid` to socket data to handle new event  `event:post_moved`
and also added `websocket.in(...` to emit just implemented client side
event `event:post_moved` so top and bottom counters are updated in real
time when a post is moved. (see other commits #4145 #4146 #4147 ).