### PR TITLE
Prevent breaking eventLoopLagThreshold value

### DIFF
--- a/src/views/admin/settings/advanced.tpl
+++ b/src/views/admin/settings/advanced.tpl
@@ -85,7 +85,7 @@
 			</div>
 			<div class="form-group">
 				<label for="eventLoopLagThreshold">Event Loop Lag Threshold (in milliseconds)</label>
-				<input class="form-control" id="eventLoopLagThreshold" type="number" data-field="eventLoopLagThreshold" placeholder="Default: 70" step="10" value="70" />
+				<input class="form-control" id="eventLoopLagThreshold" type="number" data-field="eventLoopLagThreshold" placeholder="Default: 70" step="10" min="10" value="70" />
 				<p class="help-block">
 					Lowering this value decreases wait times for page loads, but will also show the
 					"excessive load" message to more users. (Reload required)


### PR DESCRIPTION
[This problem](https://community.nodebb.org/topic/7955/and-once-again-all-my-data-has-gone/7) occurs when you put a value less than `10`.