### PR TITLE
(minor) add .svn line to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ provision.sh
 .DS_Store
 feeds/recent.rss
 .eslintcache
+.svn
 
 logs/
 


### PR DESCRIPTION
Not a big deal, but some teams have SVN integrated with app deployment process.
