### PR TITLE
Added support for the HTTP/2 (h2) protocol through 'http2' or 'spdy' …

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "express": "^4.9.5",
     "express-session": "^1.8.2",
     "express-useragent": "0.2.4",
+    "spdy": "^3.4.4",
+    "http2": "^3.3.6",
     "html-to-text": "2.0.0",
     "ip": "1.1.2",
     "jimp": "0.2.21",

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -20,7 +20,22 @@ var path = require('path'),
 
 	helpers = require('../public/src/modules/helpers');
 
-if (nconf.get('ssl')) {
+if (nconf.get('http2')) {
+	var http2 = require('http2');
+	//express fix for http2
+	Object.setPrototypeOf(express.request, http2.IncomingMessage.prototype);
+	Object.setPrototypeOf(express.response, http2.ServerResponse.prototype);
+	server = http2.createServer({
+		key: fs.readFileSync(nconf.get('http2').key),
+		cert: fs.readFileSync(nconf.get('http2').cert)
+	}, app);
+} else if (nconf.get('spdy')) {
+	server = require('spdy').createServer({
+		key: fs.readFileSync(nconf.get('spdy').key),
+		cert: fs.readFileSync(nconf.get('spdy').cert),
+		spdy: nconf.get('spdy').opts
+	}, app);
+} else if (nconf.get('ssl')) {
 	server = require('https').createServer({
 		key: fs.readFileSync(nconf.get('ssl').key),
 		cert: fs.readFileSync(nconf.get('ssl').cert)


### PR DESCRIPTION
Added support for the HTTP/2 (h2) protocol through the following packages:

- **http2**
https://github.com/molnarg/node-http2

- **spdy**
https://github.com/indutny/node-spdy

![Nodebb Http2 support](https://photos-4.dropbox.com/t/2/AADkXk7L2u-D3m2CXQEW6S9u7w8EWqu4bTF3pm2lnmAutg/12/12879496/jpeg/32x32/3/1478898000/0/2/nodebb-http2.jpg/EIvAyAkY8NEDIAcoBw/XRQg0N5DfNqkKvbBZv1Ecs945gnNhmWwTGMaJUScHX4?size_mode=3&dl=0&size=2048x1536)


As with ssl, to enable them, you need to add related information to config.json:

### http2

    {
        "url": "http://127.0.0.1:4567",
        "secret": "8c057569-0c46-4ec3-bb42-0c68106446e5",
        "database": "mongo",
        "port": 4567,
        "mongo": {
            "host": "127.0.0.1",
            "port": "27017",
            "database": "nodebb"
        },
        "http2": {
	     	 "key": "/etc/ssl/test.key",
	     	 "cert": "/etc/ssl/test.crt"
        }
    }


### spdy

    {
        "url": "http://127.0.0.1:4567",
        "secret": "8c057569-0c46-4ec3-bb42-0c68106446e5",
        "database": "mongo",
        "port": 4567,
        "mongo": {
            "host": "127.0.0.1",
            "port": "27017",
            "database": "nodebb"
        },
        "spdy": {
	     	 "key": "/etc/ssl/test.key",
	 	 "cert": "/etc/ssl/test.crt"
         }
    }



Both work, but using HAProxy as load balancer only **spdy** packages works well.
The configs I used for the test are:

### nodebb

    {
        "url": "http://127.0.0.1:4567",
        "secret": "8c057569-0c46-4ec3-bb42-0c68106446e5",
        "database": "mongo",
        "port": 4567,
        "mongo": {
            "host": "127.0.0.1",
            "port": "27017",
            "database": "nodebb"
        },
        "spdy": {
	 	"key": "/etc/ssl/test.key",
	 	"cert": "/etc/ssl/test.crt",
	 	"opts": {
                    "protocol": "h2",
                    "protocols": [ "h2", "spdy/3.1", "spdy/2.1", "http/1.1" ]
	 	}
        }
    }

### HAProxy

    global
        #debug
        chroot /var/lib/haproxy
        user haproxy
        group haproxy
        pidfile /var/run/haproxy.pid
    
        # Default SSL material locations
        ca-base /etc/ssl/certs
        crt-base /etc/ssl/private
    
        # Default ciphers to use on SSL-enabled listening sockets.
        ssl-default-bind-options   no-sslv3 no-tls-tickets force-tlsv12
        ssl-default-bind-ciphers   ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
    
        spread-checks 4
        tune.maxrewrite 1024
        tune.ssl.default-dh-param 2048
    
    defaults
        mode    http
        balance roundrobin
    
        option  dontlognull
        option  dontlog-normal
        option  redispatch
    
        maxconn 5000
        timeout connect 30s
        timeout client  30s
        timeout server  60s
        timeout queue   30s
        timeout http-request 10s
        timeout http-keep-alive 60s
    
    frontend http-in
        bind *:80
    
        stats enable
        stats refresh 30s
        #stats hide-version
        stats realm Strictly\ Private
        stats auth admin:admin
        stats uri /admin?stats
        
        redirect scheme https if !{ ssl_fc }
        
        default_backend nodes-http
    
    frontend https-in
        mode tcp
        bind *:443 ssl crt /etc/ssl/cert.pem alpn h2,http/1.1
        http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;"
        use_backend nodes-http2 if { ssl_fc_alpn -i h2 }
        default_backend nodes-http
    
    backend nodes-http
        server node1 172.59.238.121:4567 check ssl verify none
    
    backend nodes-http2
        mode tcp
        http-request add-header X-Forwarded-Proto https
        server node1 172.59.238.121:4567 check ssl verify none send-proxy
