### PR TITLE
Check if href exists before accessing it

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -366,7 +366,7 @@ $(document).ready(function () {
 			}
 
 			// Default behaviour for rss feeds
-			if (internalLink && $(this).attr('href').endsWith('.rss')) {
+			if (internalLink && $(this).attr('href') && $(this).attr('href').endsWith('.rss')) {
 				return;
 			}
 


### PR DESCRIPTION
I got a lot of errors in Firefox 50 `TypeError: $(...).attr(...) is undefined  nodebb.min.js:25167:24` which points exactly to that line I’ve changed.
Since HTML5 `href` is not a required attribute of an `a` tag. We have a couple of links without `href` and every time you click it you will get this error.