### PR TITLE
Add API endpoint analogs to websocket interface

### DIFF
--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -192,7 +192,7 @@ SocketCategories.isModerator = function(socket, cid, callback) {
 	user.isModerator(socket.uid, cid, callback);
 };
 
-SocketCategories.getCategory = function(socket, cid, callback){
+SocketCategories.getCategory = function(socket, cid, callback) {
 	async.waterfall([
 		function (next) {
 			privileges.categories.can('read', cid, socket.uid, next);

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -192,4 +192,18 @@ SocketCategories.isModerator = function(socket, cid, callback) {
 	user.isModerator(socket.uid, cid, callback);
 };
 
+SocketCategories.getCategory = function(socket, cid, callback){
+	async.waterfall([
+		function (next) {
+			privileges.categories.can('read', cid, socket.uid, next);
+		},
+		function (canRead, next) {
+			if (!canRead) {
+				return next(new Error('[[error:no-privileges]]'));
+			}
+			categories.getCategoryData(cid, next);
+		}
+	], callback);
+};
+
 module.exports = SocketCategories;

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -77,6 +77,26 @@ SocketPosts.getRawPost = function(socket, pid, callback) {
 	], callback);
 };
 
+SocketPosts.getPost = function(socket, pid, callback) {
+	async.waterfall([
+		function(next) {
+			privileges.posts.can('read', pid, socket.uid, next);
+		},
+		function(canRead, next) {
+			if (!canRead) {
+				return next(new Error('[[error:no-privileges]]'));
+			}
+			posts.getPostData(pid, next);
+		},
+		function(postData, next) {
+			if (parseInt(postData.deleted, 10) === 1) {
+				return next(new Error('[[error:no-post]]'));
+			}
+			next(null, postData);
+		}
+	], callback);
+};
+
 SocketPosts.loadMoreFavourites = function(socket, data, callback) {
 	loadMorePosts('uid:' + data.uid + ':favourites', socket.uid, data, callback);
 };

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -126,4 +126,24 @@ SocketTopics.isModerator = function(socket, tid, callback) {
 	});
 };
 
+SocketTopics.getTopic = function (socket, tid, callback) {
+	async.waterfall([
+		function (next) {
+			privileges.topics.can('read', tid, socket.uid, next);
+		},
+		function (canRead, next) {
+			if (!canRead) {
+				return next(new Error('[[error:no-privileges]]'));
+			}
+			topics.getTopicData(tid, next);
+		},
+		function (topicData, next) {
+			if (parseInt(topicData.deleted, 10) === 1) {
+				return next(new Error('[[error:no-topic]]'));
+			}
+			next(null, topicData);
+		}
+	], callback);
+};
+
 module.exports = SocketTopics;

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -194,7 +194,7 @@ SocketUser.saveSettings = function(socket, data, callback) {
 				return next(null, true);
 			}
 			user.isAdminOrGlobalMod(socket.uid, next);
-		}, 
+		},
 		function(allowed, next) {
 			if (!allowed) {
 				return next(new Error('[[error:no-privileges]]'));
@@ -332,5 +332,46 @@ SocketUser.invite = function(socket, email, callback) {
 
 };
 
+
+SocketUser.getUserByUID = getUserByUID;
+
+function getUserByUID(socket, uid, callback) {
+	async.parallel({
+		userData: async.apply(user.getUserData, uid),
+		settings: async.apply(user.getSettings, uid)
+	}, function(err, results) {
+		if (err || !results.userData) {
+			return callback(err||new Error('[[error:no-user]]'));
+		}
+
+		results.userData.email = results.settings.showemail ? results.userData.email : undefined;
+		results.userData.fullname = results.settings.showfullname ? results.userData.fullname : undefined;
+
+		callback(null,results.userData);
+	});
+}
+
+SocketUser.getUserByUsername = function(socket, username, callback) {
+	async.waterfall([
+		function(next) {
+			user.getUidByUsername(username || 0, next);
+		},
+		function(uid, next) {
+			getUserByUID(socket, uid, next);
+		}
+	], callback);
+};
+
+SocketUser.getUserByEmail = function(socket, email, callback) {
+
+	async.waterfall([
+		function(next) {
+			user.getUidByEmail(email || 0, next);
+		},
+		function(uid, next) {
+			getUserByUID(socket, uid, next);
+		}
+	], callback);
+};
 
 module.exports = SocketUser;


### PR DESCRIPTION
includes `post.getPost`, `topic.getTopic`, `category.getCategory`, `user.getUserBy*`

These additional websocket interfaces, along with the existing functionality should enable integrations to use the websocket interface exclusively after authentication

Category, Post, and Topic endpoints enforce user read permissions so there should not be a risk of data leak there.

I'm less sure of the `user.getUserBy*` methods but as these were cribbed from the REST API endpoints and behave identically in my testing any data leak possibility already exists in the REST API endpoint