### PR TITLE
Add /unread/new, which is the same as /unread but does not show topics that were already partially read by the user.

### DIFF
--- a/public/src/client/footer.js
+++ b/public/src/client/footer.js
@@ -13,6 +13,12 @@ define('forum/footer', ['notifications', 'chat', 'components', 'translator'], fu
 			.attr('data-content', count > 99 ? '99+' : count);
 	}
 
+	function updateUnreadNewTopicCount(count) {
+		$('#unread-new-count i')
+			.toggleClass('unread-count', count > 0)
+			.attr('data-content', count > 99 ? '99+' : count);
+	}
+
 	function updateUnreadChatCount(count) {
 		components.get('chat/icon')
 			.toggleClass('unread-count', count > 0)
@@ -61,6 +67,7 @@ define('forum/footer', ['notifications', 'chat', 'components', 'translator'], fu
 			}
 
 			updateUnreadTopicCount(data.unreadTopicCount);
+			updateUnreadNewTopicCount(data.unreadNewTopicCount);
 			updateUnreadChatCount(data.unreadChatCount);
 			Notifications.updateNotifCount(data.unreadNotificationCount);
 		});

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -16,6 +16,7 @@ unreadController.get = function(req, res, next) {
 	var stop = (parseInt(meta.config.topicsPerList, 10) || 20) - 1;
 	var results;
 	var cid = req.query.cid;
+	var seen = !req.query.unseen;
 
 	async.waterfall([
 		function(next) {
@@ -24,7 +25,7 @@ unreadController.get = function(req, res, next) {
 					user.getWatchedCategories(req.uid, next);
 				},
 				unreadTopics: function(next) {
-					topics.getUnreadTopics(cid, req.uid, 0, stop, next);
+					topics.getUnreadTopics(cid, req.uid, 0, stop, seen, next);
 				}
 			}, next);
 		},
@@ -64,7 +65,7 @@ unreadController.get = function(req, res, next) {
 
 
 unreadController.unreadTotal = function(req, res, next) {
-	topics.getTotalUnread(req.uid, function (err, data) {
+	topics.getTotalUnread(req.uid, !req.query.unseen, function (err, data) {
 		if (err) {
 			return next(err);
 		}

--- a/src/controllers/unread.js
+++ b/src/controllers/unread.js
@@ -12,11 +12,17 @@ var plugins = require('../plugins');
 
 var unreadController = {};
 
+var validFilter = {'': true, 'new': true};
+
 unreadController.get = function(req, res, next) {
 	var stop = (parseInt(meta.config.topicsPerList, 10) || 20) - 1;
 	var results;
 	var cid = req.query.cid;
-	var seen = !req.query.unseen;
+	var filter = req.params.filter || '';
+
+	if (!validFilter[filter]) {
+		return next();
+	}
 
 	async.waterfall([
 		function(next) {
@@ -25,7 +31,7 @@ unreadController.get = function(req, res, next) {
 					user.getWatchedCategories(req.uid, next);
 				},
 				unreadTopics: function(next) {
-					topics.getUnreadTopics(cid, req.uid, 0, stop, seen, next);
+					topics.getUnreadTopics(cid, req.uid, 0, stop, filter, next);
 				}
 			}, next);
 		},
@@ -65,7 +71,13 @@ unreadController.get = function(req, res, next) {
 
 
 unreadController.unreadTotal = function(req, res, next) {
-	topics.getTotalUnread(req.uid, !req.query.unseen, function (err, data) {
+	var filter = req.params.filter || '';
+
+	if (!validFilter[filter]) {
+		return next();
+	}
+
+	topics.getTotalUnread(req.uid, filter, function (err, data) {
 		if (err) {
 			return next(err);
 		}

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -22,7 +22,7 @@ module.exports =  function(app, middleware, controllers) {
 
 	router.get('/categories/:cid/moderators', controllers.api.getModerators);
 	router.get('/recent/posts/:term?', controllers.api.getRecentPosts);
-	router.get('/unread/total', middleware.authenticate, controllers.unread.unreadTotal);
+	router.get('/unread/:filter?/total', middleware.authenticate, controllers.unread.unreadTotal);
 	router.get('/topic/teaser/:topic_id', controllers.topics.teaser);
 
 	var multipart = require('connect-multiparty');

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -55,7 +55,7 @@ function categoryRoutes(app, middleware, controllers) {
 	setupPageRoute(app, '/categories', middleware, [], controllers.categories.list);
 	setupPageRoute(app, '/popular/:term?', middleware, [], controllers.popular.get);
 	setupPageRoute(app, '/recent', middleware, [], controllers.recent.get);
-	setupPageRoute(app, '/unread', middleware, [middleware.authenticate], controllers.unread.get);
+	setupPageRoute(app, '/unread/:filter?', middleware, [middleware.authenticate], controllers.unread.get);
 
 	setupPageRoute(app, '/category/:category_id/:slug/:topic_index', middleware, [], controllers.category.get);
 	setupPageRoute(app, '/category/:category_id/:slug?', middleware, [], controllers.category.get);

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -245,6 +245,7 @@ SocketUser.getUnreadCounts = function(socket, data, callback) {
 	}
 	async.parallel({
 		unreadTopicCount: async.apply(topics.getTotalUnread, socket.uid),
+		unreadNewTopicCount: async.apply(topics.getTotalUnread, socket.uid, 'new'),
 		unreadChatCount: async.apply(messaging.getUnreadCount, socket.uid),
 		unreadNotificationCount: async.apply(user.notifications.getUnreadCount, socket.uid)
 	}, callback);

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -14,21 +14,21 @@ var utils = require('../../public/src/utils');
 
 module.exports = function(Topics) {
 
-	Topics.getTotalUnread = function(uid, allowSeen, callback) {
+	Topics.getTotalUnread = function(uid, filter, callback) {
 		if (!callback) {
-			callback = allowSeen;
-			allowSeen = true;
+			callback = filter;
+			filter = '';
 		}
 
-		Topics.getUnreadTids(0, uid, 0, 99, allowSeen, function(err, tids) {
+		Topics.getUnreadTids(0, uid, 0, 99, filter, function(err, tids) {
 			callback(err, tids ? tids.length : 0);
 		});
 	};
 
-	Topics.getUnreadTopics = function(cid, uid, start, stop, allowSeen, callback) {
+	Topics.getUnreadTopics = function(cid, uid, start, stop, filter, callback) {
 		if (!callback) {
-			callback = allowSeen;
-			allowSeen = true;
+			callback = filter;
+			filter = '';
 		}
 
 
@@ -40,7 +40,7 @@ module.exports = function(Topics) {
 
 		async.waterfall([
 			function(next) {
-				Topics.getUnreadTids(cid, uid, start, stop, allowSeen, next);
+				Topics.getUnreadTids(cid, uid, start, stop, filter, next);
 			},
 			function(tids, next) {
 				if (!tids.length) {
@@ -64,10 +64,10 @@ module.exports = function(Topics) {
 		return Date.now() - (parseInt(meta.config.unreadCutoff, 10) || 2) * 86400000;
 	};
 
-	Topics.getUnreadTids = function(cid, uid, start, stop, allowSeen, callback) {
+	Topics.getUnreadTids = function(cid, uid, start, stop, filter, callback) {
 		if (!callback) {
-			callback = allowSeen;
-			allowSeen = true;
+			callback = filter;
+			filter = '';
 		}
 
 		uid = parseInt(uid, 10);
@@ -110,7 +110,12 @@ module.exports = function(Topics) {
 			});
 
 			var tids = results.recentTids.filter(function(recentTopic) {
-				return !userRead[recentTopic.value] || allowSeen && recentTopic.score > userRead[recentTopic.value];
+				switch (filter) {
+					default:
+						return !userRead[recentTopic.value] || recentTopic.score > userRead[recentTopic.value];
+					case 'new':
+						return !userRead[recentTopic.value];
+				}
 			}).map(function(topic) {
 				return topic.value;
 			}).filter(function(tid, index, array) {


### PR DESCRIPTION
The filter argument is optional, so this will only break compatibility if a plugin is replacing core functionality directly (`module.func = function() { ... }`)

See: #4474 (GitHub isn't allowing me to re-open the old one because I force-pushed to the branch)