### PR TITLE
Automatically detect user language based on browser accepts header

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -35,5 +35,6 @@
     "allowPrivateGroups": 1,
     "unreadCutoff": 2,
     "bookmarkThreshold": 5,
-    "topicsPerList": 20
+    "topicsPerList": 20,
+    "autoDetectLang": 1
 }

--- a/public/language/en-GB/admin/general/languages.json
+++ b/public/language/en-GB/admin/general/languages.json
@@ -1,5 +1,6 @@
 {
 	"language-settings": "Language Settings",
 	"description": "The default language determines the language settings for all users who are visiting your forum. <br />Individual users can override the default language on their account settings page.",
-	"default-language": "Default Language"
+	"default-language": "Default Language",
+	"auto-detect": "Auto Detect Language Setting for Guests"
 }

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -176,7 +176,8 @@
 		}).join('');
 	};
 
-	helpers.localeToHTML = function (locale) {
+	helpers.localeToHTML = function (locale, fallback) {
+		locale = locale || fallback || 'en-GB';
 		return locale.replace('_', '-');
 	};
 

--- a/src/controllers/admin/languages.js
+++ b/src/controllers/admin/languages.js
@@ -18,6 +18,7 @@ languagesController.get = function (req, res, next) {
 
 		res.render('admin/general/languages', {
 			languages: languages,
+			autoDetectLang: parseInt(meta.config.autoDetectLang, 10) === 1,
 		});
 	});
 };

--- a/src/meta/languages.js
+++ b/src/meta/languages.js
@@ -102,6 +102,25 @@ function getTranslationTree(callback) {
 			});
 		},
 
+		// save a list of languages to `${buildLanguagesPath}/metadata.json`
+		// avoids readdirs later on
+		function (ref, next) {
+			async.waterfall([
+				function (next) {
+					mkdirp(buildLanguagesPath, next);
+				},
+				function (x, next) {
+					fs.writeFile(path.join(buildLanguagesPath, 'metadata.json'), JSON.stringify({
+						languages: ref.languages.sort(),
+						namespaces: ref.namespaces.sort(),
+					}), next);
+				},
+				function (next) {
+					next(null, ref);
+				},
+			], next);
+		},
+
 		// for each language and namespace combination,
 		// run through core and all plugins to generate
 		// a full translation hash

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -133,6 +133,7 @@ module.exports = function (middleware) {
 				templateValues.customJS = templateValues.useCustomJS ? meta.config.customJS : '';
 				templateValues.maintenanceHeader = parseInt(meta.config.maintenanceMode, 10) === 1 && !results.isAdmin;
 				templateValues.defaultLang = meta.config.defaultLang || 'en-GB';
+				templateValues.userLang = res.locals.config.userLang;
 				templateValues.privateUserInfo = parseInt(meta.config.privateUserInfo, 10) === 1;
 				templateValues.privateTagListing = parseInt(meta.config.privateTagListing, 10) === 1;
 

--- a/src/views/admin/general/languages.tpl
+++ b/src/views/admin/general/languages.tpl
@@ -16,6 +16,17 @@
 					</select>
 				</div>
 			</form>
+
+			<form class="row">
+				<div class="form-group col-sm-6">
+					<div class="checkbox">
+						<label class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
+							<input class="mdl-switch__input" type="checkbox" data-field="autoDetectLang" <!-- IF autoDetectLang -->checked<!-- ENDIF autoDetectLang -->/>
+							<span class="mdl-switch__label">[[admin/general/languages:auto-detect]]</span>
+						</label>
+					</div>
+				</div>
+			</form>
 		</div>
 	</div>
 </div>

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -206,7 +206,7 @@ function setupAutoLocale(app, callback) {
 		});
 
 		app.use(function (req, res, next) {
-			if (parseInt(req.uid, 10) > 0) {
+			if (parseInt(req.uid, 10) > 0 || parseInt(meta.config.autoDetectLang, 10) !== 1) {
 				return next();
 			}
 

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -55,13 +55,16 @@ module.exports.listen = function (callback) {
 	callback = callback || function () { };
 	emailer.registerApp(app);
 
-	setupExpressApp(app);
-
-	helpers.register();
-
-	logger.init(app);
-
 	async.waterfall([
+		function (next) {
+			setupExpressApp(app, next);
+		},
+		function (next) {
+			helpers.register();
+
+			logger.init(app);
+			next();
+		},
 		initializeNodeBB,
 		function (next) {
 			winston.info('NodeBB Ready');
@@ -110,7 +113,7 @@ function initializeNodeBB(callback) {
 	});
 }
 
-function setupExpressApp(app) {
+function setupExpressApp(app, callback) {
 	var middleware = require('./middleware');
 
 	var relativePath = nconf.get('relative_path');
@@ -155,6 +158,8 @@ function setupExpressApp(app) {
 	var toobusy = require('toobusy-js');
 	toobusy.maxLag(parseInt(meta.config.eventLoopLagThreshold, 10) || 100);
 	toobusy.interval(parseInt(meta.config.eventLoopInterval, 10) || 500);
+
+	setupAutoLocale(app, callback);
 }
 
 function setupFavicon(app) {
@@ -186,6 +191,35 @@ function setupCookie() {
 	}
 
 	return cookie;
+}
+
+function setupAutoLocale(app, callback) {
+	languages.listCodes(function (err, codes) {
+		if (err) {
+			return callback(err);
+		}
+
+		var defaultLang = meta.config.defaultLang || 'en-GB';
+
+		var langs = [defaultLang].concat(codes).filter(function (el, i, arr) {
+			return arr.indexOf(el) === i;
+		});
+
+		app.use(function (req, res, next) {
+			if (parseInt(req.uid, 10) > 0) {
+				return next();
+			}
+
+			var lang = req.acceptsLanguages(langs);
+			if (!lang) {
+				return next();
+			}
+			req.query.lang = lang;
+			next();
+		});
+
+		callback();
+	});
 }
 
 function listen(callback) {

--- a/test/locale-detect.js
+++ b/test/locale-detect.js
@@ -1,0 +1,41 @@
+'use strict';
+
+var	assert = require('assert');
+var nconf = require('nconf');
+var request = require('request');
+
+var meta = require('../src/meta');
+
+describe('Language detection', function () {
+	it('should detect the language for a guest', function (done) {
+		request(nconf.get('url') + '/api/config', {
+			headers: {
+				'Accept-Language': 'de-DE,de;q=0.5',
+			},
+		}, function (err, res, body) {
+			assert.ifError(err);
+			assert.ok(body);
+
+			assert.strictEqual(JSON.parse(body).userLang, 'de');
+			done();
+		});
+	});
+
+	it('should do nothing when disabled', function (done) {
+		meta.configs.set('autoDetectLang', 0, function (err) {
+			assert.ifError(err);
+
+			request(nconf.get('url') + '/api/config', {
+				headers: {
+					'Accept-Language': 'de-DE,de;q=0.5',
+				},
+			}, function (err, res, body) {
+				assert.ifError(err);
+				assert.ok(body);
+
+				assert.strictEqual(JSON.parse(body).userLang, 'en-GB');
+				done();
+			});
+		});
+	});
+});


### PR DESCRIPTION
- [x] Only for guest users, of course
- [x] Added option for disabling the feature
- [x] Registration already uses the query value so new users get the same language that's autodetected
- [x] Tests