### PR TITLE
don't delay image loading when "delay image loading" is unchecked

### DIFF
--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -239,11 +239,13 @@ define('forum/topic/posts', [
 	Posts.unloadImages = function(posts) {
 		var images = posts.find('[component="post/content"] img:not(.not-responsive)');
 
-		images.each(function() {
-			$(this).attr('data-src', $(this).attr('src'));
-			$(this).attr('data-state', 'unloaded');
-			$(this).attr('src', 'about:blank');
-		});
+		if (config.delayImageLoading) {
+			images.each(function() {
+				$(this).attr('data-src', $(this).attr('src'));
+			}).attr('data-state', 'unloaded').attr('src', 'about:blank');
+		} else {
+			images.attr('data-state', 'loaded');
+		}
 	};
 
 	Posts.loadImages = function(threshold) {
@@ -263,7 +265,7 @@ define('forum/topic/posts', [
 
 			var images = components.get('post/content').find('img[data-state="unloaded"]'),
 				visible = images.filter(function() {
-					return config.delayImageLoading ? utils.isElementInViewport(this) : true;
+					return utils.isElementInViewport(this);
 				}),
 				scrollTop = $(window).scrollTop(),
 				adjusting = false,


### PR DESCRIPTION
Demonstration: https://www.youtube.com/watch?v=-CwsB_xIO34

The local one (first) is using this patch, and the live one (second) is not. Both have the delay image loading option unchecked.

/cc @halcyon1234