### PR TITLE
Add tls options for redis db

### DIFF
--- a/src/database/redis.js
+++ b/src/database/redis.js
@@ -85,6 +85,10 @@
 		}
 
 		options = options || {};
+		options.tls = {
+			servername: redis_socket_or_host
+		};
+		
 		if (nconf.get('redis:password')) {
 			options.auth_pass = nconf.get('redis:password');
 		}


### PR DESCRIPTION
For me it would be nice to have an option to enable **tls** in redis database, maybe configurable from config.json file