### PR TITLE
Fix #6076, `action:home.get:*` returned to previous functionality

### DIFF
--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var helpers = {};
+var helpers = module.exports;
 
 helpers.setupPageRoute = function (router, name, middleware, middlewares, controller) {
 	middlewares = [middleware.maintenanceMode, middleware.registrationComplete, middleware.pageView, middleware.pluginHooks].concat(middlewares);
@@ -13,5 +13,3 @@ helpers.setupAdminPageRoute = function (router, name, middleware, middlewares, c
 	router.get(name, middleware.admin.buildHeader, middlewares, controller);
 	router.get('/api' + name, middlewares, controller);
 };
-
-module.exports = helpers;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -122,7 +122,9 @@ module.exports = function (app, middleware, hotswapIds, callback) {
 	app.use(middleware.stripLeadingSlashes);
 
 	// handle custom homepage routes
-	app.use(relativePath, controllers.home);
+	app.use(relativePath, controllers.home.rewrite);
+	// homepage handled by `action:homepage.get:[route]`
+	setupPageRoute(app, '/', middleware, [], controllers.home.pluginHook);
 
 	adminRoutes(router, middleware, controllers);
 	metaRoutes(router, middleware, controllers);

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -4,6 +4,8 @@ var async = require('async');
 var assert = require('assert');
 var nconf = require('nconf');
 var request = require('request');
+var fs = require('fs');
+var path = require('path');
 
 var db = require('./mocks/databasemock');
 var categories = require('../src/categories');
@@ -15,6 +17,7 @@ var meta = require('../src/meta');
 var translator = require('../src/translator');
 var privileges = require('../src/privileges');
 var plugins = require('../src/plugins');
+var utils = require('../src/utils');
 var helpers = require('./helpers');
 
 describe('Controllers', function () {
@@ -58,125 +61,160 @@ describe('Controllers', function () {
 		});
 	});
 
-
-	it('should load default home route', function (done) {
-		request(nconf.get('url'), function (err, res, body) {
-			assert.ifError(err);
-			assert.equal(res.statusCode, 200);
-			assert(body);
-			done();
-		});
-	});
-
-	it('should load unread as home route', function (done) {
-		meta.configs.set('homePageRoute', 'unread', function (err) {
-			assert.ifError(err);
-
-			request(nconf.get('url'), function (err, res, body) {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body);
-				done();
-			});
-		});
-	});
-
-	it('should load recent as home route', function (done) {
-		meta.configs.set('homePageRoute', 'recent', function (err) {
-			assert.ifError(err);
-
-			request(nconf.get('url'), function (err, res, body) {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body);
-				done();
-			});
-		});
-	});
-
-	it('should load popular as home route', function (done) {
-		meta.configs.set('homePageRoute', 'popular', function (err) {
-			assert.ifError(err);
-
-			request(nconf.get('url'), function (err, res, body) {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body);
-				done();
-			});
-		});
-	});
-
-	it('should load category as home route', function (done) {
-		meta.configs.set('homePageRoute', 'category/1/test-category', function (err) {
-			assert.ifError(err);
-
-			request(nconf.get('url'), function (err, res, body) {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body);
-				done();
-			});
-		});
-	});
-
-	it('should load not load breadcrumbs on home page route', function (done) {
-		request(nconf.get('url') + '/api', { json: true }, function (err, res, body) {
-			assert.ifError(err);
-			assert.equal(res.statusCode, 200);
-			assert(body);
-			assert(!body.breadcrumbs);
-			done();
-		});
-	});
-
-	it('should redirect to custom homepage', function (done) {
-		meta.configs.set('homePageRoute', 'groups', function (err) {
-			assert.ifError(err);
-
-			request(nconf.get('url'), function (err, res, body) {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body);
-				done();
-			});
-		});
-	});
-
-	it('should 404 if custom homepage does not exist', function (done) {
-		meta.configs.set('homePageRoute', 'this-route-does-not-exist', function (err) {
-			assert.ifError(err);
-
-			request(nconf.get('url'), function (err, res, body) {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 404);
-				assert(body);
-				done();
-			});
-		});
-	});
-
-	it('should render custom homepage with hook', function (done) {
+	describe('homepage', function () {
 		function hookMethod(hookData) {
 			assert(hookData.req);
 			assert(hookData.res);
 			assert(hookData.next);
-			hookData.res.json('works');
-		}
-		plugins.registerHook('myTestPlugin', {
-			hook: 'action:homepage.get:custom',
-			method: hookMethod,
-		});
-		meta.configs.set('homePageRoute', 'custom', function (err) {
-			assert.ifError(err);
 
+			hookData.res.render('custom', {
+				works: true,
+			});
+		}
+		var message = utils.generateUUID();
+		var tplPath = path.join(nconf.get('views_dir'), 'custom.tpl');
+
+		before(function () {
+			plugins.registerHook('myTestPlugin', {
+				hook: 'action:homepage.get:custom',
+				method: hookMethod,
+			});
+
+			fs.writeFileSync(tplPath, message);
+		});
+
+		it('should load default', function (done) {
 			request(nconf.get('url'), function (err, res, body) {
 				assert.ifError(err);
 				assert.equal(res.statusCode, 200);
-				assert.equal(body, '"works"');
-				plugins.unregisterHook('myTestPlugin', 'action:homepage.get:custom', hookMethod);
+				assert(body);
 				done();
 			});
+		});
+
+		it('should load unread', function (done) {
+			meta.configs.set('homePageRoute', 'unread', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert(body);
+					done();
+				});
+			});
+		});
+
+		it('should load recent', function (done) {
+			meta.configs.set('homePageRoute', 'recent', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert(body);
+					done();
+				});
+			});
+		});
+
+		it('should load popular', function (done) {
+			meta.configs.set('homePageRoute', 'popular', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert(body);
+					done();
+				});
+			});
+		});
+
+		it('should load category', function (done) {
+			meta.configs.set('homePageRoute', 'category/1/test-category', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert(body);
+					done();
+				});
+			});
+		});
+
+		it('should not load breadcrumbs on home page route', function (done) {
+			request(nconf.get('url') + '/api', { json: true }, function (err, res, body) {
+				assert.ifError(err);
+				assert.equal(res.statusCode, 200);
+				assert(body);
+				assert(!body.breadcrumbs);
+				done();
+			});
+		});
+
+		it('should redirect to custom', function (done) {
+			meta.configs.set('homePageRoute', 'groups', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert(body);
+					done();
+				});
+			});
+		});
+
+		it('should 404 if custom does not exist', function (done) {
+			meta.configs.set('homePageRoute', 'this-route-does-not-exist', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 404);
+					assert(body);
+					done();
+				});
+			});
+		});
+
+		it('api should work with hook', function (done) {
+			meta.configs.set('homePageRoute', 'custom', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url') + '/api', { json: true }, function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert.equal(body.works, true);
+					assert.equal(body.template.custom, true);
+
+					done();
+				});
+			});
+		});
+
+		it('should render with hook', function (done) {
+			meta.configs.set('homePageRoute', 'custom', function (err) {
+				assert.ifError(err);
+
+				request(nconf.get('url'), function (err, res, body) {
+					assert.ifError(err);
+					assert.equal(res.statusCode, 200);
+					assert.ok(body);
+					assert.ok(body.indexOf('<main id="panel"'));
+					assert.ok(body.indexOf(message) !== -1);
+
+					done();
+				});
+			});
+		});
+
+		after(function () {
+			plugins.unregisterHook('myTestPlugin', 'action:homepage.get:custom', hookMethod);
+			fs.unlinkSync(tplPath);
+			fs.unlinkSync(tplPath.replace(/\.tpl$/, '.js'));
 		});
 	});
 


### PR DESCRIPTION
Added tests to confirm `buildHeader` is used and `/api` works