### PR TITLE
    Moved file stream events from outstream (os) to instream.pipe() (…

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "eslint": "^4.8.0",
-    "eslint-config-airbnb-base": "^12.0.1",
+    "eslint": "^4.9.0",
+    "eslint-config-airbnb-base": "^12.0.2",
     "eslint-plugin-import": "^2.7.0",
     "grunt": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -233,9 +233,7 @@ function saveFileToLocal(uploadedFile, uid, callback) {
 				path: upload.path,
 				name: uploadedFile.name,
 			};
-			if (plugins.hasListeners('filter:uploadStored')) {
-				plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next);
-			}
+			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next);
 		},
 		function (data, next) {
 			next(null, data.storedFile);

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -185,7 +185,7 @@ uploadsController.uploadGroupCover = function (uid, uploadedFile, callback) {
 			file.isFileTypeAllowed(uploadedFile.path, next);
 		},
 		function (next) {
-			saveFileToLocal(uploadedFile, next);
+			saveFileToLocal(uploadedFile, uid, next);
 		},
 	], callback);
 };
@@ -213,10 +213,10 @@ uploadsController.uploadFile = function (uid, uploadedFile, callback) {
 		return callback(new Error('[[error:invalid-file-type, ' + allowed.join('&#44; ') + ']]'));
 	}
 
-	saveFileToLocal(uploadedFile, callback);
+	saveFileToLocal(uploadedFile, uid, callback);
 };
 
-function saveFileToLocal(uploadedFile, callback) {
+function saveFileToLocal(uploadedFile, uid, callback) {
 	var filename = uploadedFile.name || 'upload';
 	var extension = path.extname(filename) || '';
 
@@ -228,12 +228,14 @@ function saveFileToLocal(uploadedFile, callback) {
 		},
 		function (upload, next) {
 			var storedFile = {
+				uid: uid,
 				url: nconf.get('relative_path') + upload.url,
 				path: upload.path,
 				name: uploadedFile.name,
 			};
-
-			plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next);
+			if (plugins.hasListeners('filter:uploadStored')) {
+				plugins.fireHook('filter:uploadStored', { uploadedFile: uploadedFile, storedFile: storedFile }, next);
+			}
 		},
 		function (data, next) {
 			next(null, data.storedFile);

--- a/src/file.js
+++ b/src/file.js
@@ -32,16 +32,15 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 
 		var is = fs.createReadStream(tempPath);
 		var os = fs.createWriteStream(uploadPath);
-		is.on('end', function () {
-			callback(null, {
-				url: '/assets/uploads/' + folder + '/' + filename,
-				path: uploadPath,
-			});
+		is.pipe(os)
+		  .on('finish', function () {
+		    callback(null, {
+		      url: '/assets/uploads/' + folder + '/' + filename,
+		      path: uploadPath,
+		    });
+		  })
+		  .on('error', callback);
 		});
-
-		os.on('error', callback);
-		is.pipe(os);
-	});
 };
 
 file.base64ToLocal = function (imageData, uploadPath, callback) {

--- a/src/file.js
+++ b/src/file.js
@@ -45,9 +45,7 @@ file.copyFile = function (src, dst, opts, cb) {
 	}
 
 	/* Test for availability of fs.CopyFile */
-	const semver = require('semver');
-
-	if (semver.gte(process.version, '8.5.0')) {
+	if (fs.copyFile === 'function') {
 		fs.copyFile(src, dst, opts, cb);
 	} else {
 		/* lifted nearly wholesale from https://github.com/coolaj86/utile-fs/blob/master/fs.extra/fs.copy.js */

--- a/src/file.js
+++ b/src/file.js
@@ -23,7 +23,7 @@ file.copyFile = function (src, dst, urlPath, opts, cb) {
 		var is = fs.createReadStream(src);
 		var os = fs.createWriteStream(dst);
 		is.pipe(os)
-			.on('end', function () {
+			.on('finish', function () {
 				cb(null, {
 					url: urlPath,
 					path: dst,

--- a/src/file.js
+++ b/src/file.js
@@ -12,7 +12,7 @@ var utils = require('./utils');
 
 var file = module.exports;
 
-file.copyFile = function (src, dst, urlPath, opts, cb) {
+file.copyFile = function (src, dst, opts, cb) {
 	/* Wrapper for copyFile function with code to handle it not being present. If/When nodejs 8.5 or greater is a baseline requirement/assumption,
 	   this can be pruned and wholesale replace in all calls with fs.copyFile. */
 
@@ -24,10 +24,7 @@ file.copyFile = function (src, dst, urlPath, opts, cb) {
 		var os = fs.createWriteStream(dst);
 		is.pipe(os)
 			.on('finish', function () {
-				cb(null, {
-					url: urlPath,
-					path: dst,
-				});
+				cb(null);
 			})
 			.on('error', cb);
 	}
@@ -53,9 +50,7 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 		}
 	});
 
-	var urlPath = '/assets/uploads/' + folder + '/' + filename;
-
-	file.copyFile(tempPath, uploadPath, urlPath, {}, function (err) {
+	file.copyFile(tempPath, uploadPath, {}, function (err) {
 		if (err) {
 			callback(err);
 		} else {

--- a/src/file.js
+++ b/src/file.js
@@ -84,7 +84,7 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 
 	file.copyFile(tempPath, uploadPath, {}, function (err) {
 		if (err) {
-			callback();
+			callback(err);
 		} else {
 			callback(null, {
 				url: '/assets/uploads/' + folder + '/' + filename,

--- a/src/file.js
+++ b/src/file.js
@@ -12,7 +12,7 @@ var utils = require('./utils');
 
 var file = module.exports;
 
-file.copyFile(src, dst, opts, cb) {
+file.copyFile = function(src, dst, opts, cb) {
 	/* Wrapper for copyFile function with code to handle it not being present. If/When nodejs 8.5 or greater is a baseline requirement/assumption,
 	   this can be pruned and wholesale replace in all calls with fs.copyFile. */
 
@@ -82,6 +82,7 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 		if (err) {
 			callback(err);
 		}
+	});
 
   /* When nodeJS 8.5.0 is below the assumed base, change this to fs.copyfile and remove the above function */
 

--- a/src/file.js
+++ b/src/file.js
@@ -33,13 +33,13 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 		var is = fs.createReadStream(tempPath);
 		var os = fs.createWriteStream(uploadPath);
 		is.pipe(os)
-		  .on('finish', function () {
-		    callback(null, {
-		      url: '/assets/uploads/' + folder + '/' + filename,
-		      path: uploadPath,
-		    });
-		  })
-		  .on('error', callback);
+			.on('finish', function () {
+				callback(null, {
+					url: '/assets/uploads/' + folder + '/' + filename,
+					path: uploadPath,
+				});
+			})
+			.on('error', callback);
 		});
 };
 

--- a/src/file.js
+++ b/src/file.js
@@ -12,57 +12,56 @@ var utils = require('./utils');
 
 var file = module.exports;
 
-file.copyFile = function(src, dst, opts, cb) {
+file.copyFile = function (src, dst, opts, cb) {
 	/* Wrapper for copyFile function with code to handle it not being present. If/When nodejs 8.5 or greater is a baseline requirement/assumption,
 	   this can be pruned and wholesale replace in all calls with fs.copyFile. */
 
 	function noop() {}
 
-  /* Test for availability of fs.CopyFile */
+	function copyHelper(err) {
+		var is;
+		var os;
+
+		if (!err && !(opts.replace || opts.overwrite)) {
+			return cb(new Error('File ' + dst + ' exists.'));
+		}
+
+		fs.stat(src, function (err, stat) {
+			if (err) {
+				return cb(err);
+			}
+
+			is = fs.createReadStream(src);
+			os = fs.createWriteStream(dst);
+
+			is.pipe(os);
+			os.on('close', function (err) {
+				if (err) {
+					return cb(err);
+				}
+
+				fs.utimes(dst, stat.atime, stat.mtime, cb);
+			});
+		});
+	}
+
+	/* Test for availability of fs.CopyFile */
 	const semver = require('semver');
 
 	if (semver.gte(process.version, '8.5.0')) {
-    fs.copyFile(src, dst, opts, cb);
-	}
-	else {
+		fs.copyFile(src, dst, opts, cb);
+	} else {
 		/* lifted nearly wholesale from https://github.com/coolaj86/utile-fs/blob/master/fs.extra/fs.copy.js */
-		if ('function' === typeof opts) {
+		if (typeof opts === 'function') {
 			cb = opts;
 			opts = null;
 		}
 		opts = opts || {};
 
-		function copyHelper(err) {
-			var is
-			, os;
-
-			if (!err && !(opts.replace || opts.overwrite)) {
-				return cb(new Error("File " + dst + " exists."));
-			}
-
-			fs.stat(src, function (err, stat) {
-				if (err) {
-					return cb(err);
-				}
-
-				is = fs.createReadStream(src);
-				os = fs.createWriteStream(dst);
-
-				is.pipe(os);
-				os.on('close', function (err) {
-					if (err) {
-						return cb(err);
-					}
-
-					fs.utimes(dst, stat.atime, stat.mtime, cb);
-				});
-	     });
-		 }
-
-		 cb = cb || noop;
-		 fs.stat(dst, copyHelper);
+		cb = cb || noop;
+		fs.stat(dst, copyHelper);
 	}
-}
+};
 
 
 file.saveFileToLocal = function (filename, folder, tempPath, callback) {
@@ -84,7 +83,7 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 		}
 	});
 
-  /* When nodeJS 8.5.0 is below the assumed base, change this to fs.copyfile and remove the above function */
+	/* When nodeJS 8.5.0 is below the assumed base, change this to fs.copyfile and remove the above function */
 
 	file.copyFile(tempPath, uploadPath, {}, function (err) {
 		if (err) {
@@ -96,7 +95,6 @@ file.saveFileToLocal = function (filename, folder, tempPath, callback) {
 			});
 		}
 	});
-
 };
 
 file.base64ToLocal = function (imageData, uploadPath, callback) {

--- a/src/file.js
+++ b/src/file.js
@@ -39,7 +39,6 @@ file.copyFile = function (src, dst, opts, cb) {
 				if (err) {
 					return cb(err);
 				}
-
 				fs.utimes(dst, stat.atime, stat.mtime, cb);
 			});
 		});

--- a/src/file.js
+++ b/src/file.js
@@ -45,7 +45,7 @@ file.copyFile = function (src, dst, opts, cb) {
 	}
 
 	/* Test for availability of fs.CopyFile */
-	if (fs.copyFile === 'function') {
+	if (typeof fs.copyFile === 'function') {
 		fs.copyFile(src, dst, opts, cb);
 	} else {
 		/* lifted nearly wholesale from https://github.com/coolaj86/utile-fs/blob/master/fs.extra/fs.copy.js */


### PR DESCRIPTION
…is.pipe()) as they were not triggering as written.

    'finished' event changed to 'finish' as this is the correct name.

    I am uncertain if this is a regression or node change or happenstance.