### PR TITLE
fix js-propagate for restarted secondary instances

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -86,21 +86,10 @@ Loader.addWorkerEvents = function(worker) {
 		if (message && typeof message === 'object' && message.action) {
 			switch (message.action) {
 				case 'ready':
-					if (Loader.js.target['nodebb.min.js'] && Loader.js.target['nodebb.min.js'].cache && !worker.isPrimary) {
+					if (Loader.js.target['nodebb.min.js'] && Loader.js.target['acp.min.js'] && !worker.isPrimary) {
 						worker.send({
 							action: 'js-propagate',
-							cache: Loader.js.target['nodebb.min.js'].cache,
-							map: Loader.js.target['nodebb.min.js'].map,
-							target: 'nodebb.min.js'
-						});
-					}
-
-					if (Loader.js.target['acp.min.js'] && Loader.js.target['acp.min.js'].cache && !worker.isPrimary) {
-						worker.send({
-							action: 'js-propagate',
-							cache: Loader.js.target['acp.min.js'].cache,
-							map: Loader.js.target['acp.min.js'].map,
-							target: 'acp.min.js'
+							data: Loader.js.target
 						});
 					}
 


### PR DESCRIPTION
Example error message:

```text
21/7 04:02 [6040] - error: /nodebb.min.js
 TypeError: Cannot read property 'nodebb.min.js' of undefined
    at sendMinifiedJS (/usr/src/app/src/routes/meta.js:11:28)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/src/app/node_modules/express/lib/router/route.js:131:13)
    at middleware.addExpiresHeaders (/usr/src/app/src/middleware/middleware.js:252:2)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/src/app/node_modules/express/lib/router/route.js:131:13)
    at Route.dispatch (/usr/src/app/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at /usr/src/app/node_modules/express/lib/router/index.js:277:22
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at Function.handle (/usr/src/app/node_modules/express/lib/router/index.js:176:3)
    at router (/usr/src/app/node_modules/express/lib/router/index.js:46:12)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at /usr/src/app/node_modules/express/lib/router/index.js:618:15
    at next (/usr/src/app/node_modules/express/lib/router/index.js:256:14)
    at Function.handle (/usr/src/app/node_modules/express/lib/router/index.js:176:3)
    at router (/usr/src/app/node_modules/express/lib/router/index.js:46:12)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at middleware.maintenanceMode (/usr/src/app/src/middleware/maintenance.js:13:11)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at Logger.expressLogger (/usr/src/app/src/logger.js:140:11)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at /usr/src/app/src/routes/authentication.js:22:4
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at SessionStrategy.strategy.pass (/usr/src/app/node_modules/passport/lib/middleware/authenticate.js:325:9)
    at /usr/src/app/node_modules/passport/lib/strategies/session.js:65:12
    at pass (/usr/src/app/node_modules/passport/lib/authenticator.js:327:31)
    at deserialized (/usr/src/app/node_modules/passport/lib/authenticator.js:339:7)
    at /usr/src/app/src/routes/authentication.js:84:3
    at pass (/usr/src/app/node_modules/passport/lib/authenticator.js:347:9)
    at Authenticator.deserializeUser (/usr/src/app/node_modules/passport/lib/authenticator.js:352:5)
    at SessionStrategy.authenticate (/usr/src/app/node_modules/passport/lib/strategies/session.js:53:28)
    at attempt (/usr/src/app/node_modules/passport/lib/middleware/authenticate.js:348:16)
    at authenticate (/usr/src/app/node_modules/passport/lib/middleware/authenticate.js:349:7)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at initialize (/usr/src/app/node_modules/passport/lib/middleware/initialize.js:53:5)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at middleware.processRender (/usr/src/app/src/middleware/render.js:99:3)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at middleware.addHeaders (/usr/src/app/src/middleware/middleware.js:97:2)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:312:13)
    at /usr/src/app/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:330:12)
    at next (/usr/src/app/node_modules/express/lib/router/index.js:271:10)
    at /usr/src/app/node_modules/express-session/index.js:463:7
    at Command.callback (/usr/src/app/node_modules/connect-redis/lib/connect-redis.js:148:14)
    at RedisClient.return_reply (/usr/src/app/node_modules/redis/index.js:664:25)
    at JavascriptReplyParser.reply_parser.send_reply (/usr/src/app/node_modules/redis/index.js:332:14)
    at JavascriptReplyParser.run (/usr/src/app/node_modules/redis/lib/parsers/javascript.js:132:18)
    at JavascriptReplyParser.execute (/usr/src/app/node_modules/redis/lib/parsers/javascript.js:107:10)
    at Socket.<anonymous> (/usr/src/app/node_modules/redis/index.js:131:27)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:153:18)
    at Socket.Readable.push (_stream_readable.js:111:10)
    at TCP.onread (net.js:536:20)
```