### PR TITLE
Added HSTS headers as opt-in feature with en/GB and pl translation st…

### DIFF
--- a/public/language/en-GB/admin/settings/advanced.json
+++ b/public/language/en-GB/admin/settings/advanced.json
@@ -9,6 +9,8 @@
 	"headers.acao-help": "To deny access to all sites, leave empty",
 	"headers.acam": "Access-Control-Allow-Methods",
 	"headers.acah": "Access-Control-Allow-Headers",
+	"headers.hsts": "HTTP Strict Transport Security",
+	"headers.hsts-help": "Tells the browsers to always choose https first when protocol is not defined. To enable, set a max-age declaration (sugested is 15552000 - 180 days in seconds).",
 	"traffic-management": "Traffic Management",
 	"traffic.help": "NodeBB deploys equipped with a module that automatically denies requests in high-traffic situations. You can tune these settings here, although the defaults are a good starting point.",
 	"traffic.enable": "Enable Traffic Management",

--- a/public/language/pl/admin/settings/advanced.json
+++ b/public/language/pl/admin/settings/advanced.json
@@ -9,8 +9,6 @@
 	"headers.acao-help": "Aby zablokować dostęp do wszystkich stron, pozostaw puste.",
 	"headers.acam": "Access-Control-Allow-Methods",
 	"headers.acah": "Access-Control-Allow-Headers",
-	"headers.hsts": "HTTP Strict Transport Security",
-	"headers.hsts-help": "Sugeruje przeglądarce by zawsze wybierała protokół https jeżeli żaden protokół nie jest zdefiniowany przez użytkownika. Aby włączyć należy zdefiniować wartość \"max-age\" (sugerujemy 15552000 - 180 dni w sekundach).",
 	"traffic-management": "Zarządzanie ruchem",
 	"traffic.help": "NodeBB jest dostarczane z modułem, który automatycznie blokuje żądania w sytuacjach wysokiego ruchu. Tutaj możesz zmienić te ustawienia, ale ustawienia początkowe są dobrym punktem wyjścia w większości sytuacji.",
 	"traffic.enable": "Włącz zarządzanie ruchem",

--- a/public/language/pl/admin/settings/advanced.json
+++ b/public/language/pl/admin/settings/advanced.json
@@ -9,6 +9,8 @@
 	"headers.acao-help": "Aby zablokować dostęp do wszystkich stron, pozostaw puste.",
 	"headers.acam": "Access-Control-Allow-Methods",
 	"headers.acah": "Access-Control-Allow-Headers",
+	"headers.hsts": "HTTP Strict Transport Security",
+	"headers.hsts-help": "Sugeruje przeglądarce by zawsze wybierała protokół https jeżeli żaden protokół nie jest zdefiniowany przez użytkownika. Aby włączyć należy zdefiniować wartość \"max-age\" (sugerujemy 15552000 - 180 dni w sekundach).",
 	"traffic-management": "Zarządzanie ruchem",
 	"traffic.help": "NodeBB jest dostarczane z modułem, który automatycznie blokuje żądania w sytuacjach wysokiego ruchu. Tutaj możesz zmienić te ustawienia, ale ustawienia początkowe są dobrym punktem wyjścia w większości sytuacji.",
 	"traffic.enable": "Włącz zarządzanie ruchem",

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -15,6 +15,11 @@ module.exports = function (middleware) {
 			headers['Access-Control-Allow-Origin'] = encodeURI(meta.config['access-control-allow-origin']);
 		}
 
+		if (meta.config['strict-transport-security']) {
+			headers['Strict-Transport-Security']
+				= 'max-age=' + parseInt(meta.config['strict-transport-security'], 10);
+		}
+
 		for (var key in headers) {
 			if (headers.hasOwnProperty(key) && headers[key]) {
 				res.setHeader(key, headers[key]);

--- a/src/views/admin/settings/advanced.tpl
+++ b/src/views/admin/settings/advanced.tpl
@@ -48,6 +48,13 @@
 				<label for="access-control-allow-headers">[[admin/settings/advanced:headers.acah]]</label>
 				<input class="form-control" id="access-control-allow-headers" type="text" placeholder="" data-field="access-control-allow-headers" /><br />
 			</div>
+			<div class="form-group">
+				<label for="strict-transport-security">[[admin/settings/advanced:headers.hsts]]</label>
+				<input class="form-control" id="strict-transport-security" type="number" placeholder="" data-field="strict-transport-security" /><br />
+				<p class="help-block">
+					[[admin/settings/advanced:headers.hsts-help]]
+				</p>
+			</div>
 		</form>
 	</div>
 </div>


### PR DESCRIPTION
Hello everyone.

This is my first contribution here, hope you will like it.

My NodeBB forum is https only. I'd like to improve my users' security level and harvest the low hanging fruit by adding HSTS header.

I guess it's not something every admin would like to enable, therefore I added it as the opt-in header available in the settings/advanced page.

Like I mentioned before, it's my first contribution here, so I guess you might want me to adjust the code and I'm open for change requests.

Since I have your attention, quick question:

You mentioned we use here airbnb, but I see tabs instead of spaces. Isn't airbnb code style require spaces?