### PR TITLE
a post object which filter:topic.reply can modify

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -243,18 +243,7 @@ module.exports = function (Topics) {
 				user.isReadyToPost(uid, cid, next);
 			},
 			function (next) {
-				plugins.fireHook('filter:topic.reply', data, next);
-			},
-			function (filteredData, next) {
-				content = filteredData.content || data.content;
-				if (content) {
-					content = utils.rtrim(content);
-				}
-
-				check(content, meta.config.minimumPostLength, meta.config.maximumPostLength, 'content-too-short', 'content-too-long', next);
-			},
-			function (next) {
-				posts.create({
+				var post = {
 					uid: uid,
 					tid: tid,
 					handle: data.handle,
@@ -262,7 +251,22 @@ module.exports = function (Topics) {
 					toPid: data.toPid,
 					timestamp: data.timestamp,
 					ip: data.req ? data.req.ip : null,
-				}, next);
+				};
+				data.post = post;
+				plugins.fireHook('filter:topic.reply', data, next);
+			},
+			function (filteredData, next) {
+				content = filteredData.post.content || filteredData.content || data.content;
+				if (content) {
+					content = utils.rtrim(content);
+				}
+
+				filteredData.post.content = content;
+
+				check(content, meta.config.minimumPostLength, meta.config.maximumPostLength, 'content-too-short', 'content-too-long', next);
+			},
+			function (next) {
+				posts.create(data.post, next);
 			},
 			function (_postData, next) {
 				postData = _postData;


### PR DESCRIPTION
Currently, the post object is created after the plugin filter, so the filter can not pass any custom data.

NOTE:  This changes the data format for `filter:topic.reply`, so perhaps this is a breaking change and only the MASTER branch version of this PR should be merged.    I need this for custom data to work, so I don't mind the plugin interface change.