### PR TITLE
Fix /topic/:tid/:slug?page=:page for users with infinite scroll enabled

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -260,7 +260,7 @@ define('forum/topic', [
 
 				Topic.replaceURLTimeout = 0;
 				if (history.replaceState) {
-					var search = (window.location.search ? window.location.search : '');
+					var search = (window.location.search && !/^\?page=\d+$/.test(window.location.search) ? window.location.search : '');
 					history.replaceState({
 						url: newUrl + search
 					}, null, window.location.protocol + '//' + window.location.host + RELATIVE_PATH + '/' + newUrl + search);

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -97,7 +97,9 @@ topicsController.get = function(req, res, callback) {
 				req.params.post_index = 0;
 			}
 			if (!settings.usePagination) {
-				currentPage = 1;
+				if (req.params.post_index !== 0) {
+					currentPage = 1;
+				}
 				if (reverse) {
 					postIndex = Math.max(0, postCount - (req.params.post_index || postCount) - Math.ceil(settings.postsPerPage / 2));
 				} else {


### PR DESCRIPTION
make ?page=[numbers] links work for users with pagination disabled. remove ?page when updating the URL for infinite scroll