### PR TITLE
Check password length on setup and prompt again

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -221,8 +221,8 @@ function createAdministrator(next) {
 
 function createAdmin(callback) {
 	var User = require('./user');
-	var	Groups = require('./groups');
-	var	password;
+	var Groups = require('./groups');
+	var password;
 	var meta = require('./meta');
 
 	winston.warn('No administrators have been detected, running initial user setup\n');

--- a/src/install.js
+++ b/src/install.js
@@ -220,9 +220,10 @@ function createAdministrator(next) {
 }
 
 function createAdmin(callback) {
-	var User = require('./user'),
-		Groups = require('./groups'),
-		password;
+	var User = require('./user');
+	var	Groups = require('./groups');
+	var	password;
+	var meta = require('./meta');
 
 	winston.warn('No administrators have been detected, running initial user setup\n');
 
@@ -262,6 +263,12 @@ function createAdmin(callback) {
 				winston.warn("Passwords did not match, please try again");
 				return retryPassword(results);
 			}
+			
+			if (results.password.length < meta.config.minimumPasswordLength) {
+				winston.warn("Password too short, please try again");
+				return retryPassword(results);
+			}
+			
 			var adminUid;
 			async.waterfall([
 				function (next) {


### PR DESCRIPTION
Check the password length on `./nodebb setup` and prompt for re-entry if requirements not met.

Right now setup fails on admin account creation if password is too short and running `./nodebb setup` again without deleting the existing `config.json` created by the failed setup, admin account prompts do not show up.

Set up automatically creates an admin account with a random password and displays the credentials on console and it's easy to miss them with all the other messages setup generates.