### PR TITLE
remove HTTP(S) schema for external bootstrap CSS file.

### DIFF
--- a/public/src/client/account/settings.js
+++ b/public/src/client/account/settings.js
@@ -64,7 +64,7 @@ define('forum/account/settings', ['forum/account/header', 'components', 'csrf'],
 
 		$('#bootswatchSkin').on('change', function() {
 			var css = $('#bootswatchCSS'),
-				val = $(this).val() === 'default' ? config['theme:src'] : 'http://maxcdn.bootstrapcdn.com/bootswatch/latest/' + $(this).val() + '/bootstrap.min.css';
+				val = $(this).val() === 'default' ? config['theme:src'] : '//maxcdn.bootstrapcdn.com/bootswatch/latest/' + $(this).val() + '/bootstrap.min.css';
 
 			css.attr('href', val);
 		});


### PR DESCRIPTION
remove HTTP(S) schema from external bootstrap CSS file to avoid mixed content error.