### PR TITLE
fix for removing topic thumb on edit

### DIFF
--- a/src/posts/edit.js
+++ b/src/posts/edit.js
@@ -121,9 +121,7 @@ module.exports = function(Posts) {
 				topicData.slug = tid + '/' + (utils.slugify(title) || 'topic');
 			}
 
-			if (data.topic_thumb) {
-				topicData.thumb = data.topic_thumb;
-			}
+			topicData.thumb = data.topic_thumb || '';
 
 			data.tags = data.tags || [];
 


### PR DESCRIPTION
fix for issue where editing the main post and deleting the topic thumb is not removing it from the topic.