### PR TITLE
Fixed wrong callback given to groups.join

### DIFF
--- a/src/upgrades/1.10.0/view_deleted_privilege.js
+++ b/src/upgrades/1.10.0/view_deleted_privilege.js
@@ -18,7 +18,7 @@ module.exports = {
 				async.waterfall([
 					async.apply(db.getSortedSetRange.bind(db), 'group:cid:' + cid + ':privileges:moderate:members', 0, -1),
 					function (uids, next) {
-						async.each(uids, uid => groups.join('cid:' + cid + ':privileges:posts:view_deleted', uid, next), next);
+						async.each(uids, (uid, next) => groups.join('cid:' + cid + ':privileges:posts:view_deleted', uid, next), next);
 					},
 				], next);
 			}, callback);


### PR DESCRIPTION
While resetting my development environment for NodeBB I just noticed this error in the upgrade script for 1.10. Groups.join wasn't calling the callback given by async.each but instead the one above created a duplicate callback called error.