### PR TITLE
ZSET scores are float: parseInt => parseFloat

### DIFF
--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -17,7 +17,7 @@ module.exports = function (db, module) {
 
 		value = helpers.valueToString(value);
 
-		db.collection('objects').update({_key: key, value: value}, {$set: {score: parseInt(score, 10)}}, {upsert:true, w: 1}, function (err) {
+		db.collection('objects').update({_key: key, value: value}, {$set: {score: parseFloat(score)}}, {upsert:true, w: 1}, function (err) {
 			if (err && err.message.startsWith('E11000 duplicate key error')) {
 				return process.nextTick(module.sortedSetAdd, key, score, value, callback);
 			}
@@ -38,7 +38,7 @@ module.exports = function (db, module) {
 		var bulk = db.collection('objects').initializeUnorderedBulkOp();
 
 		for(var i = 0; i < scores.length; ++i) {
-			bulk.find({_key: key, value: values[i]}).upsert().updateOne({$set: {score: parseInt(scores[i], 10)}});
+			bulk.find({_key: key, value: values[i]}).upsert().updateOne({$set: {score: parseFloat(scores[i])}});
 		}
 
 		bulk.execute(function (err) {
@@ -56,7 +56,7 @@ module.exports = function (db, module) {
 		var bulk = db.collection('objects').initializeUnorderedBulkOp();
 
 		for(var i = 0; i < keys.length; ++i) {
-			bulk.find({_key: keys[i], value: value}).upsert().updateOne({$set: {score: parseInt(score, 10)}});
+			bulk.find({_key: keys[i], value: value}).upsert().updateOne({$set: {score: parseFloat(score)}});
 		}
 
 		bulk.execute(function (err) {
@@ -564,7 +564,7 @@ module.exports = function (db, module) {
 		}
 		var data = {};
 		value = helpers.valueToString(value);
-		data.score = parseInt(increment, 10);
+		data.score = parseFloat(increment);
 
 		db.collection('objects').findAndModify({_key: key, value: value}, {}, {$inc: data}, {new: true, upsert: true}, function (err, result) {
 			// if there is duplicate key error retry the upsert

--- a/src/database/redis/sorted.js
+++ b/src/database/redis/sorted.js
@@ -115,7 +115,7 @@ module.exports = function (redisClient, module) {
 			}
 			var objects = [];
 			for(var i = 0; i < data.length; i += 2) {
-				objects.push({value: data[i], score: parseInt(data[i + 1], 10)});
+				objects.push({value: data[i], score: parseFloat(data[i + 1])});
 			}
 			callback(null, objects);
 		});
@@ -144,7 +144,7 @@ module.exports = function (redisClient, module) {
 			}
 			var objects = [];
 			for(var i = 0; i < data.length; i += 2) {
-				objects.push({value: data[i], score: parseInt(data[i + 1], 10)});
+				objects.push({value: data[i], score: parseFloat(data[i + 1])});
 			}
 			callback(null, objects);
 		});
@@ -195,7 +195,7 @@ module.exports = function (redisClient, module) {
 
 	module.sortedSetScore = function (key, value, callback) {
 		redisClient.zscore(key, value, function (err, score) {
-			callback(err, !err ? parseInt(score, 10) : undefined);
+			callback(err, !err ? parseFloat(score) : undefined);
 		});
 	};
 
@@ -289,7 +289,7 @@ module.exports = function (redisClient, module) {
 			results = results[1] || [];
 			var objects = [];
 			for(var i = 0; i < results.length; i += 2) {
-				objects.push({value: results[i], score: parseInt(results[i + 1], 10)});
+				objects.push({value: results[i], score: parseFloat(results[i + 1])});
 			}
 			callback(null, objects);
 		});
@@ -297,7 +297,7 @@ module.exports = function (redisClient, module) {
 
 	module.sortedSetIncrBy = function (key, increment, value, callback) {
 		redisClient.zincrby(key, increment, value, function (err, newValue) {
-			callback(err, !err ? parseInt(newValue, 10) : undefined);
+			callback(err, !err ? parseFloat(newValue) : undefined);
 		});
 	};
 

--- a/test/database/sorted.js
+++ b/test/database/sorted.js
@@ -10,7 +10,7 @@ describe('Sorted Set methods', function () {
 	before(function (done) {
 		async.parallel([
 			function (next) {
-				db.sortedSetAdd('sortedSetTest1', [1, 2, 3], ['value1', 'value2', 'value3'], next);
+				db.sortedSetAdd('sortedSetTest1', [1.1, 1.2, 1.3], ['value1', 'value2', 'value3'], next);
 			},
 			function (next) {
 				db.sortedSetAdd('sortedSetTest2', [1, 4], ['value1', 'value4'], next);
@@ -97,7 +97,7 @@ describe('Sorted Set methods', function () {
 			db.getSortedSetRangeWithScores('sortedSetTest1', 0, -1, function (err, values) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.deepEqual(values, [{value: 'value1', score: 1}, {value: 'value2', score: 2}, {value: 'value3', score: 3}]);
+				assert.deepEqual(values, [{value: 'value1', score: 1.1}, {value: 'value2', score: 1.2}, {value: 'value3', score: 1.3}]);
 				done();
 			});
 		});
@@ -108,7 +108,7 @@ describe('Sorted Set methods', function () {
 			db.getSortedSetRevRangeWithScores('sortedSetTest1', 0, -1, function (err, values) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.deepEqual(values, [{value: 'value3', score: 3}, {value: 'value2', score: 2}, {value: 'value1', score: 1}]);
+				assert.deepEqual(values, [{value: 'value3', score: 1.3}, {value: 'value2', score: 1.2}, {value: 'value1', score: 1.1}]);
 				done();
 			});
 		});
@@ -116,7 +116,7 @@ describe('Sorted Set methods', function () {
 
 	describe('getSortedSetRangeByScore()', function () {
 		it('should get count elements with score between min max sorted by score lowest to highest', function (done) {
-			db.getSortedSetRangeByScore('sortedSetTest1', 0, -1, '-inf', 2, function (err, values) {
+			db.getSortedSetRangeByScore('sortedSetTest1', 0, -1, '-inf', 1.2, function (err, values) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
 				assert.deepEqual(values, ['value1', 'value2']);
@@ -127,7 +127,7 @@ describe('Sorted Set methods', function () {
 
 	describe('getSortedSetRevRangeByScore()', function () {
 		it('should get count elements with score between max min sorted by score highest to lowest', function (done) {
-			db.getSortedSetRevRangeByScore('sortedSetTest1', 0, -1, '+inf', 2, function (err, values) {
+			db.getSortedSetRevRangeByScore('sortedSetTest1', 0, -1, '+inf', 1.2, function (err, values) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
 				assert.deepEqual(values, ['value3', 'value2']);
@@ -138,10 +138,10 @@ describe('Sorted Set methods', function () {
 
 	describe('getSortedSetRangeByScoreWithScores()', function () {
 		it('should get count elements with score between min max sorted by score lowest to highest with scores', function (done) {
-			db.getSortedSetRangeByScoreWithScores('sortedSetTest1', 0, -1, '-inf', 2, function (err, values) {
+			db.getSortedSetRangeByScoreWithScores('sortedSetTest1', 0, -1, '-inf', 1.2, function (err, values) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.deepEqual(values, [{value: 'value1', score: 1}, {value: 'value2', score: 2}]);
+				assert.deepEqual(values, [{value: 'value1', score: 1.1}, {value: 'value2', score: 1.2}]);
 				done();
 			});
 		});
@@ -149,10 +149,10 @@ describe('Sorted Set methods', function () {
 
 	describe('getSortedSetRevRangeByScoreWithScores()', function () {
 		it('should get count elements with score between max min sorted by score highest to lowest', function (done) {
-			db.getSortedSetRevRangeByScoreWithScores('sortedSetTest1', 0, -1, '+inf', 2, function (err, values) {
+			db.getSortedSetRevRangeByScoreWithScores('sortedSetTest1', 0, -1, '+inf', 1.2, function (err, values) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.deepEqual(values, [{value: 'value3', score: 3}, {value: 'value2', score: 2}]);
+				assert.deepEqual(values, [{value: 'value3', score: 1.3}, {value: 'value2', score: 1.2}]);
 				done();
 			});
 		});
@@ -169,7 +169,7 @@ describe('Sorted Set methods', function () {
 		});
 
 		it('should return number of elements between scores min max inclusive', function (done) {
-			db.sortedSetCount('sortedSetTest1', '-inf', 2, function (err, count) {
+			db.sortedSetCount('sortedSetTest1', '-inf', 1.2, function (err, count) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
 				assert.equal(count, 2);
@@ -321,7 +321,7 @@ describe('Sorted Set methods', function () {
 			db.sortedSetScore('sortedSetTest1', 'value2', function (err, score) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.equal(score, 2);
+				assert.equal(score, 1.2);
 				done();
 			});
 		});
@@ -332,7 +332,7 @@ describe('Sorted Set methods', function () {
 			db.sortedSetsScore(['sortedSetTest1', 'sortedSetTest2', 'doesnotexist'], 'value1', function (err, scores) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.deepEqual(scores, [1, 1, null]);
+				assert.deepEqual(scores, [1.1, 1, null]);
 				done();
 			});
 		});
@@ -355,7 +355,7 @@ describe('Sorted Set methods', function () {
 			db.sortedSetScores('sortedSetTest1', ['value2', 'value1', 'doesnotexist'], function (err, scores) {
 				assert.equal(err, null);
 				assert.equal(arguments.length, 2);
-				assert.deepEqual(scores, [2, 1, null]);
+				assert.deepEqual(scores, [1.2, 1.1, null]);
 				done();
 			});
 		});


### PR DESCRIPTION
In Redis, scores in sorted sets can be floats – so we should use `parseFloat` instead of `parseInt` when converting from string to number.
Should not lead to #4939 again, as `new Date()` works regardless of whether it's being passed a float or integer (both being represented by the same data type in js)
