### PR TITLE
Check file size in upload modal locally (if possible)

### DIFF
--- a/public/language/de/uploads.json
+++ b/public/language/de/uploads.json
@@ -1,0 +1,6 @@
+{
+	"uploading-file" : "Lade Datei hoch...",
+	"select-file-to-upload": "Wähle eine Datei zum Hochladen aus!",
+	"upload-success": "Datei erfolgreich hochgeladen!",
+	"maximum-file-size": "Maximal %1 kb"
+}

--- a/public/src/modules/uploader.js
+++ b/public/src/modules/uploader.js
@@ -16,9 +16,10 @@ define('uploader', ['csrf', 'translator'], function(csrf, translator) {
 	};
 
 	module.show = function(data, callback) {
+		var fileSize = data.hasOwnProperty('fileSize') && data.fileSize !== undefined ? parseInt(data.fileSize, 10) : false;
 		parseModal({
 			showHelp: data.hasOwnProperty('showHelp') && data.showHelp !== undefined ? data.showHelp : true,
-			fileSize: data.hasOwnProperty('fileSize') && data.fileSize !== undefined ? parseInt(data.fileSize, 10) : false,
+			fileSize: fileSize,
 			title: data.title || '[[global:upload_file]]',
 			description: data.description || '',
 			button: data.button || '[[global:upload]]',
@@ -40,13 +41,17 @@ define('uploader', ['csrf', 'translator'], function(csrf, translator) {
 			});
 
 			uploadForm.submit(function() {
-				onSubmit(uploadModal, callback);
+				onSubmit(uploadModal, fileSize, callback);
 				return false;
 			});
 		});
 	};
 
-	function onSubmit(uploadModal, callback) {
+	module.hideAlerts = function(modal) {
+		$(modal).find('#alert-status, #alert-success, #alert-error, #upload-progress-box').addClass('hide');
+	};
+
+	function onSubmit(uploadModal, fileSize, callback) {
 		function showAlert(type, message) {
 			module.hideAlerts(uploadModal);
 			uploadModal.find('#alert-' + type).translateText(message).removeClass('hide');
@@ -57,8 +62,12 @@ define('uploader', ['csrf', 'translator'], function(csrf, translator) {
 		uploadModal.find('#upload-progress-bar').css('width', '0%');
 		uploadModal.find('#upload-progress-box').show().removeClass('hide');
 
-		if (!uploadModal.find('#fileInput').val()) {
+		var fileInput = uploadModal.find('#fileInput');
+		if (!fileInput.val()) {
 			return showAlert('error', '[[uploads:select-file-to-upload]]');
+		}
+		if (hasValidFileSize(fileInput[0], fileSize) === false) {
+			return showAlert('error', '[[error:file-too-big, ' + fileSize + ']]');
 		}
 
 		uploadModal.find('#uploadForm').ajaxSubmit({
@@ -107,9 +116,11 @@ define('uploader', ['csrf', 'translator'], function(csrf, translator) {
 		return response;
 	}
 
-	module.hideAlerts = function(modal) {
-		$(modal).find('#alert-status, #alert-success, #alert-error, #upload-progress-box').addClass('hide');
-	};
+	function hasValidFileSize(fileElement, maxSize) {
+		if (window.FileReader && maxSize) {
+			return fileElement.files[0].size <= maxSize * 1000;
+		}
+	}
 
 	return module;
 });


### PR DESCRIPTION
Hi there! :)

Motivation:
Traffic is expensive. In fact, it's the most expensive resource we have to deal with. :)

Changes:
- Introduced `fileSize` and `fileInput` (values are used twice after change)
- Added `hasValidFileSize`, utilizing [FileReaderAPI](https://developer.mozilla.org/en-US/docs/Web/API/FileReader)
 - Explicit `false` check (line 69) is on purpose, since function returns `undefined` if FileReader isn't supported or file size just isn't limited.

- Added German translation for uploads.json. Transifex shows 0 strings in need of translation, yet uploads:* is in use.