### PR TITLE
In --no-daemon unlink of nonexisting pidfile

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -187,7 +187,9 @@ Loader.stop = function () {
 	killWorkers();
 
 	// Clean up the pidfile
-	fs.unlinkSync(pidFilePath);
+	if (nconf.get('daemon') !== 'false' && nconf.get('daemon') !== false) {
+		fs.unlinkSync(pidFilePath);
+	}
 };
 
 function killWorkers() {


### PR DESCRIPTION
When running application using --no-deamon, when process is killed with signal SIGTERM, it exits with code 1, due to fact that pidfile does not exist