### PR TITLE
Add cid for filter:category.update hook

### DIFF
--- a/src/categories/update.js
+++ b/src/categories/update.js
@@ -41,7 +41,7 @@ module.exports = function (Categories) {
 				}
 			},
 			function (next) {
-				plugins.fireHook('filter:category.update', { category: modifiedFields }, next);
+				plugins.fireHook('filter:category.update', { cid: cid, category: modifiedFields }, next);
 			},
 			function (categoryData, next) {
 				category = categoryData.category;


### PR DESCRIPTION
No category id was provided and therefore when `filter:category.update` hook is triggered, there is no way to figure out which category was edited