### PR TITLE
workaround for a crash caused by topicTitle being undefined

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -450,7 +450,7 @@ var async = require('async'),
 						});
 						var numUsers = usernames.length;
 
-						var title = S(notifications[modifyIndex].topicTitle).decodeHTMLEntities().s;
+						var title = S(String(notifications[modifyIndex].topicTitle)).decodeHTMLEntities().s;
 						var titleEscaped = title.replace(/%/g, '&#37;').replace(/,/g, '&#44;');
 
 						if (numUsers === 2) {


### PR DESCRIPTION
I'm unsure of the best way to do this, but this does fix the crash. Not sure where the undefined value is coming from, though.