### PR TITLE
ACP: plugins list

### DIFF
--- a/public/less/admin/extend/plugins.less
+++ b/public/less/admin/extend/plugins.less
@@ -31,4 +31,11 @@
 			color: #4CAF50;
 		}
 	}
+
+	.controls .btn {
+		display: list-item;
+		width: 120px;
+		margin-bottom: 3px;
+		margin-left: 10px;
+	}
 }

--- a/public/less/admin/extend/plugins.less
+++ b/public/less/admin/extend/plugins.less
@@ -24,4 +24,11 @@
 			.pointer;
 		}
 	}
+
+	#noupgradable {
+		text-align: center;
+		.fa-check {
+			color: #4CAF50;
+		}
+	}
 }

--- a/public/src/admin/extend/plugins.js
+++ b/public/src/admin/extend/plugins.js
@@ -233,6 +233,9 @@ define('admin/extend/plugins', function() {
 				$('#upgrade ul').append($(this).clone(true));
 			}
 		});
+		if ($('#upgrade ul').children().length === 0) {
+			$('#noupgradable').removeClass('hidden');
+		}
 	}
 
 	return Plugins;

--- a/src/controllers/admin/plugins.js
+++ b/src/controllers/admin/plugins.js
@@ -26,8 +26,8 @@ pluginsController.get = function(req, res, next) {
 				next(null, plugins);
 			});
 		},
-		custom_header: function(next) {
-			plugins.fireHook('filter:admin.header.build', {plugins: []}, next);
+		menuEntries: function(next) {
+			plugins.buildSettingsMenuEntries({plugins: [], authentication: []}, next);
 		}
 	}, function(err, payload) {
 		if (err) {

--- a/src/controllers/admin/plugins.js
+++ b/src/controllers/admin/plugins.js
@@ -43,7 +43,8 @@ pluginsController.get = function(req, res, next) {
 				var routeMatchRX = /nodebb-(?:plugin|rewards|theme|widget)-(.*)/;
 				var routeToMatch = '/plugins/' + plugin.id.match(routeMatchRX)[1];
 
-				if (_.findWhere(payload.custom_header.plugins, {route: routeToMatch})) {
+				if (_.findWhere(payload.menuEntries.plugins, {route: routeToMatch}) ||
+						_.findWhere(payload.menuEntries.authentication, {route: routeToMatch})) {
 					plugin.settingsRoute = routeToMatch.substr(1);
 				}
 

--- a/src/views/admin/extend/plugins.tpl
+++ b/src/views/admin/extend/plugins.tpl
@@ -24,6 +24,10 @@
 			</div>
 			<div class="tab-pane fade" id="upgrade">
 				<ul class="upgrade"></ul>
+				<div class="hidden" id="noupgradable">
+					<i class="fa fa-5x fa-check"></i>
+					<p><h4>All plugins up to date!</h4></p>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/src/views/admin/partials/installed_plugin_item.tpl
+++ b/src/views/admin/partials/installed_plugin_item.tpl
@@ -1,13 +1,16 @@
 					<!-- IF !installed.error -->
 					<li id="{installed.id}" data-plugin-id="{installed.id}" data-version="{installed.version}" class="clearfix">
-						<div class="pull-right">
+						<div class="pull-right controls">
 							<!-- IF installed.isTheme -->
 							<a href="{config.relative_path}/admin/appearance/themes" class="btn btn-info">Themes</a>
 							<!-- ELSE -->
-							<button data-action="toggleActive" class="btn <!-- IF installed.active --> btn-warning<!-- ELSE --> btn-success<!-- ENDIF installed.active -->"><i class="fa fa-power-off"></i> <!-- IF installed.active -->Deactivate<!-- ELSE -->Activate<!-- ENDIF installed.active --></button>
+							<button data-action="toggleActive" class="btn<!-- IF installed.active --> btn-warning<!-- ELSE --> btn-success<!-- ENDIF installed.active -->"><i class="fa fa-power-off"></i> <!-- IF installed.active -->Deactivate<!-- ELSE -->Activate<!-- ENDIF installed.active --></button>
 							<!-- ENDIF installed.isTheme -->
 
 							<button data-action="toggleInstall" data-installed="1" class="btn btn-danger"><i class="fa fa-trash-o"></i> Uninstall</button>
+							<!-- IF installed.settingsRoute -->
+							<a href="{config.relative_path}/admin/{installed.settingsRoute}" class="btn btn-primary"><i class="fa fa-wrench"></i> Settings</a>
+							<!-- ENDIF installed.settingsRoute -->
 						</div>
 
 						<h2><strong>{installed.name}</strong></h2>
@@ -20,7 +23,7 @@
 							<button data-action="upgrade" class="btn btn-success btn-xs"><i class="fa fa-download"></i> Upgrade</button>
 						<!-- ENDIF installed.outdated -->
 						<!-- IF installed.url -->
-						<p>For more information: <a target="_blank" href="{installed.url}">{installed.url}</a></p>
+						<p>For more information: <br/><a target="_blank" href="{installed.url}">{installed.url}</a></p>
 						<!-- ENDIF installed.url -->
 					</li>
 					<!-- ENDIF !installed.error -->


### PR DESCRIPTION
What he said: #4563 

I'm not entirely satisfied, though. Using `filter:admin.header.build` violates POLA quite a bit. I wouldn't really expect _header_.build in the plugin controller. Introducing a new hook doesn't feel right, either.

`plugin.json`:

```
"settingsPage": {
    "name": "Plugin Title",
    "renderMethod": "admin.renderSettings",
    "middlewares": [
      "admin.logMW"
    ]
  }
```

`plugins/load.js`

```
...     },
    function(next) {
        loadLanguages(pluginData, next);
    },
    function(next) {
        registerSettingsPage(pluginData, pluginPath, next);
    }
], function(err) {
    if (err) {
        winston.verbose('[plugins] Could not ...
```

:wink: But that's for another PR...

Update:
What do you know; found one: #4569 :smirk: 
