### PR TITLE
update blacklist.js to strip ports from v4

### DIFF
--- a/src/meta/blacklist.js
+++ b/src/meta/blacklist.js
@@ -66,7 +66,7 @@ Blacklist.test = function (clientIp, callback) {
 	// clientIp = '2001:db8:85a3:0:0:8a2e:370:7334';	// IPv6
 	// clientIp = '127.0.15.1';	// IPv4
 	// clientIp = '127.0.15.1:3443'; // IPv4 with port strip port to not fail 
-	clientIp = clientIp.split(":").length == 2 ? clientIp.split(":")[0] : clientIp;
+	clientIp = clientIp.split(":").length === 2 ? clientIp.split(":")[0] : clientIp;
 	
 	var addr = ipaddr.parse(clientIp);
 

--- a/src/meta/blacklist.js
+++ b/src/meta/blacklist.js
@@ -65,6 +65,9 @@ Blacklist.test = function (clientIp, callback) {
 	// Some handy test addresses
 	// clientIp = '2001:db8:85a3:0:0:8a2e:370:7334';	// IPv6
 	// clientIp = '127.0.15.1';	// IPv4
+	// clientIp = '127.0.15.1:3443'; // IPv4 with port strip port to not fail 
+	clientIp = clientIp.split(":").length == 2 ? clientIp.split(":")[0] : clientIp;
+	
 	var addr = ipaddr.parse(clientIp);
 
 	if (


### PR DESCRIPTION
Blacklist.test in blacklist.js to strip port from ipv4.
my site was passing in 
24.18.192.75:52506
and nodebb was giving 
28/10 04:34:41 [6680] - error: /login
 Error: ipaddr: the address has neither IPv6 nor IPv4 format
So i updated the client Ip to strip the port number if its a v4 IP