### PR TITLE
Fix scoped themes

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -186,8 +186,9 @@ program
 program
 	.command('build [targets...]')
 	.description('Compile static assets ' + '(JS, CSS, templates, languages, sounds)'.red)
-	.action(function (targets) {
-		require('./manage').build(targets.length ? targets : true);
+	.option('-s, --series', 'Run builds in series without extra processes')
+	.action(function (targets, options) {
+		require('./manage').build(targets.length ? targets : true, options);
 	})
 	.on('--help', function () {
 		require('./manage').buildTargets();

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -134,12 +134,21 @@ function buildTargets(targets, parallel, callback) {
 	}, callback);
 }
 
-function build(targets, callback) {
+function build(targets, options, callback) {
+	if (!callback && typeof options === 'function') {
+		callback = options;
+		options = {};
+	} else if (!options) {
+		options = {};
+	}
+
 	if (targets === true) {
 		targets = allTargets;
 	} else if (!Array.isArray(targets)) {
 		targets = targets.split(',');
 	}
+
+	var parallel = !nconf.get('series') && !options.series;
 
 	targets = targets
 		// get full target name
@@ -200,7 +209,6 @@ function build(targets, callback) {
 				require('./minifier').maxThreads = threads - 1;
 			}
 
-			var parallel = !nconf.get('series');
 			if (parallel) {
 				winston.info('[build] Building in parallel mode');
 			} else {

--- a/src/meta/css.js
+++ b/src/meta/css.js
@@ -89,6 +89,7 @@ function getImports(files, prefix, extension, callback) {
 function getBundleMetadata(target, callback) {
 	var paths = [
 		path.join(__dirname, '../../node_modules'),
+		path.join(__dirname, '../../public/less'),
 		path.join(__dirname, '../../public/vendor/fontawesome/less'),
 	];
 


### PR DESCRIPTION
Added `public/less` to the base less paths.

@barisusakli there's an issue resulting in the minifier css bundler not returning results, which leads to the `async.waterfall` not working correctly (the `bundle` variable is set to the `next` function)