### PR TITLE
fixed non standard chars for IE-slug

### DIFF
--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -84,6 +84,14 @@
 			} else {
 				str = XRegExp.replace(str, utils.invalidUnicodeChars, '-');
 			}
+
+			//remove accents and other non a-zA-Z - from same url as above. but some stuff added (IE-fix, otherwise no problem)
+			var from = "ÀÁÄÅÂÆÈÉËÊÍÌÎÏÓÒÖØÚÙÜÛÑÇàáäåâæèéëêìíïîòóøöôùúüûñç·/_,:;";
+			var to   = "AAAAAAEEEEIIIIOOOOUUUUNCaaaaaaeeeeiiiiooooouuuunc------";
+
+			for (var i=0, l=from.length ; i<l ; i++)
+				str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
+
 			str = !preserveCase ? str.toLocaleLowerCase() : str;
 			str = str.replace(utils.collapseWhitespace, '-');
 			str = str.replace(utils.collapseDash, '-');

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -85,14 +85,19 @@
 				str = XRegExp.replace(str, utils.invalidUnicodeChars, '-');
 			}
 
+			str = !preserveCase ? str.toLocaleLowerCase() : str;
+
 			//remove accents and other non a-zA-Z - from same url as above. but some stuff added (IE-fix, otherwise no problem)
-			var from = "ÀÁÄÅÂÆÈÉËÊÍÌÎÏÓÒÖØÚÙÜÛÑÇàáäåâæèéëêìíïîòóøöôùúüûñç·/_,:;";
-			var to   = "AAAAAAEEEEIIIIOOOOUUUUNCaaaaaaeeeeiiiiooooouuuunc------";
+			var from = 	'àáäåâæèéëêìíïîòóøöôùúüûñç·/_,:;';
+			var to = 	'aaaaaaeeeeiiiiooooouuuunc------';
+			if(preserveCase) {
+				from = from + "ÀÁÄÅÂÆÈÉËÊÍÌÎÏÓÒÖØÚÙÜÛÑÇ";
+				to = to 	+ "AAAAAAEEEEIIIIOOOOUUUUNC";
+			}
 
 			for (var i=0, l=from.length ; i<l ; i++)
 				str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i));
 
-			str = !preserveCase ? str.toLocaleLowerCase() : str;
 			str = str.replace(utils.collapseWhitespace, '-');
 			str = str.replace(utils.collapseDash, '-');
 			str = str.replace(utils.trimTrailingDash, '');


### PR DESCRIPTION
Due to problems with IE and Swedish category, topic and post-slugs I had to rewrite slugify to remove more non-ascii chars. There are maybe more of them, but this is what I came up with, some from the url you referenced in code, some of my own. Hope it works for you!