### PR TITLE
Fix language route when running nodebb with a relative path.

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -145,7 +145,7 @@ module.exports = function(app, middleware, hotswapIds) {
 	}
 
 	app.use(middleware.privateUploads);
-	app.use('/language/:code', middleware.processLanguages);
+	app.use(relativePath + '/language/:code', middleware.processLanguages);
 	app.use(relativePath, express.static(path.join(__dirname, '../../', 'public'), {
 		maxAge: app.enabled('cache') ? 5184000000 : 0
 	}));


### PR DESCRIPTION
Problem:
If nodebb is running with a relative_path, the router it will not match the url. 
Translations will be served directly from public/language/code and they will not be parsed through the controller.
All the plugin translations will not be parsed.

How to duplicate:
 - add relative path to the config.json or env var

`  "url": "http://localhost:4567/relative/test",
    "relative_path": "/relative/test",`

Then you can check that the router does not match. ( console.log inside processLanguage method )

http://localhost:4567/relative/test/language/de/global.json  <--- it will be served directly.