### PR TITLE
Add relativePath to /ping and /sping

### DIFF
--- a/src/webserver.js
+++ b/src/webserver.js
@@ -133,8 +133,8 @@ function setupExpressApp(app, callback) {
 
 	app.use(compression());
 
-	app.get('/ping', ping);
-	app.get('/sping', ping);
+	app.get(relativePath + '/ping', ping);
+	app.get(relativePath + '/sping', ping);
 
 	setupFavicon(app);
 


### PR DESCRIPTION
Issue: 
  /ping and /sping are not working when using relativePath's. 