### PR TITLE
Keep old versions of avatars in the filesystem

### DIFF
--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -25,6 +25,7 @@ module.exports = function(User) {
 		var updateUid = uid;
 		var imageDimension = parseInt(meta.config.profileImageDimension, 10) || 128;
 		var convertToPNG = parseInt(meta.config['profile:convertProfileImageToPNG'], 10) === 1;
+		var keepAllVersions = parseInt(meta.config['profile:keepAllUserImages'], 10) === 1;
 		var uploadedImage;
 
 		async.waterfall([
@@ -42,7 +43,7 @@ module.exports = function(User) {
 					return plugins.fireHook('filter:uploadImage', {image: picture, uid: updateUid}, next);
 				}
 
-				var filename = updateUid + '-profileimg-' + Date.now() + (convertToPNG ? '.png' : extension);
+				var filename = updateUid + '-profileimg' + (keepAllVersions ? '-' + Date.now() : '') + (convertToPNG ? '.png' : extension);
 
 				async.waterfall([
 					function(next) {
@@ -120,6 +121,7 @@ module.exports = function(User) {
 	};
 
 	User.updateCoverPicture = function(data, callback) {
+		var keepAllVersions = parseInt(meta.config['profile:keepAllUserImages'], 10) === 1;
 		var url, md5sum;
 
 		if (!data.imageData && data.position) {
@@ -167,7 +169,7 @@ module.exports = function(User) {
 					return plugins.fireHook('filter:uploadImage', {image: image, uid: data.uid}, next);
 				}
 
-				var filename = data.uid + '-profilecover-' + Date.now();
+				var filename = data.uid + '-profilecover' + (keepAllVersions ? '-' + Date.now() : '');
 				async.waterfall([
 					function (next) {
 						file.isFileTypeAllowed(data.file.path, next);

--- a/src/user/picture.js
+++ b/src/user/picture.js
@@ -42,7 +42,7 @@ module.exports = function(User) {
 					return plugins.fireHook('filter:uploadImage', {image: picture, uid: updateUid}, next);
 				}
 
-				var filename = updateUid + '-profileimg' + (convertToPNG ? '.png' : extension);
+				var filename = updateUid + '-profileimg-' + Date.now() + (convertToPNG ? '.png' : extension);
 
 				async.waterfall([
 					function(next) {
@@ -68,21 +68,7 @@ module.exports = function(User) {
 						});
 					},
 					function(next) {
-						User.getUserField(updateUid, 'uploadedpicture', next);
-					},
-					function(oldpicture, next) {
-						if (!oldpicture) {
-							return file.saveFileToLocal(filename, 'profile', picture.path, next);
-						}
-						var oldpicturePath = path.join(nconf.get('base_dir'), nconf.get('upload_path'), 'profile', path.basename(oldpicture));
-
-						fs.unlink(oldpicturePath, function (err) {
-							if (err) {
-								winston.error(err);
-							}
-
-							file.saveFileToLocal(filename, 'profile', picture.path, next);
-						});
+						file.saveFileToLocal(filename, 'profile', picture.path, next);
 					},
 				], next);
 			},
@@ -181,7 +167,7 @@ module.exports = function(User) {
 					return plugins.fireHook('filter:uploadImage', {image: image, uid: data.uid}, next);
 				}
 
-				var filename = data.uid + '-profilecover';
+				var filename = data.uid + '-profilecover-' + Date.now();
 				async.waterfall([
 					function (next) {
 						file.isFileTypeAllowed(data.file.path, next);

--- a/src/views/admin/settings/uploads.tpl
+++ b/src/views/admin/settings/uploads.tpl
@@ -115,6 +115,13 @@
 					(in kilobytes, default: 2,048 KiB)
 				</p>
 			</div>
+
+			<div class="checkbox">
+				<label class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
+					<input class="mdl-switch__input" type="checkbox" data-field="profile:keepAllUserImages">
+					<span class="mdl-switch__label"><strong>Keep old versions of avatars and profile covers on the server</strong></span>
+				</label>
+			</div>
 		</form>
 	</div>
 </div>


### PR DESCRIPTION
Keep old versions of avatars in the filesystem. Change the avatar URL each time a new one is uploaded to avoid caching problems. Closes #4722.