### PR TITLE
Avoid HTML codes in Twitter social share text

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -15,7 +15,7 @@ define('forum/topic/postTools', ['share', 'navigator', 'components', 'translator
 
 		addPostHandlers(tid);
 
-		share.addShareHandlers(ajaxify.data.title);
+		share.addShareHandlers(ajaxify.data.titleRaw);
 
 		addVoteHandler();
 


### PR DESCRIPTION
When using the Topic social share option to share via Twitter, the topic title can sometimes include html codes.

```
> ajaxify.data.title
"Stuwil&#x27;s post"
```

The titleRaw attribute should be used to return plaintext, which will then be URI encoded.


```
> ajaxify.data.titleRaw
"Stuwil's post"
```
