### PR TITLE
Fixed czech translation for timeago

### DIFF
--- a/public/src/modules/translator.js
+++ b/public/src/modules/translator.js
@@ -72,10 +72,6 @@
 				languageCode = 'en';
 				break;
 
-			case 'cs':
-				languageCode = 'cz';
-				break;
-
 			case 'fa_IR':
 				languageCode = 'fa';
 				break;


### PR DESCRIPTION
When czech language is set, browser throws **404 Not Found** error on **jquery.timeago.cz.js**

Thats because translation file were renamed:
-  https://github.com/rmm5t/jquery-timeago/commit/81f072ebb253eca4eea47edcb3009d326c329843
- https://github.com/NodeBB/NodeBB/blob/master/public/vendor/jquery/timeago/locales/jquery.timeago.cs.js

so cs->cz override is no needed anymore.