### PR TITLE
Customize bookmark threshold

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -143,7 +143,7 @@ define('forum/topic', [
 			if (components.get('post/anchor', postIndex).length) {
 				return navigator.scrollToPostIndex(postIndex, true);
 			}
-		} else if (bookmark && (!config.usePagination || (config.usePagination && ajaxify.data.pagination.currentPage === 1)) && ajaxify.data.postcount > 5) {
+		} else if (bookmark && (!config.usePagination || (config.usePagination && ajaxify.data.pagination.currentPage === 1)) && ajaxify.data.postcount > ajaxify.data.config.bookmarkThreshold) {
 			navigator.update(0);
 			app.alert({
 				alert_id: 'bookmark',
@@ -280,7 +280,8 @@ define('forum/topic', [
 		var bookmarkKey = 'topic:' + ajaxify.data.tid + ':bookmark';
 		var currentBookmark = ajaxify.data.bookmark || localStorage.getItem(bookmarkKey);
 
-		if (ajaxify.data.postcount > 5 && (!currentBookmark || parseInt(index, 10) > parseInt(currentBookmark, 10))) {
+		if (ajaxify.data.postcount > ajaxify.data.config.bookmarkThreshold && (!currentBookmark || parseInt(index, 10) > parseInt(currentBookmark, 10))) {
+			console.log('setting bookmark: ' + index );
 			if (app.user.uid) {
 				socket.emit('topics.bookmark', {
 					'tid': ajaxify.data.tid,

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -281,7 +281,6 @@ define('forum/topic', [
 		var currentBookmark = ajaxify.data.bookmark || localStorage.getItem(bookmarkKey);
 
 		if (ajaxify.data.postcount > ajaxify.data.config.bookmarkThreshold && (!currentBookmark || parseInt(index, 10) > parseInt(currentBookmark, 10))) {
-			console.log('setting bookmark: ' + index );
 			if (app.user.uid) {
 				socket.emit('topics.bookmark', {
 					'tid': ajaxify.data.tid,

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -60,6 +60,7 @@ apiController.getConfig = function(req, res, next) {
 	config.csrf_token = req.csrfToken();
 	config.searchEnabled = plugins.hasListeners('filter:search.query');
 	config.bootswatchSkin = 'default';
+	config.bookmarkThreshold = parseInt(meta.config.bookmarkThreshold, 10) || 5;
 
 	async.waterfall([
 		function (next) {

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -100,6 +100,10 @@
 				<label for="unreadCutoff">Unread cutoff days</label>
 				<input id="unreadCutoff" type="text" class="form-control" value="2" data-field="unreadCutoff">
 			</div>
+			<div class="form-group">
+				<label for="bookmarkthreshold">Minimum posts in topic before tracking last read</label>
+				<input id="bookmarkthreshold" type="text" class="form-control" value="5" data-field="bookmarkThreshold">
+			</div>
 		</form>
 	</div>
 </div>


### PR DESCRIPTION
Adds a site specified threshold for user last read bookmarks. Defaults to 5, the current hard coded value, previously set in response to issue #3759.

Not remembering that the user read something can be confusing, especially if any of the first few posts are long.