### PR TITLE
add missing ACP defaults for new install

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -34,5 +34,5 @@
     "teaserPost": "last",
     "allowPrivateGroups": 1,
     "unreadCutoff": 2,
-    "bookmarkthreshold": 5
+    "bookmarkThreshold": 5
 }

--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -9,6 +9,8 @@
     "maximumPostLength": 32767,
     "minimumTagsPerTopic": 0,
     "maximumTagsPerTopic": 5,
+    "minimumTagLength": 3,
+    "maximumTagLength": 15,
     "allowGuestSearching": 0,
     "allowTopicsThumbnail": 0,
     "registrationType": "normal",
@@ -30,5 +32,7 @@
     "requireEmailConfirmation": 0,
     "allowProfileImageUploads": 1,
     "teaserPost": "last",
-    "allowPrivateGroups": 1
+    "allowPrivateGroups": 1,
+    "unreadCutoff": 2,
+    "bookmarkthreshold": 5
 }


### PR DESCRIPTION
these settings appear to be set for new installs when you check the ACP page but are not available in `Meta.config` unless you click "Save" button on the ACP settings page.