### PR TITLE
Use setImmediate instead of process.nextTick.

### DIFF
--- a/src/database/mongo/hash.js
+++ b/src/database/mongo/hash.js
@@ -82,7 +82,7 @@ module.exports = function (db, module) {
 	module.getObjects = function (keys, callback) {
 		var cachedData = {};
 		function getFromCache() {
-			process.nextTick(callback, null, keys.map(function (key) {
+			setImmediate(callback, null, keys.map(function (key) {
 				return _.clone(cachedData[key]);
 			}));
 		}

--- a/src/database/mongo/sorted.js
+++ b/src/database/mongo/sorted.js
@@ -418,7 +418,7 @@ module.exports = function (db, module) {
 			// https://jira.mongodb.org/browse/SERVER-14322
 			// https://docs.mongodb.org/manual/reference/command/findAndModify/#upsert-and-unique-index
 			if (err && err.message.startsWith('E11000 duplicate key error')) {
-				return process.nextTick(module.sortedSetIncrBy, key, increment, value, callback);
+				return setImmediate(module.sortedSetIncrBy, key, increment, value, callback);
 			}
 			callback(err, result && result.value ? result.value.score : null);
 		});
@@ -521,7 +521,7 @@ module.exports = function (db, module) {
 						}
 
 						if (ids.length < options.batch && (!done || ids.length === 0)) {
-							return process.nextTick(next, null);
+							return setImmediate(next, null);
 						}
 						processFn(ids, function (err) {
 							_next(err);
@@ -532,7 +532,7 @@ module.exports = function (db, module) {
 						if (options.interval) {
 							setTimeout(next, options.interval);
 						} else {
-							process.nextTick(next);
+							setImmediate(next);
 						}
 					},
 				], next);

--- a/src/database/mongo/sorted/add.js
+++ b/src/database/mongo/sorted/add.js
@@ -16,7 +16,7 @@ module.exports = function (db, module) {
 
 		db.collection('objects').update({ _key: key, value: value }, { $set: { score: parseFloat(score) } }, { upsert: true, w: 1 }, function (err) {
 			if (err && err.message.startsWith('E11000 duplicate key error')) {
-				return process.nextTick(module.sortedSetAdd, key, score, value, callback);
+				return setImmediate(module.sortedSetAdd, key, score, value, callback);
 			}
 			callback(err);
 		});

--- a/src/meta/minifier.js
+++ b/src/meta/minifier.js
@@ -276,9 +276,9 @@ function buildCSS(data, callback) {
 		] : [autoprefixer]).process(lessOutput.css, {
 			from: undefined,
 		}).then(function (result) {
-			process.nextTick(callback, null, { code: result.css });
+			setImmediate(callback, null, { code: result.css });
 		}, function (err) {
-			process.nextTick(callback, err);
+			setImmediate(callback, err);
 		});
 	});
 }

--- a/src/privileges/users.js
+++ b/src/privileges/users.js
@@ -123,7 +123,7 @@ module.exports = function (privileges) {
 
 	privileges.users.canEdit = function (callerUid, uid, callback) {
 		if (parseInt(callerUid, 10) === parseInt(uid, 10)) {
-			return process.nextTick(callback, null, true);
+			return setImmediate(callback, null, true);
 		}
 		async.waterfall([
 			function (next) {

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -66,7 +66,7 @@ Upgrade.appendPluginScripts = function (files, callback) {
 					next();
 				} catch (e) {
 					winston.warn('[upgrade/appendPluginScripts] Unable to read plugin.json for plugin `' + plugin + '`. Skipping.');
-					process.nextTick(next);
+					setImmediate(next);
 				}
 			}, function (err) {
 				// Return list of upgrade scripts for continued processing


### PR DESCRIPTION
setImmediate runs after IO handlers, but process.nextTick supercedes them. This can cause the nodejs process to be killed by the kernel.