### PR TITLE
Send plugin `postData` changes up the line

### DIFF
--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -58,7 +58,8 @@ module.exports = function(Posts) {
 
 				plugins.fireHook('filter:post.save', postData, next);
 			},
-			function(postData, next) {
+			function(_postData, next) {
+				postData = _postData;
 				db.setObject('post:' + postData.pid, postData, next);
 			},
 			function(next) {


### PR DESCRIPTION
I change `postData.content` in my plugin's method for this hook. This changes the behavior to the expected behavior which matches that of `filter:post.edit`