### PR TITLE
Read data for ACP menu entry from plugin.json

### DIFF
--- a/src/middleware/admin.js
+++ b/src/middleware/admin.js
@@ -80,7 +80,7 @@ middleware.renderHeader = function(req, res, data, next) {
 				});
 			},
 			custom_header: function(next) {
-				plugins.fireHook('filter:admin.header.build', custom_header, next);
+				plugins.buildSettingsMenuEntries(custom_header, next);
 			},
 			config: function(next) {
 				controllers.api.getConfig(req, res, next);

--- a/src/plugins.js
+++ b/src/plugins.js
@@ -7,6 +7,7 @@ var winston = require('winston');
 var semver = require('semver');
 var express = require('express');
 var nconf = require('nconf');
+var _ = require('underscore');
 
 var db = require('./database');
 var emitter = require('./emitter');
@@ -35,6 +36,7 @@ var middleware;
 	Plugins.customLanguageFallbacks = {};
 	Plugins.libraryPaths = [];
 	Plugins.versionWarning = [];
+	Plugins.settingsPages = {};
 
 	Plugins.initialized = false;
 
@@ -84,6 +86,7 @@ var middleware;
 		Plugins.clientScripts.length = 0;
 		Plugins.acpScripts.length = 0;
 		Plugins.libraryPaths.length = 0;
+		Plugins.settingsPages = {};
 
 		Plugins.registerHook('core', {
 			hook: 'static:app.load',
@@ -140,6 +143,17 @@ var middleware;
 			app.render.apply(app, arguments);
 		};
 
+		Object.keys(Plugins.settingsPages).forEach(function(pluginId) {
+			router.get('/admin' + Plugins.settingsPages[pluginId].route,
+									middleware.admin.buildHeader, middleware.isAdmin, middleware.applyCSRF,
+									Plugins.settingsPages[pluginId].middlewares,
+									Plugins.settingsPages[pluginId].renderMethod);
+			router.get('/api/admin' + Plugins.settingsPages[pluginId].route,
+									middleware.isAdmin, middleware.applyCSRF,
+									Plugins.settingsPages[pluginId].middlewares,
+									Plugins.settingsPages[pluginId].renderMethod);
+		});
+
 		Plugins.fireHook('static:app.load', {app: app, router: router, middleware: middleware, controllers: controllers}, function(err) {
 			if (err) {
 				return winston.error('[plugins] Encountered error while executing post-router plugins hooks: ' + err.message);
@@ -149,6 +163,36 @@ var middleware;
 			winston.verbose('[plugins] All plugins reloaded and rerouted');
 			callback();
 		});
+	};
+
+	Plugins.buildSettingsMenuEntries = function(custom_header, callback) {
+		async.waterfall([
+			async.apply(Plugins.fireHook, 'filter:admin.header.build', custom_header),
+			function(custom_header, next) {
+				Object.keys(Plugins.settingsPages).forEach(function(pluginId) {
+					var settingsPage = Plugins.settingsPages[pluginId];
+					custom_header[settingsPage.isAuthentication ? 'authentication' : 'plugins'].push({
+						name: settingsPage.name,
+						route: settingsPage.route
+					});
+				});
+				next(null, custom_header);
+			}
+		], callback);
+	};
+
+	Plugins.getMethodRef = function(id, method) {
+		if (typeof method === 'string' && method.length > 0) {
+			method = method.split('.').reduce(function(memo, prop) {
+				if (memo && memo[prop]) {
+					return memo[prop];
+				} else {
+					// Couldn't find method by path, aborting
+					return null;
+				}
+			}, Plugins.libraries[id]);
+		}
+		return method;
 	};
 
 	Plugins.getTemplates = function(callback) {

--- a/src/plugins/hooks.js
+++ b/src/plugins/hooks.js
@@ -26,8 +26,6 @@ module.exports = function(Plugins) {
 			}
 		}
 
-		var method;
-
 		if (Object.keys(Plugins.deprecatedHooks).indexOf(data.hook) !== -1) {
 			winston.warn('[plugins/' + id + '] Hook `' + data.hook + '` is deprecated, ' + 
 				(Plugins.deprecatedHooks[data.hook] ?
@@ -43,21 +41,8 @@ module.exports = function(Plugins) {
 				data.priority = 10;
 			}
 
-			if (typeof data.method === 'string' && data.method.length > 0) {
-				method = data.method.split('.').reduce(function(memo, prop) {
-					if (memo && memo[prop]) {
-						return memo[prop];
-					} else {
-						// Couldn't find method by path, aborting
-						return null;
-					}
-				}, Plugins.libraries[data.id]);
-
-				// Write the actual method reference to the hookObj
-				data.method = method;
-
-				register();
-			} else if (typeof data.method === 'function') {
+			data.method = Plugins.getMethodRef(id, data.method) || data.method;
+			if (typeof data.method === 'function') {
 				register();
 			} else {
 				winston.warn('[plugins/' + id + '] Hook method mismatch: ' + data.hook + ' => ' + data.method);

--- a/src/plugins/load.js
+++ b/src/plugins/load.js
@@ -256,9 +256,10 @@ module.exports = function(Plugins) {
 				}
 
 				var renderMethod;
+				var shortId = pluginData.id.match(settingsRouteRX)[1];
 				Plugins.settingsPages[pluginData.id] = {};
-				Plugins.settingsPages[pluginData.id].name = settingsPage.name;
-				Plugins.settingsPages[pluginData.id].route = '/plugins/' + pluginData.id.match(settingsRouteRX)[1];
+				Plugins.settingsPages[pluginData.id].name = settingsPage.name || shortId;
+				Plugins.settingsPages[pluginData.id].route = '/plugins/' + shortId;
 				renderMethod = Plugins.getMethodRef(pluginData.id, settingsPage.renderMethod) || settingsPage.renderMethod;
 				if (typeof renderMethod !== 'function') {
 					winston.error(logTag + ' Unable to find settings page\'s render method: ' + renderMethod);
@@ -271,16 +272,16 @@ module.exports = function(Plugins) {
 
 				Plugins.settingsPages[pluginData.id].middlewares = [];
 				if (Array.isArray(settingsPage.middlewares) && settingsPage.middlewares.length > 0) {
-					async.each(settingsPage.middlewares, function(middleware, next) {
+					settingsPage.middlewares.forEach(function(middleware) {
 						var middlewareRef = Plugins.getMethodRef(pluginData.id, middleware) || middleware;
 						if (typeof middlewareRef !== 'function') {
 							winston.warn(logTag + ' Unable to find middleware method: ' + middlewareRef);
 						} else {
 							Plugins.settingsPages[pluginData.id].middlewares.push(middlewareRef);
 						}
-						next();
-					}, callback);
+					});
 				}
+				callback();
 
 			} catch (err) {
 				logLibraryLoadErr(pluginData.id, err.stack);

--- a/src/plugins/load.js
+++ b/src/plugins/load.js
@@ -47,6 +47,9 @@ module.exports = function(Plugins) {
 				},
 				function(next) {
 					loadLanguages(pluginData, next);
+				},
+				function(next) {
+					registerSettingsPage(pluginData, pluginPath, next);
 				}
 			], function(err) {
 				if (err) {
@@ -84,9 +87,7 @@ module.exports = function(Plugins) {
 		var libraryPath = path.join(pluginPath, pluginData.library);
 
 		try {
-			if (!Plugins.libraries[pluginData.id]) {
-				Plugins.requireLibrary(pluginData.id, libraryPath);
-			}
+			ensureLibraryLoaded(pluginData.id, libraryPath);
 
 			if (Array.isArray(pluginData.hooks) && pluginData.hooks.length > 0) {
 				async.each(pluginData.hooks, function(hook, next) {
@@ -96,8 +97,7 @@ module.exports = function(Plugins) {
 				callback();
 			}
 		} catch(err) {
-			winston.error(err.stack);
-			winston.warn('[plugins] Unable to parse library for: ' + pluginData.id);
+			logLibraryLoadErr(pluginData.id, err.stack);
 			callback();
 		}
 	}
@@ -168,7 +168,7 @@ module.exports = function(Plugins) {
 		}
 
 		callback();
-	};
+	}
 
 	function mapClientModules(pluginData, callback) {
 		if (Array.isArray(pluginData.modules)) {
@@ -182,7 +182,7 @@ module.exports = function(Plugins) {
 		}
 
 		callback();
-	};
+	}
 
 	function loadLanguages(pluginData, callback) {
 		if (typeof pluginData.languages !== 'string') {
@@ -231,6 +231,59 @@ module.exports = function(Plugins) {
 				callback();
 			});
 		});
+	}
+
+	function registerSettingsPage(pluginData, pluginPath, callback) {
+		if (!pluginData.library) {
+			return callback();
+		}
+
+		var settingsPage = pluginData.settingsPage;
+		var libraryPath = path.join(pluginPath, pluginData.library);
+		var settingsRouteRX = /nodebb-(?:plugin|rewards|theme|widget)-(.*)/;
+
+		if (settingsPage) {
+			try {
+				ensureLibraryLoaded(pluginData.id, libraryPath);
+
+				var headerBuildHooks = Plugins.loadedHooks['filter:admin.header.build'];
+				var redundantHook = _.findWhere(headerBuildHooks, {id: pluginData.id});
+				if (redundantHook) {
+					winston.warn('[plugins/' + pluginData.id + '] Deprecation warning: No need to use filter:admin.header.build when "settingsPage" is defined in plugin.json!');
+					Plugins.loadedHooks['filter:admin.header.build'] = _.without(headerBuildHooks, redundantHook);
+				}
+
+				Plugins.settingsPages[pluginData.id] = {};
+				Plugins.settingsPages[pluginData.id].name = settingsPage.name;
+				Plugins.settingsPages[pluginData.id].route = '/plugins/' + pluginData.id.match(settingsRouteRX)[1];
+				Plugins.settingsPages[pluginData.id].renderMethod = Plugins.getMethodRef(pluginData.id, settingsPage.renderMethod);
+				Plugins.settingsPages[pluginData.id].isAuthentication = settingsPage.isAuthentication;
+
+				Plugins.settingsPages[pluginData.id].middlewares = [];
+				if (Array.isArray(settingsPage.middlewares) && settingsPage.middlewares.length > 0) {
+					async.each(settingsPage.middlewares, function(middleware, next) {
+						Plugins.settingsPages[pluginData.id].middlewares.push(Plugins.getMethodRef(pluginData.id, middleware));
+						next();
+					}, callback);
+				}
+
+			} catch (err) {
+				logLibraryLoadErr(pluginData.id, err.stack);
+			}
+		} else {
+			callback();
+		}
+	}
+
+	function ensureLibraryLoaded(id, libraryPath) {
+		if (!Plugins.libraries[id]) {
+				Plugins.requireLibrary(id, libraryPath);
+		}
+	}
+
+	function logLibraryLoadErr(id, stack) {
+		winston.error(stack);
+		winston.warn('[plugins] Unable to parse library for: ' + id);
 	}
 
 	Plugins.loadPluginInfo = function(pluginPath, callback) {


### PR DESCRIPTION
- No need to hook filter:admin.header.build ('hook')
- No need to set routes manually
- Enforces /admin/plugins/:pluginId for routes
  (:pluginId without nodebb-(plugin|theme|widget|rewards)-)
- Backwards compatible; giving warning and removing
  redundant hook when both hook and JSON are used
- DRY: ensureLibraryLoaded, logLibraryLoadErr and getMethodRef
