### PR TITLE
Allow first page of group members to be retrieved via websocket

### DIFF
--- a/src/socket.io/groups.js
+++ b/src/socket.io/groups.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var async = require('async'),
+var	async = require('async'),
 
 	groups = require('../groups'),
 	meta = require('../meta'),
@@ -11,14 +11,14 @@ var async = require('async'),
 	SocketGroups = {};
 
 
-SocketGroups.before = function (socket, method, data, next) {
+SocketGroups.before = function(socket, method, data, next) {
 	if (!data) {
 		return next(new Error('[[error:invalid-data]]'));
 	}
 	next();
 };
 
-SocketGroups.join = function (socket, data, callback) {
+SocketGroups.join = function(socket, data, callback) {
 	if (!parseInt(socket.uid, 10)) {
 		return callback(new Error('[[error:invalid-uid]]'));
 	}
@@ -27,7 +27,7 @@ SocketGroups.join = function (socket, data, callback) {
 		return callback(new Error('[[error:not-allowed]]'));
 	}
 
-	groups.exists(data.groupName, function (err, exists) {
+	groups.exists(data.groupName, function(err, exists) {
 		if (err || !exists) {
 			return callback(err || new Error('[[error:no-group]]'));
 		}
@@ -39,7 +39,7 @@ SocketGroups.join = function (socket, data, callback) {
 		async.parallel({
 			isAdmin: async.apply(user.isAdministrator, socket.uid),
 			groupData: async.apply(groups.getGroupData, data.groupName)
-		}, function (err, results) {
+		}, function(err, results) {
 			if (err) {
 				return callback(err);
 			}
@@ -57,7 +57,7 @@ SocketGroups.join = function (socket, data, callback) {
 	});
 };
 
-SocketGroups.leave = function (socket, data, callback) {
+SocketGroups.leave = function(socket, data, callback) {
 	if (!parseInt(socket.uid, 10)) {
 		return callback(new Error('[[error:invalid-uid]]'));
 	}
@@ -74,7 +74,7 @@ function isOwner(next) {
 		async.parallel({
 			isAdmin: async.apply(user.isAdministrator, socket.uid),
 			isOwner: async.apply(groups.ownership.isOwner, socket.uid, data.groupName)
-		}, function (err, results) {
+		}, function(err, results) {
 			if (err || (!isOwner && !results.isAdmin)) {
 				return callback(err || new Error('[[error:no-privileges]]'));
 			}
@@ -85,7 +85,7 @@ function isOwner(next) {
 
 function isInvited(next) {
 	return function (socket, data, callback) {
-		groups.isInvited(socket.uid, data.groupName, function (err, invited) {
+		groups.isInvited(socket.uid, data.groupName, function(err, invited) {
 			if (err || !invited) {
 				return callback(err || new Error('[[error:not-invited]]'));
 			}
@@ -94,70 +94,70 @@ function isInvited(next) {
 	};
 }
 
-SocketGroups.grant = isOwner(function (socket, data, callback) {
+SocketGroups.grant = isOwner(function(socket, data, callback) {
 	groups.ownership.grant(data.toUid, data.groupName, callback);
 });
 
-SocketGroups.rescind = isOwner(function (socket, data, callback) {
+SocketGroups.rescind = isOwner(function(socket, data, callback) {
 	groups.ownership.rescind(data.toUid, data.groupName, callback);
 });
 
-SocketGroups.accept = isOwner(function (socket, data, callback) {
+SocketGroups.accept = isOwner(function(socket, data, callback) {
 	groups.acceptMembership(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.reject = isOwner(function (socket, data, callback) {
+SocketGroups.reject = isOwner(function(socket, data, callback) {
 	groups.rejectMembership(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.acceptAll = isOwner(function (socket, data, callback) {
+SocketGroups.acceptAll = isOwner(function(socket, data, callback) {
 	acceptRejectAll(groups.acceptMembership, socket, data, callback);
 });
 
-SocketGroups.rejectAll = isOwner(function (socket, data, callback) {
+SocketGroups.rejectAll = isOwner(function(socket, data, callback) {
 	acceptRejectAll(groups.rejectMembership, socket, data, callback);
 });
 
 function acceptRejectAll(method, socket, data, callback) {
 	async.waterfall([
-		function (next) {
+		function(next) {
 			groups.getPending(data.groupName, next);
 		},
-		function (uids, next) {
-			async.each(uids, function (uid, next) {
+		function(uids, next) {
+			async.each(uids, function(uid, next) {
 				method(data.groupName, uid, next);
 			}, next);
 		}
 	], callback);
 }
 
-SocketGroups.issueInvite = isOwner(function (socket, data, callback) {
+SocketGroups.issueInvite = isOwner(function(socket, data, callback) {
 	groups.invite(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.rescindInvite = isOwner(function (socket, data, callback) {
+SocketGroups.rescindInvite = isOwner(function(socket, data, callback) {
 	groups.rejectMembership(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.acceptInvite = isInvited(function (socket, data, callback) {
+SocketGroups.acceptInvite = isInvited(function(socket, data, callback) {
 	groups.acceptMembership(data.groupName, socket.uid, callback);
 });
 
-SocketGroups.rejectInvite = isInvited(function (socket, data, callback) {
+SocketGroups.rejectInvite = isInvited(function(socket, data, callback) {
 	groups.rejectMembership(data.groupName, socket.uid, callback);
 });
 
-SocketGroups.update = isOwner(function (socket, data, callback) {
+SocketGroups.update = isOwner(function(socket, data, callback) {
 	groups.update(data.groupName, data.values, callback);
 });
 
 
-SocketGroups.kick = isOwner(function (socket, data, callback) {
+SocketGroups.kick = isOwner(function(socket, data, callback) {
 	if (socket.uid === parseInt(data.uid, 10)) {
 		return callback(new Error('[[error:cant-kick-self]]'));
 	}
 
-	groups.ownership.isOwner(data.uid, data.groupName, function (err, isOwner) {
+	groups.ownership.isOwner(data.uid, data.groupName, function(err, isOwner) {
 		if (err) {
 			return callback(err);
 		}
@@ -166,7 +166,7 @@ SocketGroups.kick = isOwner(function (socket, data, callback) {
 
 });
 
-SocketGroups.create = function (socket, data, callback) {
+SocketGroups.create = function(socket, data, callback) {
 	if (!socket.uid) {
 		return callback(new Error('[[error:no-privileges]]'));
 	} else if (parseInt(meta.config.allowGroupCreation, 10) !== 1) {
@@ -180,7 +180,7 @@ SocketGroups.create = function (socket, data, callback) {
 	groups.create(data, callback);
 };
 
-SocketGroups.delete = function (socket, data, callback) {
+SocketGroups.delete = function(socket, data, callback) {
 	if (data.groupName === 'administrators' ||
 		data.groupName === 'registered-users' ||
 		data.groupName === 'Global Moderators') {
@@ -190,7 +190,7 @@ SocketGroups.delete = function (socket, data, callback) {
 	async.parallel({
 		isOwner: async.apply(groups.ownership.isOwner, socket.uid, data.groupName),
 		isAdmin: async.apply(user.isAdministrator, socket.uid)
-	}, function (err, checks) {
+	}, function(err, checks) {
 		if (err) {
 			return callback(err);
 		}
@@ -202,12 +202,12 @@ SocketGroups.delete = function (socket, data, callback) {
 	});
 };
 
-SocketGroups.search = function (socket, data, callback) {
+SocketGroups.search = function(socket, data, callback) {
 	data.options = data.options || {};
 
 	if (!data.query) {
 		var groupsPerPage = 15;
-		groupsController.getGroupsFromSet(socket.uid, data.options.sort, 0, groupsPerPage - 1, function (err, data) {
+		groupsController.getGroupsFromSet(socket.uid, data.options.sort, 0, groupsPerPage - 1, function(err, data) {
 			callback(err, !err ? data.groups : null);
 		});
 		return;
@@ -216,7 +216,7 @@ SocketGroups.search = function (socket, data, callback) {
 	groups.search(data.query, data.options || {}, callback);
 };
 
-SocketGroups.loadMore = function (socket, data, callback) {
+SocketGroups.loadMore = function(socket, data, callback) {
 	if (!data.sort || !data.after) {
 		return callback();
 	}
@@ -227,36 +227,33 @@ SocketGroups.loadMore = function (socket, data, callback) {
 	groupsController.getGroupsFromSet(socket.uid, data.sort, start, stop, callback);
 };
 
-SocketGroups.searchMembers = function (socket, data, callback) {
+SocketGroups.searchMembers = function(socket, data, callback) {
 	data.uid = socket.uid;
 	groups.searchMembers(data, callback);
 };
 
-SocketGroups.loadMoreMembers = function (socket, data, callback) {
+SocketGroups.loadMoreMembers = function(socket, data, callback) {
 	if (!data.groupName || !utils.isNumber(data.after) || parseInt(data.after, 10) < 0) {
 		return callback(new Error('[[error:invalid-data]]'));
 	}
 	data.after = parseInt(data.after, 10);
-	user.getUsersFromSet('group:' + data.groupName + ':members', socket.uid, data.after, data.after + 9, function (err, users) {
+	user.getUsersFromSet('group:' + data.groupName + ':members', socket.uid, data.after, data.after + 9, function(err, users) {
 		if (err) {
 			return callback(err);
 		}
 
-		callback(null, {
-			users: users,
-			nextStart: data.after + 10
-		});
+		callback(null, {users: users, nextStart: data.after + 10});
 	});
 };
 
 SocketGroups.cover = {};
 
-SocketGroups.cover.update = function (socket, data, callback) {
+SocketGroups.cover.update = function(socket, data, callback) {
 	if (!socket.uid) {
 		return callback(new Error('[[error:no-privileges]]'));
 	}
 
-	groups.ownership.isOwner(socket.uid, data.groupName, function (err, isOwner) {
+	groups.ownership.isOwner(socket.uid, data.groupName, function(err, isOwner) {
 		if (err || !isOwner) {
 			return callback(err || new Error('[[error:no-privileges]]'));
 		}
@@ -265,12 +262,12 @@ SocketGroups.cover.update = function (socket, data, callback) {
 	});
 };
 
-SocketGroups.cover.remove = function (socket, data, callback) {
+SocketGroups.cover.remove = function(socket, data, callback) {
 	if (!socket.uid) {
 		return callback(new Error('[[error:no-privileges]]'));
 	}
 
-	groups.ownership.isOwner(socket.uid, data.groupName, function (err, isOwner) {
+	groups.ownership.isOwner(socket.uid, data.groupName, function(err, isOwner) {
 		if (err || !isOwner) {
 			return callback(err || new Error('[[error:no-privileges]]'));
 		}

--- a/src/socket.io/groups.js
+++ b/src/socket.io/groups.js
@@ -1,23 +1,24 @@
 "use strict";
 
-var	async = require('async'),
+var async = require('async'),
 
 	groups = require('../groups'),
 	meta = require('../meta'),
 	user = require('../user'),
+	utils = require('../../../public/src/utils'),
 	groupsController = require('../controllers/groups'),
 
 	SocketGroups = {};
 
 
-SocketGroups.before = function(socket, method, data, next) {
+SocketGroups.before = function (socket, method, data, next) {
 	if (!data) {
 		return next(new Error('[[error:invalid-data]]'));
 	}
 	next();
 };
 
-SocketGroups.join = function(socket, data, callback) {
+SocketGroups.join = function (socket, data, callback) {
 	if (!parseInt(socket.uid, 10)) {
 		return callback(new Error('[[error:invalid-uid]]'));
 	}
@@ -26,7 +27,7 @@ SocketGroups.join = function(socket, data, callback) {
 		return callback(new Error('[[error:not-allowed]]'));
 	}
 
-	groups.exists(data.groupName, function(err, exists) {
+	groups.exists(data.groupName, function (err, exists) {
 		if (err || !exists) {
 			return callback(err || new Error('[[error:no-group]]'));
 		}
@@ -38,7 +39,7 @@ SocketGroups.join = function(socket, data, callback) {
 		async.parallel({
 			isAdmin: async.apply(user.isAdministrator, socket.uid),
 			groupData: async.apply(groups.getGroupData, data.groupName)
-		}, function(err, results) {
+		}, function (err, results) {
 			if (err) {
 				return callback(err);
 			}
@@ -56,7 +57,7 @@ SocketGroups.join = function(socket, data, callback) {
 	});
 };
 
-SocketGroups.leave = function(socket, data, callback) {
+SocketGroups.leave = function (socket, data, callback) {
 	if (!parseInt(socket.uid, 10)) {
 		return callback(new Error('[[error:invalid-uid]]'));
 	}
@@ -73,7 +74,7 @@ function isOwner(next) {
 		async.parallel({
 			isAdmin: async.apply(user.isAdministrator, socket.uid),
 			isOwner: async.apply(groups.ownership.isOwner, socket.uid, data.groupName)
-		}, function(err, results) {
+		}, function (err, results) {
 			if (err || (!isOwner && !results.isAdmin)) {
 				return callback(err || new Error('[[error:no-privileges]]'));
 			}
@@ -84,7 +85,7 @@ function isOwner(next) {
 
 function isInvited(next) {
 	return function (socket, data, callback) {
-		groups.isInvited(socket.uid, data.groupName, function(err, invited) {
+		groups.isInvited(socket.uid, data.groupName, function (err, invited) {
 			if (err || !invited) {
 				return callback(err || new Error('[[error:not-invited]]'));
 			}
@@ -93,70 +94,70 @@ function isInvited(next) {
 	};
 }
 
-SocketGroups.grant = isOwner(function(socket, data, callback) {
+SocketGroups.grant = isOwner(function (socket, data, callback) {
 	groups.ownership.grant(data.toUid, data.groupName, callback);
 });
 
-SocketGroups.rescind = isOwner(function(socket, data, callback) {
+SocketGroups.rescind = isOwner(function (socket, data, callback) {
 	groups.ownership.rescind(data.toUid, data.groupName, callback);
 });
 
-SocketGroups.accept = isOwner(function(socket, data, callback) {
+SocketGroups.accept = isOwner(function (socket, data, callback) {
 	groups.acceptMembership(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.reject = isOwner(function(socket, data, callback) {
+SocketGroups.reject = isOwner(function (socket, data, callback) {
 	groups.rejectMembership(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.acceptAll = isOwner(function(socket, data, callback) {
+SocketGroups.acceptAll = isOwner(function (socket, data, callback) {
 	acceptRejectAll(groups.acceptMembership, socket, data, callback);
 });
 
-SocketGroups.rejectAll = isOwner(function(socket, data, callback) {
+SocketGroups.rejectAll = isOwner(function (socket, data, callback) {
 	acceptRejectAll(groups.rejectMembership, socket, data, callback);
 });
 
 function acceptRejectAll(method, socket, data, callback) {
 	async.waterfall([
-		function(next) {
+		function (next) {
 			groups.getPending(data.groupName, next);
 		},
-		function(uids, next) {
-			async.each(uids, function(uid, next) {
+		function (uids, next) {
+			async.each(uids, function (uid, next) {
 				method(data.groupName, uid, next);
 			}, next);
 		}
 	], callback);
 }
 
-SocketGroups.issueInvite = isOwner(function(socket, data, callback) {
+SocketGroups.issueInvite = isOwner(function (socket, data, callback) {
 	groups.invite(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.rescindInvite = isOwner(function(socket, data, callback) {
+SocketGroups.rescindInvite = isOwner(function (socket, data, callback) {
 	groups.rejectMembership(data.groupName, data.toUid, callback);
 });
 
-SocketGroups.acceptInvite = isInvited(function(socket, data, callback) {
+SocketGroups.acceptInvite = isInvited(function (socket, data, callback) {
 	groups.acceptMembership(data.groupName, socket.uid, callback);
 });
 
-SocketGroups.rejectInvite = isInvited(function(socket, data, callback) {
+SocketGroups.rejectInvite = isInvited(function (socket, data, callback) {
 	groups.rejectMembership(data.groupName, socket.uid, callback);
 });
 
-SocketGroups.update = isOwner(function(socket, data, callback) {
+SocketGroups.update = isOwner(function (socket, data, callback) {
 	groups.update(data.groupName, data.values, callback);
 });
 
 
-SocketGroups.kick = isOwner(function(socket, data, callback) {
+SocketGroups.kick = isOwner(function (socket, data, callback) {
 	if (socket.uid === parseInt(data.uid, 10)) {
 		return callback(new Error('[[error:cant-kick-self]]'));
 	}
 
-	groups.ownership.isOwner(data.uid, data.groupName, function(err, isOwner) {
+	groups.ownership.isOwner(data.uid, data.groupName, function (err, isOwner) {
 		if (err) {
 			return callback(err);
 		}
@@ -165,7 +166,7 @@ SocketGroups.kick = isOwner(function(socket, data, callback) {
 
 });
 
-SocketGroups.create = function(socket, data, callback) {
+SocketGroups.create = function (socket, data, callback) {
 	if (!socket.uid) {
 		return callback(new Error('[[error:no-privileges]]'));
 	} else if (parseInt(meta.config.allowGroupCreation, 10) !== 1) {
@@ -179,7 +180,7 @@ SocketGroups.create = function(socket, data, callback) {
 	groups.create(data, callback);
 };
 
-SocketGroups.delete = function(socket, data, callback) {
+SocketGroups.delete = function (socket, data, callback) {
 	if (data.groupName === 'administrators' ||
 		data.groupName === 'registered-users' ||
 		data.groupName === 'Global Moderators') {
@@ -189,7 +190,7 @@ SocketGroups.delete = function(socket, data, callback) {
 	async.parallel({
 		isOwner: async.apply(groups.ownership.isOwner, socket.uid, data.groupName),
 		isAdmin: async.apply(user.isAdministrator, socket.uid)
-	}, function(err, checks) {
+	}, function (err, checks) {
 		if (err) {
 			return callback(err);
 		}
@@ -201,12 +202,12 @@ SocketGroups.delete = function(socket, data, callback) {
 	});
 };
 
-SocketGroups.search = function(socket, data, callback) {
+SocketGroups.search = function (socket, data, callback) {
 	data.options = data.options || {};
 
 	if (!data.query) {
 		var groupsPerPage = 15;
-		groupsController.getGroupsFromSet(socket.uid, data.options.sort, 0, groupsPerPage - 1, function(err, data) {
+		groupsController.getGroupsFromSet(socket.uid, data.options.sort, 0, groupsPerPage - 1, function (err, data) {
 			callback(err, !err ? data.groups : null);
 		});
 		return;
@@ -215,7 +216,7 @@ SocketGroups.search = function(socket, data, callback) {
 	groups.search(data.query, data.options || {}, callback);
 };
 
-SocketGroups.loadMore = function(socket, data, callback) {
+SocketGroups.loadMore = function (socket, data, callback) {
 	if (!data.sort || !data.after) {
 		return callback();
 	}
@@ -226,33 +227,36 @@ SocketGroups.loadMore = function(socket, data, callback) {
 	groupsController.getGroupsFromSet(socket.uid, data.sort, start, stop, callback);
 };
 
-SocketGroups.searchMembers = function(socket, data, callback) {
+SocketGroups.searchMembers = function (socket, data, callback) {
 	data.uid = socket.uid;
 	groups.searchMembers(data, callback);
 };
 
-SocketGroups.loadMoreMembers = function(socket, data, callback) {
-	if (!data.groupName || !parseInt(data.after, 10)) {
+SocketGroups.loadMoreMembers = function (socket, data, callback) {
+	if (!data.groupName || !utils.isNumber(data.after) || parseInt(data.after, 10) < 0) {
 		return callback(new Error('[[error:invalid-data]]'));
 	}
 	data.after = parseInt(data.after, 10);
-	user.getUsersFromSet('group:' + data.groupName + ':members', socket.uid, data.after, data.after + 9, function(err, users) {
+	user.getUsersFromSet('group:' + data.groupName + ':members', socket.uid, data.after, data.after + 9, function (err, users) {
 		if (err) {
 			return callback(err);
 		}
 
-		callback(null, {users: users, nextStart: data.after + 10});
+		callback(null, {
+			users: users,
+			nextStart: data.after + 10
+		});
 	});
 };
 
 SocketGroups.cover = {};
 
-SocketGroups.cover.update = function(socket, data, callback) {
+SocketGroups.cover.update = function (socket, data, callback) {
 	if (!socket.uid) {
 		return callback(new Error('[[error:no-privileges]]'));
 	}
 
-	groups.ownership.isOwner(socket.uid, data.groupName, function(err, isOwner) {
+	groups.ownership.isOwner(socket.uid, data.groupName, function (err, isOwner) {
 		if (err || !isOwner) {
 			return callback(err || new Error('[[error:no-privileges]]'));
 		}
@@ -261,12 +265,12 @@ SocketGroups.cover.update = function(socket, data, callback) {
 	});
 };
 
-SocketGroups.cover.remove = function(socket, data, callback) {
+SocketGroups.cover.remove = function (socket, data, callback) {
 	if (!socket.uid) {
 		return callback(new Error('[[error:no-privileges]]'));
 	}
 
-	groups.ownership.isOwner(socket.uid, data.groupName, function(err, isOwner) {
+	groups.ownership.isOwner(socket.uid, data.groupName, function (err, isOwner) {
 		if (err || !isOwner) {
 			return callback(err || new Error('[[error:no-privileges]]'));
 		}

--- a/src/socket.io/groups.js
+++ b/src/socket.io/groups.js
@@ -5,7 +5,7 @@ var	async = require('async'),
 	groups = require('../groups'),
 	meta = require('../meta'),
 	user = require('../user'),
-	utils = require('../../../public/src/utils'),
+	utils = require('../../public/src/utils'),
 	groupsController = require('../controllers/groups'),
 
 	SocketGroups = {};


### PR DESCRIPTION
before this change passing a value of `0` for `after` in the call to `"groups.loadMoreMembers"` would reject with the error `[[error:invalid-data]]`, this request is in fact satisfy-able however.

This change alters the validation logic to allow `0` as a valid input for the `"after"` parameter, leaving all other behavior unchanged.