### PR TITLE
fix convert-avatars-to-png option not being honored

### DIFF
--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -57,11 +57,13 @@ module.exports = function(User) {
 						}, next);
 					},
 					function(next) {
-						if (convertToPNG) {
-							image.normalise(picture.path, extension, next);
-						} else {
-							next();
+						if (!convertToPNG) {
+							return next();
 						}
+						async.series([
+							async.apply(image.normalise, picture.path, extension),
+							async.apply(fs.rename, picture.path + '.png', picture.path)
+						], next);
 					},
 					function(next) {
 						User.getUserField(updateUid, 'uploadedpicture', next);


### PR DESCRIPTION
It was converting to PNG and then leaving the new file unused.