### PR TITLE
isMain on topic.create for filter:post.create

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -134,6 +134,7 @@ module.exports = function (Topics) {
 				var postData = data;
 				postData.tid = tid;
 				postData.ip = data.req ? data.req.ip : null;
+				postData.isMain = true;
 				posts.create(postData, next);
 			},
 			function (postData, next) {


### PR DESCRIPTION
Right now there's no way to tell if the post passed to `filter:post.create` is the main post of a topic.