### PR TITLE
Delete user invites from APM

### DIFF
--- a/public/src/admin/manage/registration.js
+++ b/public/src/admin/manage/registration.js
@@ -8,7 +8,6 @@ define('admin/manage/registration', function() {
 	Registration.init = function() {
 
 		$('.users-list').on('click', '[data-action]', function(ev) {
-			var $this = this;
 			var parent = $(this).parents('[data-username]');
 			var action = $(this).attr('data-action');
 			var username = parent.attr('data-username');
@@ -24,7 +23,6 @@ define('admin/manage/registration', function() {
 		});
 
 		$('.invites-list').on('click', '[data-action]', function(ev) {
-			var $this = this;
 			var parent = $(this).parents('[data-invitation-mail][data-invited-by]');
 			var email = parent.attr('data-invitation-mail');
 			var invitedBy = parent.attr('data-invited-by');

--- a/public/src/admin/manage/registration.js
+++ b/public/src/admin/manage/registration.js
@@ -31,12 +31,25 @@ define('admin/manage/registration', function() {
 			var action = $(this).attr('data-action');
 			var method = 'admin.user.deleteInvitation';
 
+			var removeRow = function () {
+				var nextRow = parent.next(),
+					thisRowinvitedBy = parent.find('.invited-by'),
+					nextRowInvitedBy = nextRow.find('.invited-by');
+				if (nextRowInvitedBy.html() !== undefined && nextRowInvitedBy.html().length < 2) {
+					nextRowInvitedBy.html(thisRowinvitedBy.html());
+				}
+				parent.remove();
+			};
 			if (action === 'delete') {
-				socket.emit(method, {email: email, invitedBy: invitedBy}, function(err) {
-					if (err) {
-						return app.alertError(err.message);
+				bootbox.confirm('Are you sure you wish to delete this invitation?', function(confirm) {
+					if (confirm) {
+						socket.emit(method, {email: email, invitedBy: invitedBy}, function(err) {
+							if (err) {
+								return app.alertError(err.message);
+							}
+							removeRow();
+						});
 					}
-					parent.remove();
 				});
 			}
 			return false;

--- a/public/src/admin/manage/registration.js
+++ b/public/src/admin/manage/registration.js
@@ -22,6 +22,24 @@ define('admin/manage/registration', function() {
 			});
 			return false;
 		});
+
+		$('.invites-list').on('click', '[data-action]', function(ev) {
+			var $this = this;
+			var parent = $(this).parents('[data-invitation-mail]');
+			var email = parent.attr('data-invitation-mail');
+			var action = $(this).attr('data-action');
+			var method = 'admin.user.deleteInvitation';
+
+			if (action === 'delete') {
+				socket.emit(method, {email: email}, function(err) {
+					if (err) {
+						return app.alertError(err.message);
+					}
+					parent.remove();
+				});
+			}
+			return false;
+		});
 	};
 
 	return Registration;

--- a/public/src/admin/manage/registration.js
+++ b/public/src/admin/manage/registration.js
@@ -25,13 +25,14 @@ define('admin/manage/registration', function() {
 
 		$('.invites-list').on('click', '[data-action]', function(ev) {
 			var $this = this;
-			var parent = $(this).parents('[data-invitation-mail]');
+			var parent = $(this).parents('[data-invitation-mail][data-invited-by]');
 			var email = parent.attr('data-invitation-mail');
+			var invitedBy = parent.attr('data-invited-by');
 			var action = $(this).attr('data-action');
 			var method = 'admin.user.deleteInvitation';
 
 			if (action === 'delete') {
-				socket.emit(method, {email: email}, function(err) {
+				socket.emit(method, {email: email, invitedBy: invitedBy}, function(err) {
 					if (err) {
 						return app.alertError(err.message);
 					}

--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -93,7 +93,7 @@ function registerAndLoginUser(req, res, userData, callback) {
 			}
 		},
 		function(next) {
-			user.deleteInvitation(userData.email);
+			user.deleteInvitationKey(userData.email);
 			plugins.fireHook('filter:register.complete', {uid: uid, referrer: req.body.referrer || nconf.get('relative_path') + '/'}, next);
 		}
 	], callback);

--- a/src/socket.io/admin/user.js
+++ b/src/socket.io/admin/user.js
@@ -212,6 +212,10 @@ User.search = function(socket, data, callback) {
 	});
 };
 
+User.deleteInvitation = function(socket, data, callback) {
+	user.deleteInvitation(data.email, callback);
+};
+
 User.acceptRegistration = function(socket, data, callback) {
 	user.acceptRegistration(data.username, callback);
 };

--- a/src/socket.io/admin/user.js
+++ b/src/socket.io/admin/user.js
@@ -213,7 +213,7 @@ User.search = function(socket, data, callback) {
 };
 
 User.deleteInvitation = function(socket, data, callback) {
-	user.deleteInvitation(data.email, callback);
+	user.deleteInvitation(data.invitedBy, data.email, callback);
 };
 
 User.acceptRegistration = function(socket, data, callback) {

--- a/src/user.js
+++ b/src/user.js
@@ -39,7 +39,6 @@ var	async = require('async'),
 			if (err || userData.status === 'offline' || now - parseInt(userData.lastonline, 10) < 300000) {
 				return callback(err);
 			}
-
 			User.setUserField(uid, 'lastonline', now, callback);
 		});
 	};
@@ -257,4 +256,3 @@ var	async = require('async'),
 
 
 }(exports));
-

--- a/src/user/invite.js
+++ b/src/user/invite.js
@@ -122,6 +122,7 @@ module.exports = function(User) {
 
 	User.deleteInvitation = function(email, callback) {
 		callback = callback || function() {};
+		console.log('invitation:email:' + email);
 		db.delete('invitation:email:' + email, callback);
 	};
 

--- a/src/views/admin/manage/registration.tpl
+++ b/src/views/admin/manage/registration.tpl
@@ -76,7 +76,7 @@
 		<!-- BEGIN invites.invitations -->
 		<tr data-invitation-mail="{invites.invitations.email}"
 				data-invited-by="{invites.username}">
-			<td><!-- IF @first -->{invites.username}<!-- ENDIF @first --></td>
+			<td class ="invited-by"><!-- IF @first -->{invites.username}<!-- ENDIF @first --></td>
 			<td>{invites.invitations.email}</td>
 			<td>{invites.invitations.username}
 				<div class="btn-group pull-right">

--- a/src/views/admin/manage/registration.tpl
+++ b/src/views/admin/manage/registration.tpl
@@ -74,8 +74,8 @@
 		</tr>
 		<!-- BEGIN invites -->
 		<!-- BEGIN invites.invitations -->
-		<tr data-invitation-mail="{invites.invitations.email}">
-			<!-- TODO: Upon deletion, this will result in an incorrect visual state until page is reloaded -->
+		<tr data-invitation-mail="{invites.invitations.email}"
+				data-invited-by="{invites.username}">
 			<td><!-- IF @first -->{invites.username}<!-- ENDIF @first --></td>
 			<td>{invites.invitations.email}</td>
 			<td>{invites.invitations.username}

--- a/src/views/admin/manage/registration.tpl
+++ b/src/views/admin/manage/registration.tpl
@@ -66,18 +66,23 @@
 		<br><br>
 		The username will be displayed to the right of the emails for users who have redeemed their invitations.
 	</p>
-	<table class="table table-striped users-list">
+	<table class="table table-striped invites-list">
 		<tr>
 			<th>Inviter Username</th>
 			<th>Invitee Email</th>
 			<th>Invitee Username (if registered)</th>
 		</tr>
 		<!-- BEGIN invites -->
-		<tr>
-			<!-- BEGIN invites.invitations -->
+		<!-- BEGIN invites.invitations -->
+		<tr data-invitation-mail="{invites.invitations.email}">
+			<!-- TODO: Upon deletion, this will result in an incorrect visual state until page is reloaded -->
 			<td><!-- IF @first -->{invites.username}<!-- ENDIF @first --></td>
 			<td>{invites.invitations.email}</td>
-			<td>{invites.invitations.username}</td>
+			<td>{invites.invitations.username}
+				<div class="btn-group pull-right">
+					<button class="btn btn-danger btn-xs" data-action="delete"><i class="fa fa-times"></i></button>
+				</div>
+			</td>
 		</tr>
 		<!-- END invites.invitations -->
 		<!-- END invites -->


### PR DESCRIPTION
Whenever a user invited someone else, the invite would forever remain on APM > Manage > Registration Queue.

Now there is a handy button to the right that will remove the item from the list and the invitation key if it still exists in the database (around 24 hours after sending).
#4254 
![screenshot - 060316 - 14 35 24](https://cloud.githubusercontent.com/assets/245013/13556863/66613c14-e3a9-11e5-8a32-62f49e03cb17.png)
