### PR TITLE
Start reading progress at 0

### DIFF
--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -193,7 +193,7 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 		index = index > count ? count : index;
 		var relIndex = getRelativeIndex();
 		$('.pagination-block .pagination-text').translateHtml('[[global:pagination.out_of, ' + relIndex + ', ' + count + ']]');
-		var fraction = relIndex / count;
+		var fraction = (relIndex - 1) / (count - 1 || 1);
 		$('.pagination-block meter').val(fraction);
 		$('.pagination-block .progress-bar').width((fraction * 100) + '%');
 	};


### PR DESCRIPTION
This makes the progress bar on posts start at 0% instead of (1 / numposts)