### PR TITLE
Allow listing all groups via websocket

### DIFF
--- a/src/socket.io/groups.js
+++ b/src/socket.io/groups.js
@@ -217,12 +217,12 @@ SocketGroups.search = function(socket, data, callback) {
 };
 
 SocketGroups.loadMore = function(socket, data, callback) {
-	if (!data.sort || !data.after) {
+	if (!data.sort  || !utils.isNumber(data.after) || parseInt(data.after, 10) < 0) {
 		return callback();
 	}
 
 	var groupsPerPage = 9;
-	var start = parseInt(data.after);
+	var start = parseInt(data.after, 10);
 	var stop = start + groupsPerPage - 1;
 	groupsController.getGroupsFromSet(socket.uid, data.sort, start, stop, callback);
 };


### PR DESCRIPTION
before this change passing a value of 0 for after in the call to "groups.loadMore" would respond with `null`, however such a request can be satisfied.

This change alters the validation logic to allow 0 as a valid input for the "after" parameter, and adds the missing radix specification to the parsing of the 'after' parameter forcing that parameter to be specified in base 10 to match other websocket requests.

All other behavior unchanged. I would suggest updating the abort callback to have parameter `new Error('[[error:invalid-data]]')` to fall in line with other websocket requests, but i am disinclined to make that change without much more extensive testing than i can provide on my own.

This acts as a companion to #4934 and is a blocker for SockDrawer/SockBot#346