### PR TITLE
Use mousetrap.js minified version

### DIFF
--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -79,7 +79,7 @@ module.exports = function(Meta) {
 			// modules listed below are routed through express (/src/modules) so they can be defined anonymously
 			modules: {
 				"Chart.js": './node_modules/chart.js/dist/Chart.min.js',
-				"mousetrap.js": './node_modules/mousetrap/mousetrap.js',
+				"mousetrap.js": './node_modules/mousetrap/mousetrap.min.js',
 				"jqueryui.js": 'public/vendor/jquery/js/jquery-ui.js',
 				"buzz.js": 'public/vendor/buzz/buzz.js'
 			}


### PR DESCRIPTION
didn't see a reason it shouldn't use the minified version