### PR TITLE
Fix #5973 - Disable upvoting own posts

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -144,6 +144,7 @@
 	"not-enough-reputation-to-downvote": "You do not have enough reputation to downvote this post",
 	"not-enough-reputation-to-flag": "You do not have enough reputation to flag this post",
 	"already-flagged": "You have already flagged this post",
+	"self-vote": "You cannot upvote/downvote your own post",
 
 	"reload-failed": "NodeBB encountered a problem while reloading: \"%1\". NodeBB will continue to serve the existing client-side assets, although you should undo what you did just prior to reloading.",
 

--- a/public/src/client/topic/votes.js
+++ b/public/src/client/topic/votes.js
@@ -70,11 +70,7 @@ define('forum/topic/votes', ['components', 'translator', 'benchpress'], function
 			room_id: 'topic_' + ajaxify.data.tid,
 		}, function (err) {
 			if (err) {
-				if (err.message === 'self-vote') {
-					Votes.showVotes(post.attr('data-pid'));
-				} else {
-					app.alertError(err.message);
-				}
+				app.alertError(err.message);
 			}
 		});
 

--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -153,7 +153,7 @@ module.exports = function (Posts) {
 			},
 			function (results, next) {
 				if (parseInt(uid, 10) === parseInt(results.owner, 10)) {
-					return callback(new Error('self-vote'));
+					return callback(new Error('[[error:self-vote]]'));
 				}
 
 				if (command === 'downvote' && parseInt(results.reputation, 10) < parseInt(meta.config['privileges:downvote'], 10)) {


### PR DESCRIPTION
Upvoting/downvoting own posts now shows a proper error message.