### PR TITLE
Fix issue with top-of-topic reply button not passing post ID

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -205,7 +205,7 @@ define('forum/topic/postTools', [
 				username = '';
 			}
 
-			var toPid = button.is('[component="post/reply"]') ? getData(button, 'data-pid') : null;
+			var toPid = button.is('[component="topic/reply"]') || button.is('[component="post/reply"]') ? getData(button, 'data-pid') : null;
 
 			if (selectedText) {
 				$(window).trigger('action:composer.addQuote', {


### PR DESCRIPTION
When using the top-of-topic reply button with text highlit in the original post, the post ID is not passed correctly. Until now 🙂