### PR TITLE
Preserve case of respondee's slug when responding to their post.

### DIFF
--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -338,7 +338,7 @@ define('forum/topic/postTools', [
 		}
 
 		if (post.length) {
-			slug = post.attr('data-userslug');
+			slug = utils.slugify(post.attr('data-username'), true);
 		}
 		if (post.length && post.attr('data-uid') !== '0') {
 			slug = '@' + slug;


### PR DESCRIPTION
When quoting a post by `User Name`, instead of
`@user-name said in [...]`
this change will have
`@User-Name said in [...]`

It also does a corresponding change for replies with no text body.