### PR TITLE
Fix /apple-touch-icon not sending uploaded file

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -83,7 +83,13 @@ middleware.routeTouchIcon = function (req, res) {
 	if (meta.config['brand:touchIcon'] && validator.isURL(meta.config['brand:touchIcon'])) {
 		return res.redirect(meta.config['brand:touchIcon']);
 	}
-	return res.sendFile(path.join(__dirname, '../../public', meta.config['brand:touchIcon'] || '/logo.png'), {
+	var iconPath = '../../public';
+	if (meta.config['brand:touchIcon']) {
+		iconPath += meta.config['brand:touchIcon'].replace(/assets\/uploads/, 'uploads');
+	} else {
+		iconPath += '/logo.png';
+	}
+	return res.sendFile(path.join(__dirname, iconPath), {
 		maxAge: req.app.enabled('cache') ? 5184000000 : 0,
 	});
 };

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -4,6 +4,7 @@ var async = require('async');
 var	assert = require('assert');
 var nconf = require('nconf');
 var path = require('path');
+var request = require('request');
 
 var db = require('./mocks/databasemock');
 var categories = require('../src/categories');
@@ -247,12 +248,19 @@ describe('Upload Controllers', function () {
 		});
 
 		it('should upload touch icon', function (done) {
+			var touchiconAssetPath = '/assets/uploads/system/touchicon-orig.png';
 			helpers.uploadFile(nconf.get('url') + '/api/admin/uploadTouchIcon', path.join(__dirname, '../test/files/test.png'), {}, jar, csrf_token, function (err, res, body) {
 				assert.ifError(err);
 				assert.equal(res.statusCode, 200);
 				assert(Array.isArray(body));
-				assert.equal(body[0].url, '/assets/uploads/system/touchicon-orig.png');
-				done();
+				assert.equal(body[0].url, touchiconAssetPath);
+				meta.config['brand:touchIcon'] = touchiconAssetPath;
+				request(nconf.get('url') + '/apple-touch-icon', function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert(body);
+					done();
+				});
 			});
 		});
 	});


### PR DESCRIPTION
This fixes the following error:

$ wget https://nodebb.yourdomain/apple-touch-icon

28/6 09:57:06 [28332] - error: /apple-touch-icon
 Error: ENOENT: no such file or directory, stat '/home/sweet/nodebb/public/assets/uploads/system/touchicon-orig.png'
    at Error (native)