### PR TITLE
initial postData.votes=0, to avoid a REDIS ERR value is not a valid float

### DIFF
--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -41,7 +41,8 @@ module.exports = function(Posts) {
 					'reputation': 0,
 					'editor': '',
 					'edited': 0,
-					'deleted': 0
+					'deleted': 0,
+					'votes': 0
 				};
 
 				if (data.toPid) {


### PR DESCRIPTION

when this is called. https://github.com/NodeBB/NodeBB/blob/ff88186d410c4af5a8c069d22c3d01747868fc90/src/topics/posts.js#L281