### PR TITLE
Loss of Exif Orientation in scaled images

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -37,6 +37,10 @@ image.resizeImage = function (data, callback) {
 			var y = 0;
 			var crop;
 
+			if (image._exif && image._exif.tags && image._exif.tags.Orientation) {
+				image.exifRotate();
+			}
+
 			if (origRatio !== desiredRatio) {
 				if (desiredRatio > origRatio) {
 					desiredRatio = 1 / desiredRatio;


### PR DESCRIPTION
Implements Jimp exitRotate() new method (jimp 0.2.28) to solve incoherent rotations when scaling images.