### PR TITLE
fix: auto cropper on image upload selects maximum image area by default

### DIFF
--- a/public/src/modules/pictureCropper.js
+++ b/public/src/modules/pictureCropper.js
@@ -42,6 +42,7 @@ define('pictureCropper', ['translator', 'cropper'], function (translator, croppe
 				var img = document.getElementById('cropped-image');
 				var cropperTool = new cropper.default(img, {
 					aspectRatio: data.aspectRatio,
+					autoCropArea: 1,
 					viewMode: 1,
 					cropmove: function () {
 						if (data.restrictImageDimension) {


### PR DESCRIPTION
Current implementation of the uploaded avatar cropper selects an 80% area crop by default. this causes extra effort and annoyance to users who already have uploaded a square image and do not wish to crop.

This patch fixes this.

Current behavior: 
![image](https://cloud.githubusercontent.com/assets/829476/23611610/10378818-0246-11e7-890e-ee5756f9a280.png)

New behavior on square image:
![image](https://cloud.githubusercontent.com/assets/829476/23612055/da458a64-0247-11e7-9a5e-e2dc29f974d7.png)

New behavior on non square image:
![image](https://cloud.githubusercontent.com/assets/829476/23612101/160c7abc-0248-11e7-8568-e39d9ec90f3b.png)

