### PR TITLE
stop ajaxify opening local assets

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -349,6 +349,10 @@ $(document).ready(function () {
 				return;
 			}
 
+			if (this.href.test(/^\/(assets|plugins)/i)) {
+				return;
+			}
+
 			var internalLink = utils.isInternalURI(this, window.location, RELATIVE_PATH);
 
 			var process = function () {


### PR DESCRIPTION
Hi,

My configuration uses `assets/uploads` for static user uploaded files. This causes problem when using `nodebb-plugin-lightbox` as `ajaxifyAnchors` function forcefully does window.open on link hrefs, preventing any js to work properly. I have added just a regexp not to ajaxify plugins and assets local urls

Signed-off-by: Krzysztof Antoszek <krzysztof@antoszek.net>