### PR TITLE
Add missing relative path to Admin tags and widgets links

### DIFF
--- a/src/views/admin/extend/widgets.tpl
+++ b/src/views/admin/extend/widgets.tpl
@@ -33,7 +33,7 @@
 				<div class="available-widgets">
 					<p>Select a widget from the dropdown menu and then drag and drop it into a template's widget area on the left.</p>
 					<!-- IF !widgets.length -->
-					<div class="alert alert-info">No widgets found! Activate the essential widgets plugin in the <a href="/admin/extend/plugins">plugins</a> control panel.</div>
+					<div class="alert alert-info">No widgets found! Activate the essential widgets plugin in the <a href="{config.relative_path}/admin/extend/plugins">plugins</a> control panel.</div>
 					<!-- ENDIF !widgets.length -->
 					<p>
 						<select id="widget-selector" class="form-control">

--- a/src/views/admin/manage/tags.tpl
+++ b/src/views/admin/manage/tags.tpl
@@ -44,7 +44,7 @@
 		<div class="panel panel-default">
 			<div class="panel-body">
 				<input class="form-control" type="text" id="tag-search" placeholder="Search for tags..."/><br/>
-				Click <a href="/admin/settings/tags">here</a> to visit the tag settings page.
+				Click <a href="{config.relative_path}/admin/settings/tags">here</a> to visit the tag settings page.
 			</div>
 		</div>
 	</div>

--- a/src/views/admin/settings/tags.tpl
+++ b/src/views/admin/settings/tags.tpl
@@ -21,7 +21,7 @@
 				<input id="maximumTagLength" type="text" class="form-control" value="15" data-field="maximumTagLength">
 			</div>
 		</form>
-		Click <a href="/admin/manage/tags">here</a> to visit the tag management page.
+		Click <a href="{config.relative_path}/admin/manage/tags">here</a> to visit the tag management page.
 	</div>
 </div>
 


### PR DESCRIPTION
These were missing on some links in Extend -> Widgets and between the Tags pages, causing 404s when using a relative path.