### PR TITLE
Add additional lexical dbal operations.

### DIFF
--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -596,11 +596,19 @@ module.exports = function (db, module) {
 		var query = {_key: key, value: {}};
 
 		if (min !== '-') {
-			query.value = {$gte: min};
+			if (min.match('(')) {
+				query.value = {$gt: parseInt(min, 10)};
+			} else {
+				query.value = {$gte: parseInt(min, 10)};
+			}
 		}
 		if (max !== '+') {
 			query.value = query.value || {};
-			query.value.$lte = max;
+			if (max.match('(')) {
+				query.value = {$lt: parseInt(max, 10)};
+			} else {
+				query.value = {$lte: parseInt(max, 10)};
+			}
 		}
 
 		db.collection('objects').find(query, {_id: 0, value: 1})
@@ -624,11 +632,19 @@ module.exports = function (db, module) {
 		var query = {_key: key};
 
 		if (min !== '-') {
-			query.value = {$gte: min};
+			if (min.match('(')) {
+				query.value = {$gt: parseInt(min, 10)};
+			} else {
+				query.value = {$gte: parseInt(min, 10)};
+			}
 		}
 		if (max !== '+') {
 			query.value = query.value || {};
-			query.value.$lte = max;
+			if (max.match('(')) {
+				query.value = {$lt: parseInt(max, 10)};
+			} else {
+				query.value = {$lte: parseInt(max, 10)};
+			}
 		}
 
 		db.collection('objects').remove(query, function (err) {

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -592,7 +592,13 @@ module.exports = function (db, module) {
 		});
 	};
 
-	function sortedSetLex(method, sort, key, min, max, start, count, callback) {
+	function sortedSetLex(key, min, max, sort, start, count, callback) {
+		if (!callback) {
+			callback = start;
+			start = 0;
+			count = 0;
+		}
+
 		var query = {_key: key, value: {}};
 
 		if (min !== '-') {
@@ -696,7 +702,6 @@ module.exports = function (db, module) {
 			callback
 		);
 	};
-
 
 	module.sortedSetIntersectCard = function (keys, callback) {
 		if (!Array.isArray(keys) || !keys.length) {

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -582,7 +582,7 @@ module.exports = function (db, module) {
 		sortedSetLex(key, min, max, 1, start, count, callback);
 	};
 
-	module.getSortedSetRevRangeByLex = function (key, min, max, start, count, callback) {
+	module.getSortedSetRevRangeByLex = function (key, max, min, start, count, callback) {
 		sortedSetLex(key, min, max, -1, start, count, callback);
 	};
 
@@ -599,7 +599,7 @@ module.exports = function (db, module) {
 			count = 0;
 		}
 
-		var query = {_key: key, value: {}};
+		var query = {_key: key};
 
 		if (min !== '-') {
 			if (min.match(/^\(/)) {

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -596,18 +596,22 @@ module.exports = function (db, module) {
 		var query = {_key: key, value: {}};
 
 		if (min !== '-') {
-			if (min.match('(')) {
-				query.value = {$gt: parseInt(min, 10)};
+			if (min.match(/^\(/)) {
+				query.value = {$gt: min.slice(1)};
+			} else if (min.match(/^\[/)) {
+				query.value = {$gte: min.slice(1)};
 			} else {
-				query.value = {$gte: parseInt(min, 10)};
+				query.value = {$gte: min};
 			}
 		}
 		if (max !== '+') {
 			query.value = query.value || {};
-			if (max.match('(')) {
-				query.value = {$lt: parseInt(max, 10)};
+			if (max.match(/^\(/)) {
+				query.value.$lt = max.slice(1);
+			} else if (max.match(/^\[/)) {
+				query.value.$lte = max.slice(1);
 			} else {
-				query.value = {$lte: parseInt(max, 10)};
+				query.value.$lte = max;
 			}
 		}
 
@@ -632,18 +636,22 @@ module.exports = function (db, module) {
 		var query = {_key: key};
 
 		if (min !== '-') {
-			if (min.match('(')) {
-				query.value = {$gt: parseInt(min, 10)};
+			if (min.match(/^\(/)) {
+				query.value = {$gt: min.slice(1)};
+			} else if (min.match(/^\[/)) {
+				query.value = {$gte: min.slice(1)};
 			} else {
-				query.value = {$gte: parseInt(min, 10)};
+				query.value = {$gte: min};
 			}
 		}
 		if (max !== '+') {
 			query.value = query.value || {};
-			if (max.match('(')) {
-				query.value = {$lt: parseInt(max, 10)};
+			if (max.match(/^\(/)) {
+				query.value.$lt = max.slice(1);
+			} else if (max.match(/^\[/)) {
+				query.value.$lte = max.slice(1);
 			} else {
-				query.value = {$lte: parseInt(max, 10)};
+				query.value.$lte = max;
 			}
 		}
 

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -293,23 +293,24 @@ module.exports = function (redisClient, module) {
 	};
 
 	module.getSortedSetRangeByLex = function (key, min, max, start, count, callback) {
-		sortedSetLex('zrangebylex', false, key, min, max, start, count, callback)
+		sortedSetLex('zrangebylex', false, key, min, max, start, count, callback);
 	};
 
 	module.getSortedSetRevRangeByLex = function (key, max, min, start, count, callback) {
-		sortedSetLex('zrevrangebylex', true, key, max, min, start, count, callback)
+		sortedSetLex('zrevrangebylex', true, key, max, min, start, count, callback);
 	};
 
-	module.sortedSetRemoveRangeByLex = function (key, min, max) {
-		sortedSetLex('zremrangebylex', false, key, min, max, callback)
+	module.sortedSetRemoveRangeByLex = function (key, min, max, callback) {
+		callback = callback || helpers.noop;
+		sortedSetLex('zremrangebylex', false, key, min, max, callback);
 	};
 
-	module.sortedSetLexCount = function (key, min, max) {
-		sortedSetLex('zlexcount', false, key, min, max, callback)
+	module.sortedSetLexCount = function (key, min, max, callback) {
+		sortedSetLex('zlexcount', false, key, min, max, callback);
 	};
 
 	function sortedSetLex(method, reverse, key, min, max, start, count, callback) {
-		if (!callback) callback === start;
+		callback = callback || start;
 
 		var minmin, maxmax;
 		if (reverse) {
@@ -321,12 +322,10 @@ module.exports = function (redisClient, module) {
 		}
 
 		if (min !== minmin) {
-			min = '' + min;
-			if (!min.match(/[\[\(]/)) min = '[' + min;
+			if (!min.match(/^[\[\(]/)) min = '[' + min;
 		}
 		if (max !== maxmax) {
-			max = '' + max;
-			if (!max.match(/[\[\(]/)) max = '[' + max;
+			if (!max.match(/^[\[\(]/)) max = '[' + max;
 		}
 
 		if (count) {

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -299,8 +299,24 @@ module.exports = function (redisClient, module) {
 		if (max !== '+') {
 			max = '(' + max;
 		}
-		redisClient.zrangebylex([key, min, max, 'LIMIT', start, count], callback);
+
+		sortedSetRangeByLex('zrangebylex', key, min, max, start, count, callback)
 	};
+
+	module.getSortedSetRevRangeByLex = function (key, max, min, start, count, callback) {
+		if (min !== '-') {
+			min = '[' + min;
+		}
+		if (max !== '+') {
+			max = '(' + max;
+		}
+
+		sortedSetRangeByLex('zrevrangebylex', key, max, min, start, count, callback)
+	};
+
+	function sortedSetRangeByLex(method, key, min, max, start, count, callback) {
+		redisClient[method]([key, min, max, 'LIMIT', start, count], callback);
+	}
 
 	module.sortedSetIntersectCard = function (keys, callback) {
 		if (!Array.isArray(keys) || !keys.length) {

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -302,7 +302,9 @@ module.exports = function (redisClient, module) {
 
 	module.sortedSetRemoveRangeByLex = function (key, min, max, callback) {
 		callback = callback || helpers.noop;
-		sortedSetLex('zremrangebylex', false, key, min, max, callback);
+		sortedSetLex('zremrangebylex', false, key, min, max, function (err) {
+			callback(err);
+		});
 	};
 
 	module.sortedSetLexCount = function (key, min, max, callback) {

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -293,29 +293,45 @@ module.exports = function (redisClient, module) {
 	};
 
 	module.getSortedSetRangeByLex = function (key, min, max, start, count, callback) {
-		if (min !== '-') {
-			min = '[' + min;
-		}
-		if (max !== '+') {
-			max = '(' + max;
-		}
-
-		sortedSetRangeByLex('zrangebylex', key, min, max, start, count, callback)
+		sortedSetLex('zrangebylex', false, key, min, max, start, count, callback)
 	};
 
 	module.getSortedSetRevRangeByLex = function (key, max, min, start, count, callback) {
-		if (min !== '-') {
-			min = '[' + min;
-		}
-		if (max !== '+') {
-			max = '(' + max;
-		}
-
-		sortedSetRangeByLex('zrevrangebylex', key, max, min, start, count, callback)
+		sortedSetLex('zrevrangebylex', true, key, max, min, start, count, callback)
 	};
 
-	function sortedSetRangeByLex(method, key, min, max, start, count, callback) {
-		redisClient[method]([key, min, max, 'LIMIT', start, count], callback);
+	module.sortedSetRemoveRangeByLex = function (key, min, max) {
+		sortedSetLex('zremrangebylex', false, key, min, max, callback)
+	};
+
+	module.sortedSetLexCount = function (key, min, max) {
+		sortedSetLex('zlexcount', false, key, min, max, callback)
+	};
+
+	function sortedSetLex(method, reverse, key, min, max, start, count, callback) {
+		if (!callback) callback === start;
+
+		if (reverse) {
+			if (min !== '+') {
+				min = '(' + min;
+			}
+			if (max !== '-') {
+				max = '[' + max;
+			}
+		} else {
+			if (min !== '-') {
+				min = '[' + min;
+			}
+			if (max !== '+') {
+				max = '(' + max;
+			}
+		}
+
+		if (count) {
+			redisClient[method]([key, min, max, 'LIMIT', start, count], callback);
+		} else {
+			redisClient[method]([key, min, max], callback);
+		}
 	}
 
 	module.sortedSetIntersectCard = function (keys, callback) {

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -311,20 +311,22 @@ module.exports = function (redisClient, module) {
 	function sortedSetLex(method, reverse, key, min, max, start, count, callback) {
 		if (!callback) callback === start;
 
+		var minmin, maxmax;
 		if (reverse) {
-			if (min !== '+') {
-				min = '(' + min;
-			}
-			if (max !== '-') {
-				max = '[' + max;
-			}
+			minmin = '+';
+			maxmax = '-';
 		} else {
-			if (min !== '-') {
-				min = '[' + min;
-			}
-			if (max !== '+') {
-				max = '(' + max;
-			}
+			minmin = '-';
+			maxmax = '+';
+		}
+
+		if (min !== minmin) {
+			min = '' + min;
+			if (!min.match(/[\[\(]/)) min = '[' + min;
+		}
+		if (max !== maxmax) {
+			max = '' + max;
+			if (!max.match(/[\[\(]/)) max = '[' + max;
 		}
 
 		if (count) {

--- a/test/database/sorted.js
+++ b/test/database/sorted.js
@@ -19,7 +19,7 @@ describe('Sorted Set methods', function () {
 				db.sortedSetAdd('sortedSetTest3', [2, 4], ['value2', 'value4'], next);
 			},
 			function (next) {
-				db.sortedSetAdd('sortedSetLex', [0, 0, 0, 0], ['a', 'b', 'c', 'd'], done);
+				db.sortedSetAdd('sortedSetLex', [0, 0, 0, 0], ['a', 'b', 'c', 'd'], next);
 			}
 		], done);
 	});

--- a/test/database/sorted.js
+++ b/test/database/sorted.js
@@ -17,6 +17,9 @@ describe('Sorted Set methods', function () {
 			},
 			function (next) {
 				db.sortedSetAdd('sortedSetTest3', [2, 4], ['value2', 'value4'], next);
+			},
+			function (next) {
+				db.sortedSetAdd('sortedSetLex', [0, 0, 0, 0], ['a', 'b', 'c', 'd'], done);
 			}
 		], done);
 	});
@@ -694,6 +697,177 @@ describe('Sorted Set methods', function () {
 		});
 	});
 
+	describe('getSortedSetRangeByLex', function () {
+		it('should return an array of all values', function (done) {
+			db.getSortedSetRangeByLex('sortedSetLex', '-', '+', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['a', 'b', 'c', 'd']);
+				done();
+			});
+		});
+
+		it('should return an array with an inclusive range by default', function (done) {
+			db.getSortedSetRangeByLex('sortedSetLex', 'a', 'd', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['a', 'b', 'c', 'd']);
+				done();
+			});
+		});
+
+		it('should return an array with an inclusive range', function (done) {
+			db.getSortedSetRangeByLex('sortedSetLex', '[a', '[d', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['a', 'b', 'c', 'd']);
+				done();
+			});
+		});
+
+		it('should return an array with an exclusive range', function (done) {
+			db.getSortedSetRangeByLex('sortedSetLex', '(a', '(d', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['b', 'c']);
+				done();
+			});
+		});
+
+		it('should return an array limited to the first two values', function (done) {
+			db.getSortedSetRangeByLex('sortedSetLex', '-', '+', 0, 2, function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['a', 'b']);
+				done();
+			});
+		});
+	});
+
+	describe('getSortedSetRevRangeByLex', function () {
+		it('should return an array of all values reversed', function (done) {
+			db.getSortedSetRevRangeByLex('sortedSetLex', '+', '-', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['d', 'c', 'b', 'a']);
+				done();
+			});
+		});
+
+		it('should return an array with an inclusive range by default reversed', function (done) {
+			db.getSortedSetRevRangeByLex('sortedSetLex', 'd', 'a', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['d', 'c', 'b', 'a']);
+				done();
+			});
+		});
+
+		it('should return an array with an inclusive range reversed', function (done) {
+			db.getSortedSetRevRangeByLex('sortedSetLex', '[d', '[a', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['d', 'c', 'b', 'a']);
+				done();
+			});
+		});
+
+		it('should return an array with an exclusive range reversed', function (done) {
+			db.getSortedSetRevRangeByLex('sortedSetLex', '(d', '(a', function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['c', 'b']);
+				done();
+			});
+		});
+
+		it('should return an array limited to the first two values reversed', function (done) {
+			db.getSortedSetRevRangeByLex('sortedSetLex', '+', '-', 0, 2, function (err, data) {
+				assert.ifError(err);
+				assert.deepEqual(data, ['d', 'c']);
+				done();
+			});
+		});
+	});
+
+	describe('sortedSetLexCount', function () {
+		it('should return the count of all values', function (done) {
+			db.sortedSetLexCount('sortedSetLex', '-', '+', function (err, data) {
+				assert.ifError(err);
+				assert.strictEqual(data, 4);
+				done();
+			});
+		});
+
+		it('should return the count with an inclusive range by default', function (done) {
+			db.sortedSetLexCount('sortedSetLex', 'a', 'd', function (err, data) {
+				assert.ifError(err);
+				assert.strictEqual(data, 4);
+				done();
+			});
+		});
+
+		it('should return the count with an inclusive range', function (done) {
+			db.sortedSetLexCount('sortedSetLex', '[a', '[d', function (err, data) {
+				assert.ifError(err);
+				assert.strictEqual(data, 4);
+				done();
+			});
+		});
+
+		it('should return the count with an exclusive range', function (done) {
+			db.sortedSetLexCount('sortedSetLex', '(a', '(d', function (err, data) {
+				assert.ifError(err);
+				assert.strictEqual(data, 2);
+				done();
+			});
+		});
+	});
+
+	describe('sortedSetRemoveRangeByLex', function () {
+		before(function (done) {
+			db.sortedSetAdd('sortedSetLex2', [0, 0, 0, 0, 0, 0, 0], ['a', 'b', 'c', 'd', 'e', 'f', 'g'], done);
+		});
+
+		it('should remove an inclusive range by default', function (done) {
+			db.sortedSetRemoveRangeByLex('sortedSetLex2', 'a', 'b', function (err) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 1);
+				db.getSortedSetRangeByLex('sortedSetLex2', '-', '+', function (err, data) {
+					assert.ifError(err);
+					assert.deepEqual(data, ['c', 'd', 'e', 'f', 'g']);
+					done();
+				});
+			});
+		});
+
+		it('should remove an inclusive range', function (done) {
+			db.sortedSetRemoveRangeByLex('sortedSetLex2', '[c', '[d', function (err) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 1);
+				db.getSortedSetRangeByLex('sortedSetLex2', '-', '+', function (err, data) {
+					assert.ifError(err);
+					assert.deepEqual(data, ['e', 'f', 'g']);
+					done();
+				});
+			});
+		});
+
+		it('should remove an exclusive range', function (done) {
+			db.sortedSetRemoveRangeByLex('sortedSetLex2', '(e', '(g', function (err) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 1);
+				db.getSortedSetRangeByLex('sortedSetLex2', '-', '+', function (err, data) {
+					assert.ifError(err);
+					assert.deepEqual(data, ['e', 'g']);
+					done();
+				});
+			});
+		});
+
+		it('should remove all values', function (done) {
+			db.sortedSetRemoveRangeByLex('sortedSetLex2', '-', '+', function (err) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 1);
+				db.getSortedSetRangeByLex('sortedSetLex2', '-', '+', function (err, data) {
+					assert.ifError(err);
+					assert.deepEqual(data, []);
+					done();
+				});
+			});
+		});
+	});
 
 	after(function (done) {
 		db.flushdb(done);


### PR DESCRIPTION
Sorry for the large pr. Need these for a seekrit mission.

Have not tested on Mongo yet. Everything works as it should on redis.

I changed the min and max values so you can actually specify inclusive or exclusive ranges (defaults to inclusive). Previously, redis always set min to inclusive and max to exclusive, while mongo set both to inclusive, which was weird.