### PR TITLE
Default mongodb db name should be "nodebb" instead of 0 (unlike redis).

### DIFF
--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -38,7 +38,7 @@
 		{
 			name: "mongo:database",
 			description: "MongoDB database name",
-			'default': nconf.get('mongo:database') || 0
+			'default': nconf.get('mongo:database') || 'nodebb'
 		}
 	];
 
@@ -74,7 +74,7 @@
 			nconf.set('mongo:port', 27017);
 		}
 		if (!nconf.get('mongo:database')) {
-			nconf.set('mongo:database', '0');
+			nconf.set('mongo:database', 'nodebb');
 		}
 
 		var hosts = nconf.get('mongo:host').split(',');


### PR DESCRIPTION
After spending couple hours of frustration configuring nodebb with mongodb, getting error about: "Can't connect to mongodb, invalid authentication", I found out that I had been connecting to the default dbname "0" (which does not exist btw). The default dbname should be named "nodebb" according to the instructions here:
http://nodebb-francais.readthedocs.org/projects/nodebb/en/latest/configuring/databases/mongo.html