### PR TITLE
DRY req props that depend on auth (fix #6727)

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -8,7 +8,7 @@ var groups = require('../groups');
 var user = require('../user');
 var helpers = require('./helpers');
 
-var groupsController = {};
+var groupsController = module.exports;
 
 groupsController.list = function (req, res, next) {
 	var sort = req.query.sort || 'alpha';
@@ -177,5 +177,3 @@ groupsController.uploadCover = function (req, res, next) {
 		res.json([{ url: image.url }]);
 	});
 };
-
-module.exports = groupsController;

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -25,8 +25,8 @@ module.exports = function (middleware) {
 				req: req,
 				res: res,
 				next: function (err) {
-					auth.setAuthVars(req, res, function() {next(err);});
-				}
+					auth.setAuthVars(req, res, function () { next(err); });
+				},
 			});
 		}
 

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -8,6 +8,8 @@ var user = require('../user');
 var privileges = require('../privileges');
 var plugins = require('../plugins');
 
+var auth = require('../routes/authentication');
+
 var controllers = {
 	helpers: require('../controllers/helpers'),
 };
@@ -22,7 +24,9 @@ module.exports = function (middleware) {
 			return plugins.fireHook('action:middleware.authenticate', {
 				req: req,
 				res: res,
-				next: next,
+				next: function (err) {
+					auth.setAuthVars(req, res, function() {next(err);});
+				}
 			});
 		}
 

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -25,7 +25,7 @@ Auth.initialize = function (app, middleware) {
 	Auth.middleware = middleware;
 };
 
-Auth.setAuthVars = function(req, res, next) {
+Auth.setAuthVars = function (req, res, next) {
 	var isSpider = req.isSpider();
 	req.loggedIn = !isSpider && !!req.user;
 	if (isSpider) {

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -19,21 +19,23 @@ Auth.initialize = function (app, middleware) {
 	app.use(passport.initialize());
 	app.use(passport.session());
 
-	app.use(function (req, res, next) {
-		var isSpider = req.isSpider();
-		req.loggedIn = !isSpider && !!req.user;
-		if (isSpider) {
-			req.uid = -1;
-		} else if (req.user) {
-			req.uid = parseInt(req.user.uid, 10);
-		} else {
-			req.uid = 0;
-		}
-		next();
-	});
+	app.use(Auth.setAuthVars);
 
 	Auth.app = app;
 	Auth.middleware = middleware;
+};
+
+Auth.setAuthVars = function(req, res, next) {
+	var isSpider = req.isSpider();
+	req.loggedIn = !isSpider && !!req.user;
+	if (isSpider) {
+		req.uid = -1;
+	} else if (req.user) {
+		req.uid = parseInt(req.user.uid, 10);
+	} else {
+		req.uid = 0;
+	}
+	next();
 };
 
 Auth.getLoginStrategies = function () {


### PR DESCRIPTION
Authentication leads to req.loggedIn and req.uid being set. However, a
later authentication event might outdate them. Here, I create one
function for setting those properties, and make sure it also is called
on the `action:middleware.authenticate` hook, which would be such an
authentication event. If there are other places, those should be added
as well.