### PR TITLE
wrapImagesInLinks with <a download> attribute

### DIFF
--- a/public/src/client/topic/images.js
+++ b/public/src/client/topic/images.js
@@ -97,19 +97,25 @@ define('forum/topic/images', [
 	Images.wrapImagesInLinks = function (posts) {
 		posts.find('[component="post/content"] img:not(.emoji)').each(function () {
 			var $this = $(this);
-			var src = $this.attr('src');
+			var src = $this.attr('src') || '';
+			var alt = $this.attr('alt') || '';
 			var suffixRegex = /-resized(\.[\w]+)?$/;
 
 			if (src === 'about:blank') {
 				return;
 			}
-
+			
 			if (utils.isRelativeUrl(src) && suffixRegex.test(src)) {
 				src = src.replace(suffixRegex, '$1');
 			}
+			var srcExt = src.split('.').slice(1).pop();
+			var altFilename = alt.split('/').pop();
+			var altExt = altFilename.split('.').slice(1).pop();
 
 			if (!$this.parent().is('a')) {
-				$this.wrap('<a href="' + src + '" target="_blank">');
+				$this.wrap('<a href="' + src + '" '
+					   + (!srcExt && altExt ? ' download="' + altFilename + '" ' : '') 
+					   + ' target="_blank" >');
 			}
 		});
 	};


### PR DESCRIPTION
if the `src` of the `img` does not have an extension, most browsers will trigger a download with whatever filename is set, also without an extension, so when it's opened in any OS, it wont have a default application to open it with.

So, In this case, if the `alt` attribute has an extension (meaning if it looks like filename) - we use that with the html5 [`download` attr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download)

The PR does not affect any src if they have an extension.

![screen shot 2017-03-22 at 12 18 53 pm](https://cloud.githubusercontent.com/assets/1398375/24193130/dbfa9192-0ef9-11e7-93fe-7f2105d4f428.png)
