### PR TITLE
Allow for a little scrolling before dismissing bookmark alert

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -221,7 +221,9 @@ define('forum/topic', [
 		} else {
 			span.html('').hide();
 		}
-		app.removeAlert('bookmark');
+		if ($(window).scrollTop() > 300) {
+			app.removeAlert('bookmark');
+		}
 	}
 
 	Topic.calculateIndex = function(index, elementCount) {


### PR DESCRIPTION
This is just in case someone scrolls a little accidentally; the alert remains so they can still follow it if they want to