### PR TITLE
Improve "scrollbar" on posts

### DIFF
--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -4,7 +4,7 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 	var navigator = {};
 	var index = 1;
 	var count = 0;
-	var navigatorUpdateTimeoutId = undefined;
+	var navigatorUpdateTimeoutId;
 
 	navigator.scrollActive = false;
 

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -165,7 +165,7 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 		index = index > count ? count : index;
 
 		$('.pagination-block .pagination-text').translateHtml('[[global:pagination.out_of, ' + index + ', ' + count + ']]');
-		$('.pagination-block .progress-bar').width((index / count * 100) + '%');
+		$('.pagination-block .progress-bar').width(($(window).scrollTop() / ($(document).height() - $(window).height()) * 100) + '%');
 	};
 
 	navigator.scrollUp = function () {

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -4,7 +4,7 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 	var navigator = {};
 	var index = 1;
 	var count = 0;
-	var navigatorUpdateTimeoutId = 0;
+	var navigatorUpdateTimeoutId = undefined;
 
 	navigator.scrollActive = false;
 
@@ -91,11 +91,12 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 	}
 
 	navigator.delayedUpdate = function () {
-		if (navigatorUpdateTimeoutId) {
-			clearTimeout(navigatorUpdateTimeoutId);
-			navigatorUpdateTimeoutId = 0;
+		if (!navigatorUpdateTimeoutId) {
+			navigatorUpdateTimeoutId = setTimeout(function () {
+				navigator.update();
+				navigatorUpdateTimeoutId = undefined;
+			}, 100);
 		}
-		navigatorUpdateTimeoutId = setTimeout(navigator.update, 100);
 	};
 
 	navigator.update = function (threshold) {
@@ -165,7 +166,9 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 		index = index > count ? count : index;
 
 		$('.pagination-block .pagination-text').translateHtml('[[global:pagination.out_of, ' + index + ', ' + count + ']]');
-		$('.pagination-block .progress-bar').width(($(window).scrollTop() / ($(document).height() - $(window).height()) * 100) + '%');
+		var fraction = $(window).scrollTop() / ($(document).height() - $(window).height());
+		$('.pagination-block meter').val(fraction);
+		$('.pagination-block .progress-bar').width((fraction * 100) + '%');
 	};
 
 	navigator.scrollUp = function () {


### PR DESCRIPTION
This PR slighty enhances the current Scroll Bars when reading a topic.
Changes:
  - The bars now start at 0%, before they started at (100/posts)% (e.g. if there were 3 posts, the bar started at 33%)
  - The delayedUpdate function was changed, to also update during scrolls and not just after they were finished, the update function is still not completely flooded with calls.
  - HTML5 meter tags are now supported instead of the bootstrap solution. At least on my machine, the transition was smoother using those tags instead of the resizing div attempt.

A picture is worth more than a thousand words, so here are some examples:
Current Behaviour:
![Old](https://thumbs.gfycat.com/LimitedCraftyAbyssiniangroundhornbill-size_restricted.gif)
New Default behaviour:
![New](https://thumbs.gfycat.com/FlakyShoddyHairstreakbutterfly-size_restricted.gif)
New HTML5 meter behaviour: (I didn't bother styling the tag, I'll leave that up to the template designers)
![Better](https://thumbs.gfycat.com/InfantileHarmoniousAiredaleterrier-size_restricted.gif)