### PR TITLE
Load images down the topic in the background

### DIFF
--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -282,10 +282,10 @@ define('forum/topic/posts', [
 			*/
 
 			var images = components.get('post/content').find('img[data-state="unloaded"]'),
-				visible = images.filter(function() {
-					return utils.isElementInViewport(this);
+				toLoad = images.filter(function() {
+					return utils.isElementBelowTopOfViewport(this);
 				}),
-				posts = $.unique(visible.map(function() {
+				posts = $.unique(toLoad.map(function() {
 					return $(this).parents('[component="post"]').get(0);
 				})),
 				scrollTop = $(window).scrollTop(),
@@ -317,8 +317,8 @@ define('forum/topic/posts', [
 				oldHeight, newHeight;
 
 			// For each image, reset the source and adjust scrollTop when loaded
-			visible.attr('data-state', 'loading');
-			visible.each(function(index, image) {
+			toLoad.attr('data-state', 'loading');
+			toLoad.each(function(index, image) {
 				image = $(image);
 
 				image.on('load', function() {

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -317,8 +317,8 @@
 			return labels;
 		},
 
-		/* Retrieved from http://stackoverflow.com/a/7557433 @ 27 Mar 2016 */
-		isElementInViewport: function(el) {
+		/* Based on code retrieved from http://stackoverflow.com/a/7557433 @ 27 Mar 2016 */
+		isElementBelowTopOfViewport: function(el) {
 			//special bonus for those using jQuery
 			if (typeof jQuery === "function" && el instanceof jQuery) {
 				el = el[0];
@@ -326,12 +326,7 @@
 
 			var rect = el.getBoundingClientRect();
 
-			return (
-				rect.top >= 0 &&
-				rect.left >= 0 &&
-				rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) && /*or $(window).height() */
-				rect.right <= (window.innerWidth || document.documentElement.clientWidth) /*or $(window).width() */
-			);
+			return rect.bottom >= 0;
 		},
 
 		// get all the url params in a single key/value hash


### PR DESCRIPTION
NodeBB only loads images that are visible. The goal is to prevent images in posts above the current viewport from loading and causing the user's place in the page to jump around. Loading images below the viewport doesn't cause the user's place to jump around, but waiting until images are visible before loading them means that as the user scrolls, images might not load until he has gone past them, causing the undesirable jumping around (i.e., jellypotato).

This pull request allows images below the top of the viewport, whether visible or not, to be loaded, making the user's experience much better.
