### PR TITLE
Replace only base URL in login return URL, fixes #5205

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -104,7 +104,7 @@ Controllers.login = function (req, res, next) {
 	var registrationType = meta.config.registrationType || 'normal';
 
 	var allowLoginWith = (meta.config.allowLoginWith || 'username-email');
-	var returnTo = (req.headers['x-return-to'] || '').replace(nconf.get('url'), '');
+	var returnTo = (req.headers['x-return-to'] || '').replace(nconf.get('base_url'), '');
 
 	var errorText;
 	if (req.query.error === 'csrf-invalid') {


### PR DESCRIPTION
The entire configuration url (base_url + relative path) is being removed from the login redirect URL. Just the base url should be removed, so that the relative path and destination remain.