### PR TITLE
Made the session cookie aware of the possible relative path

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -62,6 +62,10 @@ module.exports = function(app) {
 	if (nconf.get('secure')) {
 		cookie.secure = true;
 	}
+	
+	if (relativePath !== '') {
+		cookie.path = relativePath;
+	}
 
 	app.use(session({
 		store: db.sessionStore,


### PR DESCRIPTION
When you run two NodeBB forums on the same host but in different subfolders (e.g. http://example.com/tf1/ and http://example.com/tf2/) the session cookies will interfer with each other, because their path is set to '/'. This small change sets the path of the session cookies to the relative path if the relative path is set.

The cookies for the socket.io have their path already set correctly. So no change is necessary there.