### PR TITLE
Fix many "duplicate key" errors

### DIFF
--- a/test/authentication.js
+++ b/test/authentication.js
@@ -427,9 +427,5 @@ describe('authentication', function () {
 			},
 		], done);
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });
 

--- a/test/blacklist.js
+++ b/test/blacklist.js
@@ -72,8 +72,4 @@ describe('blacklist', function () {
 		assert(blacklist.test('1.1.1.1'));
 		done();
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/build.js
+++ b/test/build.js
@@ -124,9 +124,8 @@ describe('Build', function (done) {
 	var build = require('../src/meta/build');
 
 	before(function (done) {
-		async.series([
+		async.parallel([
 			async.apply(rimraf, path.join(__dirname, '../build/public')),
-			db.setupMockDefaults,
 			async.apply(db.activatePlugin, 'nodebb-plugin-markdown'),
 		], done);
 	});
@@ -231,9 +230,5 @@ describe('Build', function (done) {
 
 			done();
 		});
-	});
-
-	after(function (done) {
-		db.emptydb(done);
 	});
 });

--- a/test/categories.js
+++ b/test/categories.js
@@ -20,7 +20,7 @@ describe('Categories', function () {
 
 	before(function (done) {
 		groups.resetCache();
-		async.parallel({
+		async.series({
 			posterUid: function (next) {
 				User.create({ username: 'poster' }, next);
 			},
@@ -679,10 +679,5 @@ describe('Categories', function () {
 				done();
 			});
 		});
-	});
-
-
-	after(function (done) {
-		db.emptydb(done);
 	});
 });

--- a/test/controllers-admin.js
+++ b/test/controllers-admin.js
@@ -553,8 +553,4 @@ describe('Admin Controllers', function () {
 			});
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1765,9 +1765,6 @@ describe('Controllers', function () {
 
 	after(function (done) {
 		var analytics = require('../src/analytics');
-		analytics.writeData(function (err) {
-			assert.ifError(err);
-			db.emptydb(done);
-		});
+		analytics.writeData(done);
 	});
 });

--- a/test/database/hash.js
+++ b/test/database/hash.js
@@ -408,9 +408,4 @@ describe('Hash methods', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/database/keys.js
+++ b/test/database/keys.js
@@ -170,9 +170,4 @@ describe('Key methods', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/database/list.js
+++ b/test/database/list.js
@@ -200,9 +200,4 @@ describe('List methods', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/database/sets.js
+++ b/test/database/sets.js
@@ -226,9 +226,4 @@ describe('Set methods', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/database/sorted.js
+++ b/test/database/sorted.js
@@ -902,8 +902,4 @@ describe('Sorted Set methods', function () {
 			});
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/feeds.js
+++ b/test/feeds.js
@@ -113,8 +113,4 @@ describe('feeds', function () {
 			});
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/flags.js
+++ b/test/flags.js
@@ -564,8 +564,4 @@ describe('Flags', function () {
 			});
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/groups.js
+++ b/test/groups.js
@@ -436,10 +436,10 @@ describe('Groups', function () {
 				var	groups = ['Test', 'Hidden'];
 				async.every(groups, function (group, next) {
 					Groups.isMember(testUid, group, function (err, isMember) {
-						assert.ifError(err);
-						next(!isMember);
+						next(err, !isMember);
 					});
-				}, function (result) {
+				}, function (err, result) {
+					assert.ifError(err);
 					assert(result);
 
 					done();
@@ -1188,9 +1188,5 @@ describe('Groups', function () {
 				});
 			});
 		});
-	});
-
-	after(function (done) {
-		db.emptydb(done);
 	});
 });

--- a/test/logger.js
+++ b/test/logger.js
@@ -28,8 +28,4 @@ describe('logger', function () {
 			done();
 		}, 500);
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -610,8 +610,4 @@ describe('Messaging Library', function () {
 			});
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/meta.js
+++ b/test/meta.js
@@ -275,9 +275,4 @@ describe('meta', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/mocks/databasemock.js
+++ b/test/mocks/databasemock.js
@@ -116,7 +116,7 @@ before(function (done) {
 			nconf.set('theme_config', path.join(nconf.get('themes_path'), 'nodebb-theme-persona', 'theme.json'));
 			nconf.set('bcrypt_rounds', 1);
 
-			next();
+			meta.dependencies.check(next);
 		},
 		function (next) {
 			var	webserver = require('../../src/webserver');
@@ -129,6 +129,14 @@ before(function (done) {
 			webserver.listen(next);
 		},
 	], done);
+
+	// Iterate over all of the test suites/contexts
+	this.test.parent.suites.forEach(function (suite) {
+		// Attach an afterAll listener that resets the defaults
+		suite.afterAll(function (done) {
+			setupMockDefaults(done);
+		});
+	});
 });
 
 function setupMockDefaults(callback) {
@@ -147,9 +155,6 @@ function setupMockDefaults(callback) {
 		},
 		function (next) {
 			meta.configs.init(next);
-		},
-		function (next) {
-			meta.dependencies.check(next);
 		},
 		function (next) {
 			meta.config.postDelay = 0;

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -475,9 +475,4 @@ describe('Notifications', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/posts.js
+++ b/test/posts.js
@@ -740,9 +740,4 @@ describe('Post\'s', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/rewards.js
+++ b/test/rewards.js
@@ -73,9 +73,4 @@ describe('rewards', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/search.js
+++ b/test/search.js
@@ -165,8 +165,4 @@ describe('Search', function () {
 			done();
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -485,6 +485,7 @@ describe('socket.io', function () {
 		var data = [
 			{ name: 'nodebb-theme-persona', order: 0 },
 			{ name: 'nodebb-plugin-dbsearch', order: 1 },
+			{ name: 'nodebb-plugin-soundpack-default', order: 2 },
 			{ ignoreme: 'wrong data' },
 		];
 		socketAdmin.plugins.orderActivePlugins({ uid: adminUid }, data, function (err) {
@@ -584,10 +585,6 @@ describe('socket.io', function () {
 				done();
 			});
 		});
-	});
-
-	after(function (done) {
-		db.emptydb(done);
 	});
 });
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -1643,8 +1643,4 @@ describe('Topic\'s', function () {
 			});
 		});
 	});
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -256,9 +256,4 @@ describe('Upload Controllers', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });

--- a/test/user.js
+++ b/test/user.js
@@ -1467,9 +1467,4 @@ describe('User', function () {
 			});
 		});
 	});
-
-
-	after(function (done) {
-		db.emptydb(done);
-	});
 });


### PR DESCRIPTION
- Reset defaults after every test
- Remove individual `after(db.emptydb)` calls
- Fix async.every in groups test
- Update plugin list in socket tests