### PR TITLE
Ban UI fixes

### DIFF
--- a/public/src/client/account/header.js
+++ b/public/src/client/account/header.js
@@ -120,7 +120,7 @@ define('forum/account/header', [
 								data[cur.name] = cur.value;
 								return data;
 							}, {});
-							var until = formData.length ? (Date.now() + formData.length * 1000 * 60 * 60 * (parseInt(formData.unit, 10) ? 24 : 1)) : 0;
+							var until = parseInt(formData.length, 10) ? (Date.now() + formData.length * 1000 * 60 * 60 * (parseInt(formData.unit, 10) ? 24 : 1)) : 0;
 
 							socket.emit('user.banUsers', { uids: [ajaxify.data.theirid], until: until, reason: formData.reason || '' }, function (err) {
 								if (err) {

--- a/src/user/info.js
+++ b/src/user/info.js
@@ -123,7 +123,7 @@ module.exports = function (User) {
 			banObj.timestamp = parseInt(banObj.score, 10);
 			banObj.timestampReadable = new Date(banObj.score).toString();
 			banObj.timestampISO = new Date(banObj.score).toISOString();
-			banObj.reason = validator.escape(String(reasons[banObj.score])) || '[[user:info.banned-no-reason]]';
+			banObj.reason = validator.escape(String(reasons[banObj.score] || '')) || '[[user:info.banned-no-reason]]';
 
 			delete banObj.value;
 			delete banObj.score;

--- a/src/views/admin/partials/temporary-ban.tpl
+++ b/src/views/admin/partials/temporary-ban.tpl
@@ -3,7 +3,7 @@
 		<div class="col-xs-4">
 			<div class="form-group">
 				<label for="length">Ban Length</label>
-				<input class="form-control" id="length" name="length" type="number" min="1" value="1" />
+				<input class="form-control" id="length" name="length" type="number" min="0" value="1" />
 			</div>
 		</div>
 		<div class="col-xs-8">

--- a/test/user.js
+++ b/test/user.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var	assert = require('assert');
+var assert = require('assert');
 var async = require('async');
 var db = require('./mocks/databasemock');
 
@@ -424,6 +424,34 @@ describe('User', function () {
 				db.getObjectField('user:' + uid, 'cover:url', function (err, url) {
 					assert.ifError(err);
 					assert.equal(url, null);
+					done();
+				});
+			});
+		});
+	});
+
+	describe('.getModerationHistory', function () {
+		it('should return the correct ban reason', function (done) {
+			async.series([
+				function (next) {
+					User.ban(testUid, 0, '', function (err) {
+						assert.ifError(err);
+						next(err);
+					});
+				},
+				function (next) {
+					User.getModerationHistory(testUid, function (err, data) {
+						assert.ifError(err);
+						assert.equal(data.bans.length, 1, 'one ban');
+						assert.equal(data.bans[0].reason, '[[user:info.banned-no-reason]]', 'no ban reason');
+
+						next(err);
+					});
+				}
+			], function (err) {
+				assert.ifError(err);
+				User.unban(testUid, function (err) {
+					assert.ifError(err);
 					done();
 				});
 			});


### PR DESCRIPTION
- Permanent bans assigned by global moderators no longer expire immediately
  (does not apply retroactively)
- Bans with no reason given no longer have "undefined" as their reason
  (applies retroactively)
- 0 is now a selectable value for "ban duration, select 0 for permanent"
