### PR TITLE
fix logout on user self delete

### DIFF
--- a/public/src/client/account/edit.js
+++ b/public/src/client/account/edit.js
@@ -172,7 +172,7 @@ define('forum/account/edit', ['forum/account/header', 'uploader', 'translator'],
 							if (err) {
 								app.alertError(err.message);
 							}
-							app.logout();
+							window.location.href = config.relative_path + '/';
 						});
 					}
 				});


### PR DESCRIPTION
`app.logout();` throws forbidden error as the user is already deleted.