### PR TITLE
fix ajax 404 err when base url isn't root

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -148,7 +148,7 @@ module.exports = function (app, middleware, hotswapIds) {
 	app.use(relativePath, express.static(path.join(__dirname, '../../', 'public'), {
 		maxAge: app.enabled('cache') ? 5184000000 : 0
 	}));
-	app.use('/vendor/jquery/timeago/locales', middleware.processTimeagoLocales);
+	app.use(relativePath + '/vendor/jquery/timeago/locales', middleware.processTimeagoLocales);
 	app.use(controllers.handle404);
 	app.use(controllers.handleURIErrors);
 	app.use(controllers.handleErrors);


### PR DESCRIPTION
If language is not english and 'url' in config.json is '/forum'
an error happens in browser like 
`
GET http://xxxxx.com/forum/vendor/jquery/timeago/locales/jquery.timeago.zh-CN-short.js?_=1481707302832 404 (Not Found)
`