### PR TITLE
Fix mixed content warning on 503 status page and installer

### DIFF
--- a/public/503.html
+++ b/public/503.html
@@ -1,7 +1,7 @@
 <html>
 <head>
 	<title>Excessive Load Warning</title>
-	<link href='http://fonts.googleapis.com/css?family=Ubuntu:400,500,700' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Ubuntu:400,500,700' rel='stylesheet' type='text/css'>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style type="text/css">
 	body {

--- a/src/views/install/index.tpl
+++ b/src/views/install/index.tpl
@@ -7,7 +7,7 @@
 	<title>NodeBB Web Installer</title>
 
 	<link rel="stylesheet" type="text/css" href="https://bootswatch.com/united/bootstrap.min.css">
-	<link href='http://fonts.googleapis.com/css?family=Roboto:400,300,500,700' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Roboto:400,300,500,700' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 	<link rel="stylesheet" type="text/css" href="stylesheet.css">
 


### PR DESCRIPTION
The community forum just 502'd and I noticed the mixed content warning so I figured might as well push a fix, I couldn't find where the header for 502 is defined. But I searched the whole project for every mention of http and this is the only place where http was still hardcoded.