### PR TITLE
fast path for mongodb batches

### DIFF
--- a/src/batch.js
+++ b/src/batch.js
@@ -23,6 +23,11 @@ var async = require('async'),
 			return callback(new Error('[[error:process-not-a-function]]'));
 		}
 
+		// use the fast path if possible
+		if (db.processSortedSet && typeof options.doneIf !== 'function' && !utils.isNumber(options.alwaysStartAt)) {
+			return db.processSortedSet(setKey, process, options.batch || DEFAULT_BATCH_SIZE, callback);
+		}
+
 		// custom done condition
 		options.doneIf = typeof options.doneIf === 'function' ? options.doneIf : function(){};
 

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -533,4 +533,40 @@ module.exports = function(db, module) {
 				callback(err, data);
 		});
 	};
+
+	module.processSortedSet = function(setKey, process, batch, callback) {
+		var done = false, ids = [], cursor = db.collection('objects').
+			find({_key: setKey}).
+			sort({score: 1}).
+			project({_id: 0, value: 1}).
+			batchSize(batch);
+
+		async.whilst(
+			function() {
+				return !done;
+			},
+			function(next) {
+				cursor.next(function(err, item) {
+					if (err) {
+						return next(err);
+					}
+					if (item === null) {
+						done = true;
+					} else {
+						ids.push(item.value);
+					}
+
+					if (ids.length < batch && (!done || ids.length === 0)) {
+						return next(null);
+					}
+
+					process(ids, function(err) {
+						ids = [];
+						return next(err);
+					});
+				});
+			},
+			callback
+		);
+	};
 };


### PR DESCRIPTION
The upgrade for 1.0.0 looks like this: (I stopped it because I didn't want it to run for days)
![image](https://cloud.githubusercontent.com/assets/4257305/13407393/d7b2cb50-deed-11e5-9e91-25628ee6e644.png)

With this patch, it looks like this:
![image](https://cloud.githubusercontent.com/assets/4257305/13407939/a4c04a26-def0-11e5-9c99-f5388d29f0b8.png)

(at the time of posting, the upgrade's last two lines are `Creating users:notvalidated done!` and `Creating Global moderators group`)

See also: akhoury/nodebb-plugin-import#176