### PR TITLE
Add settings page to control watched categories

### DIFF
--- a/public/src/client/account/categories.js
+++ b/public/src/client/account/categories.js
@@ -1,0 +1,41 @@
+'use strict';
+
+
+define('forum/account/categories', ['forum/account/header'], function (header) {
+	var Categories = {};
+
+	Categories.init = function () {
+		header.init();
+
+		ajaxify.data.categories.forEach(function (category) {
+			handleIgnoreWatch(category.cid);
+		});
+	};
+
+	function handleIgnoreWatch(cid) {
+		var category = $('[data-cid="' + cid + '"]');
+		category.find('[component="category/watching"], [component="category/ignoring"]').on('click', function () {
+			var $this = $(this);
+			var command = $this.attr('component') === 'category/watching' ? 'watch' : 'ignore';
+
+			socket.emit('categories.' + command, cid, function (err, modified_cids) {
+				if (err) {
+					return app.alertError(err.message);
+				}
+
+				modified_cids.forEach(function (cid) {
+					var category = $('[data-cid="' + cid + '"]');
+					category.find('[component="category/watching/menu"]').toggleClass('hidden', command !== 'watch');
+					category.find('[component="category/watching/check"]').toggleClass('fa-check', command === 'watch');
+
+					category.find('[component="category/ignoring/menu"]').toggleClass('hidden', command !== 'ignore');
+					category.find('[component="category/ignoring/check"]').toggleClass('fa-check', command === 'ignore');
+				});
+
+				app.alertSuccess('[[category:' + command + '.message]]');
+			});
+		});
+	}
+
+	return Categories;
+});

--- a/src/controllers/accounts.js
+++ b/src/controllers/accounts.js
@@ -4,6 +4,7 @@ var accountsController = {
 	profile: require('./accounts/profile'),
 	edit: require('./accounts/edit'),
 	info: require('./accounts/info'),
+	categories: require('./accounts/categories'),
 	settings: require('./accounts/settings'),
 	groups: require('./accounts/groups'),
 	follow: require('./accounts/follow'),

--- a/src/controllers/accounts/categories.js
+++ b/src/controllers/accounts/categories.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var async = require('async');
+
+var user = require('../../user');
+var categories = require('../../categories');
+var accountHelpers = require('./helpers');
+
+var categoriesController = {};
+
+
+categoriesController.get = function (req, res, callback) {
+	var userData;
+	async.waterfall([
+		function (next) {
+			accountHelpers.getUserDataByUserSlug(req.params.userslug, req.uid, next);
+		},
+		function (_userData, next) {
+			userData = _userData;
+			if (!userData) {
+				return callback();
+			}
+
+			async.parallel({
+				ignored: function (next) {
+					user.getIgnoredCategories(userData.uid, next);
+				},
+				all: function (next) {
+					categories.getCategoriesByPrivilege('cid:0:children', userData.uid, 'find', next);
+				},
+			}, next);
+		},
+		function (results, next) {
+			flattenArray(results);
+			userData.categories = results.all;
+			next();
+		},
+	], function (err) {
+		if (err) {
+			return callback(err);
+		}
+
+		userData.title = '[[pages:account/watched_categories]]';
+		res.render('account/categories', userData);
+	});
+};
+
+function moveChildrenToRoot(child) {
+	this.results.all.splice(this.i + this.results.j, 0, child);
+	this.results.j = this.results.j + 1;
+}
+
+function flattenArray(results) {
+	for (var i = 0; i < results.all.length; i++) {
+		var category = results.all[i];
+
+		category.isIgnored = false;
+		if (results.ignored.includes(category.cid)) {
+			category.isIgnored = true;
+		}
+
+		if (!!category.children && !!category.children.length) {
+			results.j = 1;
+			category.children.forEach(moveChildrenToRoot, { i: i, results: results });
+			category.children = [];
+		}
+	}
+}
+
+module.exports = categoriesController;

--- a/src/routes/accounts.js
+++ b/src/routes/accounts.js
@@ -14,6 +14,7 @@ module.exports = function (app, middleware, controllers) {
 	setupPageRoute(app, '/user/:userslug/following', middleware, middlewares, controllers.accounts.follow.getFollowing);
 	setupPageRoute(app, '/user/:userslug/followers', middleware, middlewares, controllers.accounts.follow.getFollowers);
 
+	setupPageRoute(app, '/user/:userslug/categories', middleware, middlewares, controllers.accounts.categories.get);
 	setupPageRoute(app, '/user/:userslug/posts', middleware, middlewares, controllers.accounts.posts.getPosts);
 	setupPageRoute(app, '/user/:userslug/topics', middleware, middlewares, controllers.accounts.posts.getTopics);
 	setupPageRoute(app, '/user/:userslug/best', middleware, middlewares, controllers.accounts.posts.getBestPosts);

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -203,10 +203,10 @@ function ignoreOrWatch(fn, socket, cid, callback) {
 
 			async.each(cids, function (cid, next) {
 				fn(socket.uid, cid, next);
-			}, next);
+			}, next(null, cids));
 		},
-		function (next) {
-			topics.pushUnreadCount(socket.uid, next);
+		function (cids, next) {
+			topics.pushUnreadCount(socket.uid, next(null, cids));
 		},
 	], callback);
 }

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -174,6 +174,8 @@ SocketCategories.ignore = function (socket, cid, callback) {
 };
 
 function ignoreOrWatch(fn, socket, cid, callback) {
+	var cids = [parseInt(cid, 10)];
+
 	async.waterfall([
 		function (next) {
 			db.getSortedSetRange('categories:cid', 0, -1, next);
@@ -187,10 +189,7 @@ function ignoreOrWatch(fn, socket, cid, callback) {
 				c.parentCid = parseInt(c.parentCid, 10);
 			});
 
-			var cids = [parseInt(cid, 10)];
-
 			// filter to subcategories of cid
-
 			var cat;
 			do {
 				cat = categoryData.find(function (c) {
@@ -203,10 +202,13 @@ function ignoreOrWatch(fn, socket, cid, callback) {
 
 			async.each(cids, function (cid, next) {
 				fn(socket.uid, cid, next);
-			}, next(null, cids));
+			}, next);
 		},
-		function (cids, next) {
-			topics.pushUnreadCount(socket.uid, next(null, cids));
+		function (next) {
+			topics.pushUnreadCount(socket.uid, next);
+		},
+		function (next) {
+			next(null, cids);
 		},
 	], callback);
 }


### PR DESCRIPTION
This commit, together with the [pull request at the Persona theme](https://github.com/NodeBB/nodebb-theme-persona/pull/422), adds a settings page to control your watched and ignored categories.

The page shows all categories in a flat view and the buttons do update as expected, changing the watched setting in a top level modifies the setting for all sub-categories.

This closes #5851

![virtualbox_arch_12_07_2018_13_11_52](https://user-images.githubusercontent.com/2224730/42725778-e78406ee-875f-11e8-859e-678b3a455f94.png)
