### PR TITLE
Add settings to allow multiple badges to be displayed

### DIFF
--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -51,6 +51,7 @@ apiController.getConfig = function (req, res, next) {
 	config.topicsPerPage = meta.config.topicsPerPage || 20;
 	config.postsPerPage = meta.config.postsPerPage || 20;
 	config.maximumFileSize = meta.config.maximumFileSize;
+	config.showMultipleBadges = parseInt(meta.config.showMultipleBadges, 10) === 1;;
 	config['theme:id'] = meta.config['theme:id'];
 	config['theme:src'] = meta.config['theme:src'];
 	config.defaultLang = meta.config.defaultLang || 'en-GB';

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -51,7 +51,7 @@ apiController.getConfig = function (req, res, next) {
 	config.topicsPerPage = meta.config.topicsPerPage || 20;
 	config.postsPerPage = meta.config.postsPerPage || 20;
 	config.maximumFileSize = meta.config.maximumFileSize;
-	config.showMultipleBadges = parseInt(meta.config.showMultipleBadges, 10) === 1;;
+	config.showMultipleBadges = parseInt(meta.config.showMultipleBadges, 10) === 1;
 	config['theme:id'] = meta.config['theme:id'];
 	config['theme:src'] = meta.config['theme:src'];
 	config.defaultLang = meta.config.defaultLang || 'en-GB';

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -124,7 +124,7 @@ topicsController.get = function (req, res, callback) {
 
 			topics.modifyPostsByPrivilege(topicData, userPrivileges);
 
-			plugins.fireHook('filter:controllers.topic.get', {topicData: topicData, uid: req.uid}, next);
+			plugins.fireHook('filter:controllers.topic.get', { topicData: topicData, uid: req.uid }, next);
 		},
 		function (data, next) {
 
@@ -148,7 +148,7 @@ topicsController.get = function (req, res, callback) {
 		},
 		function (topicData, next) {
 			function findPost(index) {
-				for(var i = 0; i < topicData.posts.length; ++i) {
+				for (var i = 0; i < topicData.posts.length; ++i) {
 					if (parseInt(topicData.posts[i].index, 10) === parseInt(index, 10)) {
 						return topicData.posts[i];
 					}
@@ -316,7 +316,7 @@ topicsController.teaser = function (req, res, next) {
 			if (!pid) {
 				return res.status(404).json('not-found');
 			}
-			posts.getPostSummaryByPids([pid], req.uid, {stripTags: false}, next);
+			posts.getPostSummaryByPids([pid], req.uid, { stripTags: false }, next);
 		}
 	], function (err, posts) {
 		if (err) {

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -1,6 +1,5 @@
 "use strict";
 
-
 var async = require('async');
 var S = require('string');
 var nconf = require('nconf');
@@ -265,6 +264,7 @@ topicsController.get = function (req, res, callback) {
 		data.bookmarkThreshold = parseInt(meta.config.bookmarkThreshold, 10) || 5;
 		data.postEditDuration = parseInt(meta.config.postEditDuration, 10) || 0;
 		data.postDeleteDuration = parseInt(meta.config.postDeleteDuration, 10) || 0;
+		data.showMultipleBadges = parseInt(meta.config.showMultipleBadges, 10) === 1;
 		data.scrollToMyPost = settings.scrollToMyPost;
 		data.rssFeedUrl = nconf.get('relative_path') + '/topic/' + data.tid + '.rss';
 		data.pagination = pagination.create(currentPage, pageCount, req.query);

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -124,7 +124,7 @@ topicsController.get = function (req, res, callback) {
 
 			topics.modifyPostsByPrivilege(topicData, userPrivileges);
 
-			plugins.fireHook('filter:controllers.topic.get', { topicData: topicData, uid: req.uid }, next);
+			plugins.fireHook('filter:controllers.topic.get', {topicData: topicData, uid: req.uid}, next);
 		},
 		function (data, next) {
 
@@ -148,7 +148,7 @@ topicsController.get = function (req, res, callback) {
 		},
 		function (topicData, next) {
 			function findPost(index) {
-				for (var i = 0; i < topicData.posts.length; ++i) {
+				for(var i = 0; i < topicData.posts.length; ++i) {
 					if (parseInt(topicData.posts[i].index, 10) === parseInt(index, 10)) {
 						return topicData.posts[i];
 					}
@@ -316,7 +316,7 @@ topicsController.teaser = function (req, res, next) {
 			if (!pid) {
 				return res.status(404).json('not-found');
 			}
-			posts.getPostSummaryByPids([pid], req.uid, { stripTags: false }, next);
+			posts.getPostSummaryByPids([pid], req.uid, {stripTags: false}, next);
 		}
 	], function (err, posts) {
 		if (err) {

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -104,7 +104,7 @@ module.exports = function (Posts) {
 						return next(err);
 					}
 
-					userData.allGroups = userGroupsMap[userData.uid];
+					userData.allGroups = userGroupsMap[userData.uid] || [];
 
 					if (results.isMemberOfGroup && userData.groupTitle && groupsMap[userData.groupTitle]) {
 						userData.selectedGroup = groupsMap[userData.groupTitle];

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -31,6 +31,10 @@ module.exports = function (Posts) {
 					groupsData: async.apply(groups.getGroupsData, groupTitles),
 					userGroups: function (cb) {
 						groups.getUserGroups(uids, function (err, groups) {
+							if (err) {
+								return cb(err);
+							}
+
 							var allGroups = [];
 							groups.forEach(function (group, i) {
 								userGroupsMap[uids[i]] = group;

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -30,6 +30,10 @@ module.exports = function (Posts) {
 				async.parallel({
 					groupsData: async.apply(groups.getGroupsData, groupTitles),
 					userGroups: function (cb) {
+						if (parseInt(meta.config.showMultipleBadges, 10) !== 1) {
+							return cb(null, {});
+						}
+
 						groups.getUserGroups(uids, function (err, groups) {
 							if (err) {
 								return cb(err);
@@ -100,11 +104,19 @@ module.exports = function (Posts) {
 						return next(err);
 					}
 
+					userData.allGroups = userGroupsMap[userData.uid];
+
 					if (results.isMemberOfGroup && userData.groupTitle && groupsMap[userData.groupTitle]) {
 						userData.selectedGroup = groupsMap[userData.groupTitle];
-					}
 
-					userData.allGroups = userGroupsMap[userData.uid];
+						for (var i = 0; i < userData.allGroups.length; i++) {
+							if (userData.allGroups[i].name === userData.selectedGroup.name) {
+								userData.allGroups.splice(i, 1);
+								userData.allGroups.unshift(userData.selectedGroup);
+								break;
+							}
+						}
+					}
 
 					userData.custom_profile_info = results.customProfileInfo.profile;
 

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -28,7 +28,7 @@ module.exports = function (Topics) {
 	};
 
 	Topics.getTopicPosts = function (tid, set, start, stop, uid, reverse, callback) {
-		callback = callback || function () { };
+		callback = callback || function () {};
 		async.parallel({
 			posts: function (next) {
 				posts.getPostsFromSet(set, start, stop, uid, reverse, next);
@@ -69,7 +69,7 @@ module.exports = function (Topics) {
 			userData: function (next) {
 				var uids = [];
 
-				for (var i = 0; i < postData.length; ++i) {
+				for(var i = 0; i < postData.length; ++i) {
 					if (postData[i] && uids.indexOf(postData[i].uid) === -1) {
 						uids.push(postData[i].uid);
 					}
@@ -90,7 +90,7 @@ module.exports = function (Topics) {
 			},
 			editors: function (next) {
 				var editors = [];
-				for (var i = 0; i < postData.length; ++i) {
+				for(var i = 0; i < postData.length; ++i) {
 					if (postData[i] && postData[i].editor && editors.indexOf(postData[i].editor) === -1) {
 						editors.push(postData[i].editor);
 					}
@@ -186,7 +186,7 @@ module.exports = function (Topics) {
 				});
 				var parents = {};
 				parentPosts.forEach(function (post, i) {
-					parents[parentPids[i]] = { username: usersMap[post.uid] };
+					parents[parentPids[i]] = {username: usersMap[post.uid]};
 				});
 
 				postData.forEach(function (post) {
@@ -349,7 +349,7 @@ module.exports = function (Topics) {
 	};
 
 	function incrementFieldAndUpdateSortedSet(tid, field, by, set, callback) {
-		callback = callback || function () { };
+		callback = callback || function () {};
 		db.incrObjectFieldBy('topic:' + tid, field, by, function (err, value) {
 			if (err) {
 				return callback(err);

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -28,7 +28,7 @@ module.exports = function (Topics) {
 	};
 
 	Topics.getTopicPosts = function (tid, set, start, stop, uid, reverse, callback) {
-		callback = callback || function () {};
+		callback = callback || function () { };
 		async.parallel({
 			posts: function (next) {
 				posts.getPostsFromSet(set, start, stop, uid, reverse, next);
@@ -69,7 +69,7 @@ module.exports = function (Topics) {
 			userData: function (next) {
 				var uids = [];
 
-				for(var i = 0; i < postData.length; ++i) {
+				for (var i = 0; i < postData.length; ++i) {
 					if (postData[i] && uids.indexOf(postData[i].uid) === -1) {
 						uids.push(postData[i].uid);
 					}
@@ -90,7 +90,7 @@ module.exports = function (Topics) {
 			},
 			editors: function (next) {
 				var editors = [];
-				for(var i = 0; i < postData.length; ++i) {
+				for (var i = 0; i < postData.length; ++i) {
 					if (postData[i] && postData[i].editor && editors.indexOf(postData[i].editor) === -1) {
 						editors.push(postData[i].editor);
 					}
@@ -186,7 +186,7 @@ module.exports = function (Topics) {
 				});
 				var parents = {};
 				parentPosts.forEach(function (post, i) {
-					parents[parentPids[i]] = {username: usersMap[post.uid]};
+					parents[parentPids[i]] = { username: usersMap[post.uid] };
 				});
 
 				postData.forEach(function (post) {
@@ -349,7 +349,7 @@ module.exports = function (Topics) {
 	};
 
 	function incrementFieldAndUpdateSortedSet(tid, field, by, set, callback) {
-		callback = callback || function () {};
+		callback = callback || function () { };
 		db.incrObjectFieldBy('topic:' + tid, field, by, function (err, value) {
 			if (err) {
 				return callback(err);

--- a/src/views/admin/settings/group.tpl
+++ b/src/views/admin/settings/group.tpl
@@ -29,6 +29,20 @@
 				[[admin/settings/group:allow-creation-help]]
 			</p>
 
+			<div class="checkbox">
+				<label class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
+					<input class="mdl-switch__input" type="checkbox" data-field="showMultipleBadges">
+					<span class="mdl-switch__label"><strong>Show Multiple Badges</strong></span>
+				</label>
+			</div>
+
+			<p class="help-block">
+				This flag can be used to control the showing of multpile badges in for a user.
+			</p>
+			<p class="help-block">
+				<strong>Note!</strong> Even though this may be enabled, it is up to the template to handle showing the badges.
+			</p>
+
 			<label>[[admin/settings/group:max-name-length]]</label>
 			<input class="form-control" type="text" placeholder="255" data-field="maximumGroupNameLength" />
 		</form>


### PR DESCRIPTION
This exposes a setting in `meta` to say whether all of a user's badges should be displayed. This also exposes all the user's groups in a property called `allGroups` in `controllers/topics.js`. Even though this setting exists, it still needs to be supported by the theme the user has. The default behavior of using the selected group still exists to ensure that no existing sites break.

Re: https://github.com/NodeBB/NodeBB/issues/5338