### PR TITLE
Adds the filter:uploadStored hook which fires after the file is saved…

### DIFF
--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -228,11 +228,11 @@ function saveFileToLocal(uploadedFile, callback) {
 		},
 		function (upload, next) {
 			var storedFile = {
-			url: nconf.get('relative_path') + upload.url,
-			path: upload.path,
-			name: uploadedFile.name,
-		}
-		plugins.fireHook( 'filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile } );
+				url: nconf.get('relative_path') + upload.url,
+				path: upload.path,
+				name: uploadedFile.name,
+			}
+		plugins.fireHook( 'filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next );
 		next(null, storedFile);
 		},
 	], callback);

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -233,7 +233,12 @@ function saveFileToLocal(uploadedFile, callback) {
 				name: uploadedFile.name,
 			};
 
-			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, function () { next(null, storedFile); });
+			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, function (err, data) {
+				if (err) {
+					return next(err);
+				}
+				next(null, data.storedFile);
+			});
 		},
 	], callback);
 }

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -233,7 +233,7 @@ function saveFileToLocal(uploadedFile, callback) {
 				name: uploadedFile.name,
 			};
 
-			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, function() {next(null, storedFile);});
+			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, function () { next(null, storedFile); });
 		},
 	], callback);
 }

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -227,11 +227,13 @@ function saveFileToLocal(uploadedFile, callback) {
 			file.saveFileToLocal(filename, 'files', uploadedFile.path, next);
 		},
 		function (upload, next) {
-			next(null, {
-				url: nconf.get('relative_path') + upload.url,
-				path: upload.path,
-				name: uploadedFile.name,
-			});
+			var storedFile = {
+			url: nconf.get('relative_path') + upload.url,
+			path: upload.path,
+			name: uploadedFile.name,
+		}
+		plugins.fireHook( 'filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile } );
+		next(null, storedFile);
 		},
 	], callback);
 }

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -231,9 +231,10 @@ function saveFileToLocal(uploadedFile, callback) {
 				url: nconf.get('relative_path') + upload.url,
 				path: upload.path,
 				name: uploadedFile.name,
-			}
-		plugins.fireHook( 'filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next );
-		next(null, storedFile);
+			};
+
+			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next);
+			next(null, storedFile);
 		},
 	], callback);
 }

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -233,8 +233,7 @@ function saveFileToLocal(uploadedFile, callback) {
 				name: uploadedFile.name,
 			};
 
-			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next);
-			next(null, storedFile);
+			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, function() {next(null, storedFile);});
 		},
 	], callback);
 }


### PR DESCRIPTION
… in the async waterfall and passes:

                       var storedFile = {
                       url: nconf.get('relative_path') + upload.url,
                       path: upload.path,
                       name: uploadedFile.name,
               }
               plugins.fireHook( 'filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile } );