### PR TITLE
Allow text selection on /unread

### DIFF
--- a/public/src/modules/topicSelect.js
+++ b/public/src/modules/topicSelect.js
@@ -10,9 +10,9 @@ define('topicSelect', ['components'], function (components) {
 
 	TopicSelect.init = function (onSelect) {
 		topicsContainer = $('[component="category"]');
-		topicsContainer.on('selectstart', function () {
-			return false;
-		});
+                topicsContainer.on('selectstart', '[component="topic/select"]', function (ev) {
+                        ev.preventDefault();
+                });
 
 		topicsContainer.on('click', '[component="topic/select"]', function (ev) {
 			var select = $(this);


### PR DESCRIPTION
Tweak to allow the shift + click behaviour for the checkboxes while still letting the browser selection behaviour work as expected