### PR TITLE
When redirecting to fix slug, preserve any provided post_index

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -55,7 +55,11 @@ topicsController.get = function(req, res, callback) {
 			}
 
 			if ((!req.params.slug || results.topic.slug !== tid + '/' + req.params.slug) && (results.topic.slug && results.topic.slug !== tid + '/')) {
-				return helpers.redirect(res, '/topic/' + encodeURI(results.topic.slug));
+				var url = '/topic/' + encodeURI(results.topic.slug);
+				if (req.params.post_index){
+					url += '/'+req.params.post_index;
+				}
+				return helpers.redirect(res, url);
 			}
 
 			var settings = results.settings;


### PR DESCRIPTION
Fixes #4350 

Simple fix to redirect a request with a bad topic slug in a way that preserves any post_index that is associated with the original request