### PR TITLE
Add post images hook

### DIFF
--- a/public/src/client/topic/images.js
+++ b/public/src/client/topic/images.js
@@ -121,6 +121,8 @@ define('forum/topic/images', [
 					+ (!srcExt && altExt ? ' download="' + altFilename + '" ' : '')
 					+ ' target="_blank" >');
 			}
+			
+			$(window).trigger('action:images.loaded');
 		});
 	};
 

--- a/public/src/client/topic/images.js
+++ b/public/src/client/topic/images.js
@@ -20,6 +20,7 @@ define('forum/topic/images', [
 		} else {
 			images.attr('data-state', 'loaded');
 			Images.wrapImagesInLinks(posts);
+			$(window).trigger('action:images.loaded');
 		}
 	};
 
@@ -75,6 +76,7 @@ define('forum/topic/images', [
 					adjusting = false;
 
 					Images.wrapImagesInLinks(posts);
+					$(window).trigger('action:images.loaded');
 					posts.length = 0;
 				}
 			}
@@ -121,8 +123,6 @@ define('forum/topic/images', [
 					+ (!srcExt && altExt ? ' download="' + altFilename + '" ' : '')
 					+ ' target="_blank" >');
 			}
-
-			$(window).trigger('action:images.loaded');
 		});
 	};
 

--- a/public/src/client/topic/images.js
+++ b/public/src/client/topic/images.js
@@ -121,7 +121,7 @@ define('forum/topic/images', [
 					+ (!srcExt && altExt ? ' download="' + altFilename + '" ' : '')
 					+ ' target="_blank" >');
 			}
-			
+
 			$(window).trigger('action:images.loaded');
 		});
 	};


### PR DESCRIPTION
This hook would allow plugins to manipulate images inside posts  after images are manipulated by nodebb (for example, delay loading). Without this hook we can manipulate images by searching post data for them and manipulate that data, but any change on that level is either erased by nodebb once image loading starts (if delay is turned on) or it disables native image behaviour by changing image code so native behaviour is not triggered.
Hook at this place works for both delayed loading turned on and off.
Usage for this kind of hook was talked about here: https://community.nodebb.org/topic/10960/opening-uploaded-images-in-modal-windows