### PR TITLE
Plugins: inject NodeBB API object to plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "istanbul": "^0.4.2",
     "mocha": "~3.1.0",
     "mocha-lcov-reporter": "^1.2.0",
+    "sinon": "^1.17.6",
     "xmlhttprequest": "1.8.0",
     "xmlhttprequest-ssl": "1.5.3"
   },

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,10 @@
+module.exports = {
+	categories: require('./categories'),
+	database: require('./database'),
+	groups: require('./groups'),
+	meta: require('./meta'),
+	posts: require('./posts'),
+	privileges: require('./privileges'),
+	topics: require('./topics'),
+	user: require('./user')
+};

--- a/src/plugins/load.js
+++ b/src/plugins/load.js
@@ -58,7 +58,13 @@ module.exports = function (Plugins) {
 		], callback);
 	};
 
-	Plugins.loadPlugin = function (pluginPath, callback) {
+	Plugins.loadPlugin = function (pluginPath, api, callback) {
+		var args = _.toArray(arguments);
+
+		if (args.length === 2) {
+			callback = api;
+			api = null;
+		}
 		Plugins.loadPluginInfo(pluginPath, function (err, pluginData) {
 			if (err) {
 				if (err.message === '[[error:parse-error]]') {
@@ -71,7 +77,7 @@ module.exports = function (Plugins) {
 
 			async.parallel([
 				function (next) {
-					registerHooks(pluginData, pluginPath, next);
+					registerHooks(pluginData, pluginPath, api, next);
 				},
 				function (next) {
 					mapStaticDirectories(pluginData, pluginPath, next);
@@ -119,16 +125,23 @@ module.exports = function (Plugins) {
 		}
 	}
 
-	function registerHooks(pluginData, pluginPath, callback) {
+	function registerHooks(pluginData, pluginPath, api, callback) {
 		if (!pluginData.library) {
 			return callback();
+		}
+
+		var args = _.toArray(arguments);
+
+		if (args.length === 3) {
+			callback = api;
+			api = null;
 		}
 
 		var libraryPath = path.join(pluginPath, pluginData.library);
 
 		try {
 			if (!Plugins.libraries[pluginData.id]) {
-				Plugins.requireLibrary(pluginData.id, libraryPath);
+				Plugins.requireLibrary(pluginData.id, libraryPath, api);
 			}
 
 			if (Array.isArray(pluginData.hooks) && pluginData.hooks.length > 0) {

--- a/test/fixtures/plugins/plugin-api/index.js
+++ b/test/fixtures/plugins/plugin-api/index.js
@@ -1,0 +1,5 @@
+module.exports = function (api) {
+	api.foo();
+
+	return { any: 'plugin-method' };
+};

--- a/test/fixtures/plugins/plugin-api/package.json
+++ b/test/fixtures/plugins/plugin-api/package.json
@@ -1,0 +1,3 @@
+{
+    "name": "plugin-api"
+}

--- a/test/fixtures/plugins/plugin-api/plugin.json
+++ b/test/fixtures/plugins/plugin-api/plugin.json
@@ -1,0 +1,3 @@
+{
+    "library": "index.js"
+}

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -5,6 +5,7 @@ var	assert = require('assert');
 var path = require('path');
 var nconf = require('nconf');
 var request = require('request');
+var sinon = require('sinon');
 
 var db = require('./mocks/databasemock');
 var plugins = require('../src/plugins');
@@ -179,7 +180,22 @@ describe('Plugins', function () {
 		});
 	});
 
+	describe('API', function () {
+		it('should inject the given API object to the plugin when the plugin exports a function', function (done) {
+			var api = { foo: sinon.stub() };
 
+			plugins.loadPlugin(path.join(__dirname, 'fixtures/plugins/plugin-api'), api, function (err) {
+				assert.ifError(err);
+				assert.strictEqual(api.foo.calledOnce, true);
+
+				var loadedPlugin = plugins.libraries['plugin-api'];
+
+				assert.deepStrictEqual(loadedPlugin, { any: 'plugin-method' });
+
+				done();
+			});
+		});
+	});
 
 });
 


### PR DESCRIPTION
Refs: #5255

This implements the dependency injection proposal described in #5255 for plugins.
The change is fully backwards compatible, so existing plugins will continue to work without any change.
I’ve introduced a public API object in `src/api.js`, which doesn’t include everything right now, we can easily add more modules in the future.

Feedback welcomed 😉 .