### PR TITLE
Adding a patch that allows NodeBB to run within NodeIIS with no modif…

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,7 @@
 
 "use strict";
 /*global require, global, process*/
+require('iisnodePlugin');
 
 var nconf = require('nconf');
 nconf.argv().env('__');

--- a/iisnodePlugin.js
+++ b/iisnodePlugin.js
@@ -1,0 +1,35 @@
+/*
+	IISNodePlugin 
+    
+    Resolves the issues when trying to run NodeBB within IIS.
+*/
+
+if (require.main.filename.indexOf('iisnode\\interceptor.js') > 0) {
+    require.main._req_ = require.main.require;
+
+    var tryGetModule = function (mod) {
+        var result = {
+            module: undefined,
+            err: undefined,
+            hasError: false
+        };
+        try {
+            result.module = require.main._req_(mod);
+        } catch (e) {
+            result.hasError = true;
+            result.err = e;
+        }
+
+        return result;
+    }
+
+    require.main.require = function (mod) {
+        var result = tryGetModule(mod).module || tryGetModule(__dirname + '\\' + mod).module || tryGetModule(__dirname + '\\node_modules\\' + mod).module || tryGetModule(mod);
+
+        if (result.hasError) {
+            throw result.err;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
When using _require.main.require_ in IISNode. the locator.js module is used instead of the applications app.js. This needs to be in the route of the project so that it can be found. 

This patch is only used when running from IIS and allows NodeBB to run on IIS and Azure instances without having to modify modules and source files.