### PR TITLE
pass set as attribute for recent route

### DIFF
--- a/public/src/client/recent.js
+++ b/public/src/client/recent.js
@@ -133,7 +133,7 @@ define('forum/recent', ['forum/infinitescroll', 'components'], function(infinite
 
 		infinitescroll.loadMore('topics.loadMoreFromSet', {
 			after: $('[component="category"]').attr('data-nextstart'),
-			set: 'topics:recent'
+			set: $('[component="category"]').attr('data-dbset') ? $('[component="category"]').attr('data-dbset') : 'topics:recent' 
 		}, function(data, done) {
 			if (data.topics && data.topics.length) {
 				Recent.onTopicsLoaded('recent', data.topics, false, done);

--- a/public/src/client/recent.js
+++ b/public/src/client/recent.js
@@ -133,7 +133,7 @@ define('forum/recent', ['forum/infinitescroll', 'components'], function(infinite
 
 		infinitescroll.loadMore('topics.loadMoreFromSet', {
 			after: $('[component="category"]').attr('data-nextstart'),
-			set: $('[component="category"]').attr('data-dbset') ? $('[component="category"]').attr('data-dbset') : 'topics:recent' 
+			set: $('[component="category"]').attr('data-set') ? $('[component="category"]').attr('data-set') : 'topics:recent' 
 		}, function(data, done) {
 			if (data.topics && data.topics.length) {
 				Recent.onTopicsLoaded('recent', data.topics, false, done);

--- a/src/controllers/recent.js
+++ b/src/controllers/recent.js
@@ -54,7 +54,7 @@ recentController.get = function(req, res, next) {
 		var data = {};
 		data.topics = topics;
 		data.nextStart = stop + 1;
-		data.dbSet = 'topics:recent';
+		data.set = 'topics:recent';
 		data['feeds:disableRSS'] = parseInt(meta.config['feeds:disableRSS'], 10) === 1;
 		data.rssFeedUrl = nconf.get('relative_path') + '/recent.rss';
 		data.title = '[[pages:recent]]';

--- a/src/controllers/recent.js
+++ b/src/controllers/recent.js
@@ -54,6 +54,7 @@ recentController.get = function(req, res, next) {
 		var data = {};
 		data.topics = topics;
 		data.nextStart = stop + 1;
+		data.dbSet = 'topics:recent';
 		data['feeds:disableRSS'] = parseInt(meta.config['feeds:disableRSS'], 10) === 1;
 		data.rssFeedUrl = nconf.get('relative_path') + '/recent.rss';
 		data.title = '[[pages:recent]]';


### PR DESCRIPTION
Instead of looking for the set name `topics:recent` in the client side on /recent route, pass the set name using the api so that it can be set as an attribute in the template. This will help plugins like QandA can keep using the recent template and have infinite scroll working.