### PR TITLE
Fix empty lines in language selectors

### DIFF
--- a/src/languages.js
+++ b/src/languages.js
@@ -52,7 +52,10 @@ Languages.list = function (callback) {
 						return next(err);
 					}
 					if (buffer) {
-						languages.push(JSON.parse(buffer.toString()));
+						var lang = JSON.parse(buffer.toString());
+						if (lang.name && lang.code && lang.dir) {
+							languages.push(lang);
+						}
 					}
 					next();
 				});

--- a/src/meta/languages.js
+++ b/src/meta/languages.js
@@ -143,12 +143,13 @@ function getTranslationTree(callback) {
 							//  4. old plugin defaultLang (en_US)
 							async.eachLimit(plugins, 10, function (pluginData, call) {
 								var pluginLanguages = path.join(__dirname, '../../node_modules/', pluginData.id, pluginData.languages);
+								var defaultLang = pluginData.defaultLang || 'en-GB';
 
 								async.some([
 									lang,
 									lang.replace('-', '_').replace('-x-', '@'),
-									pluginData.defaultLang.replace('_', '-').replace('@', '-x-'),
-									pluginData.defaultLang.replace('-', '_').replace('-x-', '@'),
+									defaultLang.replace('_', '-').replace('@', '-x-'),
+									defaultLang.replace('-', '_').replace('-x-', '@'),
 								], function (language, next) {
 									fs.readFile(path.join(pluginLanguages, language, ns + '.json'), function (err, buffer) {
 										if (err) {


### PR DESCRIPTION
- Empty lines no longer show up
- `build/public/language` directory now cleared on rebuild
- Don't write empty JSON files

Plugins can add entirely new languages by having a `language.json` file inside the language directory.