### PR TITLE
feat: Allow text selection of Topic

### DIFF
--- a/public/src/modules/topicSelect.js
+++ b/public/src/modules/topicSelect.js
@@ -10,9 +10,6 @@ define('topicSelect', ['components'], function (components) {
 
 	TopicSelect.init = function (onSelect) {
 		topicsContainer = $('[component="category"]');
-		topicsContainer.on('selectstart', function () {
-			return false;
-		});
 
 		topicsContainer.on('click', '[component="topic/select"]', function (ev) {
 			var select = $(this);


### PR DESCRIPTION
Allows the text selection of topics via the standard browser controls

Recently we discovered that portions of NodeBB explicitly disallow selection of hypertext references in an inconsistent manner. Due to the inconsistent nature of this restriction and the fact that it acts against user expectations, I am issuing this PR to remove the block to selection of link text and bring the application as a whole a measure of increased consistency.

:-)

Discussions can be seen here: https://what.thedailywtf.com/topic/21709/link-text-selection-broken