### PR TITLE
Minify all module scripts in production

### DIFF
--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -71,7 +71,7 @@ exports.buildTargets = function (targets, callback) {
 				winston.info('[build] Building javascript');
 				var startTime = Date.now();
 				async.series([
-					meta.js.linkModules,
+					meta.js.buildModules,
 					meta.js.linkStatics,
 					async.apply(meta.js.minify, 'nodebb.min.js'),
 					async.apply(meta.js.minify, 'acp.min.js')

--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -13,6 +13,8 @@ var file = require('../file');
 var plugins = require('../plugins');
 var utils = require('../../public/src/utils');
 
+var minifierPath = path.join(__dirname, 'minifier.js');
+
 module.exports = function (Meta) {
 
 	Meta.js = {
@@ -236,7 +238,7 @@ module.exports = function (Meta) {
 		winston.verbose('[meta/js] Minifying ' + target);
 
 		var forkProcessParams = setupDebugging();
-		var minifier = Meta.js.minifierProc = fork('minifier.js', [], forkProcessParams);
+		var minifier = Meta.js.minifierProc = fork(minifierPath, [], forkProcessParams);
 
 		Meta.js.target[target] = {};
 

--- a/src/meta/minifier.js
+++ b/src/meta/minifier.js
@@ -3,7 +3,7 @@
 var uglifyjs = require('uglify-js');
 var async = require('async');
 var fs = require('fs');
-var file = require('./src/file');
+var file = require('../file');
 
 var Minifier = {
 	js: {}


### PR DESCRIPTION
If `./nodebb build` is run in a development environment, nothing changes. The defined core and script module files (`Meta.js.scripts.modules`) are just linked into the `build/public/src/modules` directory.

If `./nodebb build` is not run in a dev environment:
- Defined core and script module files minified into `build/public/src/modules`
- Files in `public/src/modules`, `public/src/client`, and `public/src/admin` are minified into the respective directories in `build/public/src`