### PR TITLE
Fix postcount is expected to be Number

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -67,6 +67,7 @@ topicsController.get = function (req, res, callback) {
 			settings = results.settings;
 			var postCount = parseInt(results.topic.postcount, 10);
 			pageCount = Math.max(1, Math.ceil(postCount / settings.postsPerPage));
+			results.topic.postcount = postCount;
 
 			if (utils.isNumber(req.params.post_index) && (req.params.post_index < 1 || req.params.post_index > postCount)) {
 				return helpers.redirect(res, '/topic/' + req.params.topic_id + '/' + req.params.slug + (req.params.post_index > postCount ? '/' + postCount : ''));


### PR DESCRIPTION
Just a line to fix a bug with post count number. Currently postcount is a String and this clashes with code in [/public/src/client/topic/posts.js:25](https://github.com/NodeBB/NodeBB/blob/d88219b4d1315091c53b8ced21d15c0b8a4474ea/public/src/client/topic/posts.js#L25):

```javascript
// postcount = 5
ajaxify.data.postcount += 1;
// postcount.type = String | postcount = 51
// postcount.type = Number | postcount = 6
```

As this is never expected to be a string it may as well fix other unknown bugs.