### PR TITLE
show the crossed-out eye icon for private email addresses

### DIFF
--- a/src/controllers/accounts/helpers.js
+++ b/src/controllers/accounts/helpers.js
@@ -64,11 +64,13 @@ helpers.getUserDataByUserSlug = function(userslug, callerUID, callback) {
 			userData.lastonlineISO = utils.toISOString(userData.lastonline || userData.joindate);
 			userData.age = Math.max(0, userData.birthday ? Math.floor((new Date().getTime() - new Date(userData.birthday).getTime()) / 31536000000) : 0);
 
+			userData.emailClass = 'hide';
+
 			if (!(isAdmin || isGlobalModerator || self || (userData.email && userSettings.showemail))) {
 				userData.email = '';
+			} else if (!userSettings.showemail) {
+				userData.emailClass = '';
 			}
-
-			userData.emailClass = (self && !userSettings.showemail) ? '' : 'hide';
 
 			if (!isAdmin && !isGlobalModerator && !self && !userSettings.showfullname) {
 				userData.fullname = '';


### PR DESCRIPTION
It currently only displays if the viewing user is the same as the owner of the profile. This patch makes it also display when a staff member is viewing their profile.