### PR TITLE
CLS must be required first

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,6 +22,7 @@
 
 var nconf = require('nconf');
 nconf.argv().env('__');
+require('continuation-local-storage');
 
 var url = require('url'),
 	async = require('async'),


### PR DESCRIPTION
Maybe in loader.js -- basically it should be at the first entry of the app somewhere to avoid closure issues. see https://gist.github.com/akhoury/acb852798e319b5ede93431e5910d3ef