### PR TITLE
Unread changes closes #6781

### DIFF
--- a/public/src/client/footer.js
+++ b/public/src/client/footer.js
@@ -44,16 +44,22 @@ define('forum/footer', ['notifications', 'chat', 'components', 'translator'], fu
 
 			var isNewTopic = post.isMain && parseInt(post.uid, 10) !== parseInt(app.user.uid, 10);
 			if (isNewTopic) {
-				var unreadNewTopicCount = parseInt($('a[href="' + config.relative_path + '/unread/new"].navigation-link i').attr('data-content'), 10) + 1;
-				updateUnreadTopicCount('/unread/new', unreadNewTopicCount);
+				var unreadNewTopicCount = parseInt($('a[href="' + config.relative_path + '/unread?filter=new"].navigation-link i').attr('data-content'), 10) + 1;
+				updateUnreadTopicCount('/unread?filter=new', unreadNewTopicCount);
+			}
+
+			var isUnreplied = parseInt(post.topic.postcount, 10) <= 1;
+			if (isUnreplied) {
+				var unreadUnrepliedTopicCount = parseInt($('a[href="' + config.relative_path + '/unread?filter=unreplied"].navigation-link i').attr('data-content'), 10) + 1;
+				updateUnreadTopicCount('/unread?filter=unreplied', unreadUnrepliedTopicCount);
 			}
 			socket.emit('topics.isFollowed', post.topic.tid, function (err, isFollowed) {
 				if (err) {
 					return app.alertError(err.message);
 				}
 				if (isFollowed) {
-					var unreadWatchedTopicCount = parseInt($('a[href="' + config.relative_path + '/unread/watched"].navigation-link i').attr('data-content'), 10) + 1;
-					updateUnreadTopicCount('/unread/watched', unreadWatchedTopicCount);
+					var unreadWatchedTopicCount = parseInt($('a[href="' + config.relative_path + '/unread?filter=watched"].navigation-link i').attr('data-content'), 10) + 1;
+					updateUnreadTopicCount('/unread?filter=watched', unreadWatchedTopicCount);
 				}
 			});
 		}
@@ -77,8 +83,8 @@ define('forum/footer', ['notifications', 'chat', 'components', 'translator'], fu
 
 	function updateUnreadCounters(data) {
 		updateUnreadTopicCount('/unread', data.unreadTopicCount);
-		updateUnreadTopicCount('/unread/new', data.unreadNewTopicCount);
-		updateUnreadTopicCount('/unread/watched', data.unreadWatchedTopicCount);
+		updateUnreadTopicCount('/unread?filter=new', data.unreadNewTopicCount);
+		updateUnreadTopicCount('/unread?filter=watched', data.unreadWatchedTopicCount);
 	}
 
 	socket.on('event:unread.updateCount', updateUnreadCounters);

--- a/public/src/client/footer.js
+++ b/public/src/client/footer.js
@@ -85,6 +85,7 @@ define('forum/footer', ['notifications', 'chat', 'components', 'translator'], fu
 		updateUnreadTopicCount('/unread', data.unreadTopicCount);
 		updateUnreadTopicCount('/unread?filter=new', data.unreadNewTopicCount);
 		updateUnreadTopicCount('/unread?filter=watched', data.unreadWatchedTopicCount);
+		updateUnreadTopicCount('/unread?filter=unreplied', data.unreadUnrepliedTopicCount);
 	}
 
 	socket.on('event:unread.updateCount', updateUnreadCounters);

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -165,15 +165,21 @@ module.exports = function (middleware) {
 							iconClass: item.iconClass + ' unread-count',
 						});
 					}
-					if (item.originalRoute === '/unread/new' && results.unreadCounts.new > 0) {
+					if (item.originalRoute === '/unread?filter=new' && results.unreadCounts.new > 0) {
 						return Object.assign({}, item, {
 							content: unreadCount.newTopic,
 							iconClass: item.iconClass + ' unread-count',
 						});
 					}
-					if (item.originalRoute === '/unread/watched' && results.unreadCounts.watched > 0) {
+					if (item.originalRoute === '/unread?filter=watched' && results.unreadCounts.watched > 0) {
 						return Object.assign({}, item, {
 							content: unreadCount.watchedTopic,
+							iconClass: item.iconClass + ' unread-count',
+						});
+					}
+					if (item.originalRoute === '/unread?filter=unreplied' && results.unreadCounts.unreplied > 0) {
+						return Object.assign({}, item, {
+							content: unreadCount.unrepliedTopic,
 							iconClass: item.iconClass + ' unread-count',
 						});
 					}

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -144,14 +144,14 @@ module.exports = function (middleware) {
 				setBootswatchCSS(templateValues, res.locals.config);
 
 				var unreadCount = {
-					topic: results.unreadCounts['']|| 0,
+					topic: results.unreadCounts[''] || 0,
 					newTopic: results.unreadCounts.new || 0,
 					watchedTopic: results.unreadCounts.watched || 0,
 					unrepliedTopic: results.unreadCounts.unreplied || 0,
 					chat: results.unreadChatCount || 0,
 					notification: results.unreadNotificationCount || 0,
 				};
-				console.log('test', unreadCount, results.unreadCounts);
+
 				Object.keys(unreadCount).forEach(function (key) {
 					if (unreadCount[key] > 99) {
 						unreadCount[key] = '99+';

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -159,31 +159,16 @@ module.exports = function (middleware) {
 				});
 
 				results.navigation = results.navigation.map(function (item) {
-					if (item.originalRoute === '/unread' && results.unreadCounts[''] > 0) {
-						return Object.assign({}, item, {
-							content: unreadCount.topic,
-							iconClass: item.iconClass + ' unread-count',
-						});
+					function modifyNavItem(item, route, count, content) {
+						if (item && item.originalRoute === route && count > 0) {
+							item.content = content;
+							item.iconClass += ' unread-count';
+						}
 					}
-					if (item.originalRoute === '/unread?filter=new' && results.unreadCounts.new > 0) {
-						return Object.assign({}, item, {
-							content: unreadCount.newTopic,
-							iconClass: item.iconClass + ' unread-count',
-						});
-					}
-					if (item.originalRoute === '/unread?filter=watched' && results.unreadCounts.watched > 0) {
-						return Object.assign({}, item, {
-							content: unreadCount.watchedTopic,
-							iconClass: item.iconClass + ' unread-count',
-						});
-					}
-					if (item.originalRoute === '/unread?filter=unreplied' && results.unreadCounts.unreplied > 0) {
-						return Object.assign({}, item, {
-							content: unreadCount.unrepliedTopic,
-							iconClass: item.iconClass + ' unread-count',
-						});
-					}
-
+					modifyNavItem(item, '/unread', results.unreadCounts[''], unreadCount.topic);
+					modifyNavItem(item, '/unread?filter=new', results.unreadCounts.new, unreadCount.newTopic);
+					modifyNavItem(item, '/unread?filter=watched', results.unreadCounts.watched, unreadCount.watchedTopic);
+					modifyNavItem(item, '/unread?filter=unreplied', results.unreadCounts.unreplied, unreadCount.unrepliedTopic);
 					return item;
 				});
 

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -160,9 +160,11 @@ module.exports = function (middleware) {
 
 				results.navigation = results.navigation.map(function (item) {
 					function modifyNavItem(item, route, count, content) {
-						if (item && item.originalRoute === route && count > 0) {
+						if (item && item.originalRoute === route) {
 							item.content = content;
-							item.iconClass += ' unread-count';
+							if (count > 0) {
+								item.iconClass += ' unread-count';
+							}
 						}
 					}
 					modifyNavItem(item, '/unread', results.unreadCounts[''], unreadCount.topic);

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -120,14 +120,17 @@ module.exports = function (middleware) {
 					banned: async.apply(user.isBanned, req.uid),
 					banReason: async.apply(user.getBannedReason, req.uid),
 
+					unreadCounts: async.apply(topics.getUnreadCounts, req.uid),
 					unreadTopicCount: async.apply(topics.getTotalUnread, req.uid),
 					unreadNewTopicCount: async.apply(topics.getTotalUnread, req.uid, 'new'),
 					unreadWatchedTopicCount: async.apply(topics.getTotalUnread, req.uid, 'watched'),
 					unreadChatCount: async.apply(messaging.getUnreadCount, req.uid),
 					unreadNotificationCount: async.apply(user.notifications.getUnreadCount, req.uid),
+
 				}, next);
 			},
 			function (results, next) {
+				console.log('test', results.unreadCounts);
 				if (results.banned) {
 					req.logout();
 					return res.redirect('/');

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -120,17 +120,12 @@ module.exports = function (middleware) {
 					banned: async.apply(user.isBanned, req.uid),
 					banReason: async.apply(user.getBannedReason, req.uid),
 
-					unreadCounts: async.apply(topics.getUnreadCounts, req.uid),
-					unreadTopicCount: async.apply(topics.getTotalUnread, req.uid),
-					unreadNewTopicCount: async.apply(topics.getTotalUnread, req.uid, 'new'),
-					unreadWatchedTopicCount: async.apply(topics.getTotalUnread, req.uid, 'watched'),
+					unreadCounts: async.apply(topics.getUnreadTids, { uid: req.uid, count: true }),
 					unreadChatCount: async.apply(messaging.getUnreadCount, req.uid),
 					unreadNotificationCount: async.apply(user.notifications.getUnreadCount, req.uid),
-
 				}, next);
 			},
 			function (results, next) {
-				console.log('test', results.unreadCounts);
 				if (results.banned) {
 					req.logout();
 					return res.redirect('/');
@@ -149,12 +144,14 @@ module.exports = function (middleware) {
 				setBootswatchCSS(templateValues, res.locals.config);
 
 				var unreadCount = {
-					topic: results.unreadTopicCount || 0,
-					newTopic: results.unreadNewTopicCount || 0,
-					watchedTopic: results.unreadWatchedTopicCount || 0,
+					topic: results.unreadCounts['']|| 0,
+					newTopic: results.unreadCounts.new || 0,
+					watchedTopic: results.unreadCounts.watched || 0,
+					unrepliedTopic: results.unreadCounts.unreplied || 0,
 					chat: results.unreadChatCount || 0,
 					notification: results.unreadNotificationCount || 0,
 				};
+				console.log('test', unreadCount, results.unreadCounts);
 				Object.keys(unreadCount).forEach(function (key) {
 					if (unreadCount[key] > 99) {
 						unreadCount[key] = '99+';
@@ -162,19 +159,19 @@ module.exports = function (middleware) {
 				});
 
 				results.navigation = results.navigation.map(function (item) {
-					if (item.originalRoute === '/unread' && results.unreadTopicCount > 0) {
+					if (item.originalRoute === '/unread' && results.unreadCounts[''] > 0) {
 						return Object.assign({}, item, {
 							content: unreadCount.topic,
 							iconClass: item.iconClass + ' unread-count',
 						});
 					}
-					if (item.originalRoute === '/unread/new' && results.unreadNewTopicCount > 0) {
+					if (item.originalRoute === '/unread/new' && results.unreadCounts.new > 0) {
 						return Object.assign({}, item, {
 							content: unreadCount.newTopic,
 							iconClass: item.iconClass + ' unread-count',
 						});
 					}
-					if (item.originalRoute === '/unread/watched' && results.unreadWatchedTopicCount > 0) {
+					if (item.originalRoute === '/unread/watched' && results.unreadCounts.watched > 0) {
 						return Object.assign({}, item, {
 							content: unreadCount.watchedTopic,
 							iconClass: item.iconClass + ' unread-count',

--- a/src/socket.io/helpers.js
+++ b/src/socket.io/helpers.js
@@ -35,6 +35,9 @@ SocketHelpers.notifyNew = function (uid, type, result) {
 			user.blocks.filterUids(uid, uids, next);
 		},
 		function (uids, next) {
+			user.blocks.filterUids(result.posts[0].topic.uid, uids, next);
+		},
+		function (uids, next) {
 			plugins.fireHook('filter:sockets.sendNewPostToUids', { uidsTo: uids, uidFrom: uid, type: type }, next);
 		},
 	], function (err, data) {

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -261,12 +261,19 @@ SocketUser.getUnreadCounts = function (socket, data, callback) {
 		return callback(null, {});
 	}
 	async.parallel({
-		unreadTopicCount: async.apply(topics.getTotalUnread, socket.uid),
-		unreadNewTopicCount: async.apply(topics.getTotalUnread, socket.uid, 'new'),
-		unreadWatchedTopicCount: async.apply(topics.getTotalUnread, socket.uid, 'watched'),
+		unreadCounts: async.apply(topics.getUnreadTids, { uid: socket.uid, count: true }),
 		unreadChatCount: async.apply(messaging.getUnreadCount, socket.uid),
 		unreadNotificationCount: async.apply(user.notifications.getUnreadCount, socket.uid),
-	}, callback);
+	}, function (err, results) {
+		if (err) {
+			return callback(err);
+		}
+		results.unreadTopicCount = results.unreadCounts[''];
+		results.unreadNewTopicCount = results.unreadCounts.new;
+		results.unreadWatchedTopicCount = results.unreadCounts.watched;
+		results.unreadUnrepliedTopicCount = results.unreadCounts.unreplied;
+		callback(null, results);
+	});
 };
 
 SocketUser.invite = function (socket, email, callback) {

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -298,7 +298,7 @@ module.exports = function (Topics) {
 						posts.getUserInfoForPosts([postData.uid], uid, next);
 					},
 					topicInfo: function (next) {
-						Topics.getTopicFields(tid, ['tid', 'title', 'slug', 'cid', 'postcount', 'mainPid'], next);
+						Topics.getTopicFields(tid, ['tid', 'uid', 'title', 'slug', 'cid', 'postcount', 'mainPid'], next);
 					},
 					parents: function (next) {
 						Topics.addParentPosts([postData], next);

--- a/src/topics/teaser.js
+++ b/src/topics/teaser.js
@@ -5,6 +5,7 @@ var async = require('async');
 var _ = require('lodash');
 var winston = require('winston');
 
+var db = require('../database');
 var meta = require('../meta');
 var user = require('../user');
 var posts = require('../posts');
@@ -118,7 +119,7 @@ module.exports = function (Topics) {
 			}
 			async.mapSeries(teasers, function (postData, nextPost) {
 				if (blockedUids.includes(parseInt(postData.uid, 10))) {
-					getPreviousNonBlockedPost(postData, uid, nextPost);
+					getPreviousNonBlockedPost(postData, blockedUids, nextPost);
 				} else {
 					setImmediate(nextPost, null, postData);
 				}
@@ -126,38 +127,40 @@ module.exports = function (Topics) {
 		});
 	}
 
-	function getPreviousNonBlockedPost(postData, uid, callback) {
+	function getPreviousNonBlockedPost(postData, blockedUids, callback) {
 		let isBlocked = false;
 		let prevPost = postData;
-		Topics.getPids(postData.tid, function (err, pids) {
-			if (err) {
-				return callback(err);
-			}
+		const postsPerIteration = 5;
+		let start = 0;
+		let stop = start + postsPerIteration - 1;
 
-			async.doWhilst(function (next) {
-				async.waterfall([
-					function (next) {
-						const index = pids.lastIndexOf(String(prevPost.pid));
-						if (index <= 0) {
-							return callback(null, null);
-						}
+		async.doWhilst(function (next) {
+			async.waterfall([
+				function (next) {
+					db.getSortedSetRevRange('tid:' + postData.tid + ':posts', start, stop, next);
+				},
+				function (pids, next) {
+					if (!pids.length) {
+						return callback(null, null);
+					}
 
-						posts.getPostFields(pids[index - 1], ['pid', 'uid', 'timestamp', 'tid', 'content'], next);
-					},
-					function (_prevPost, next) {
-						prevPost = _prevPost;
-						user.blocks.is(prevPost.uid, uid, next);
-					},
-					function (_isBlocked, next) {
-						isBlocked = _isBlocked;
-						next();
-					},
-				], next);
-			}, function () {
-				return isBlocked && prevPost && prevPost.pid;
-			}, function (err) {
-				callback(err, prevPost);
-			});
+					posts.getPostsFields(pids, ['pid', 'uid', 'timestamp', 'tid', 'content'], next);
+				},
+				function (prevPosts, next) {
+					isBlocked = prevPosts.every(function (post) {
+						const isPostBlocked = blockedUids.includes(parseInt(post.uid, 10));
+						prevPost = !isPostBlocked ? post : prevPost;
+						return isPostBlocked;
+					});
+					start += postsPerIteration;
+					stop = start + postsPerIteration - 1;
+					next();
+				},
+			], next);
+		}, function () {
+			return isBlocked && prevPost && prevPost.pid;
+		}, function (err) {
+			callback(err, prevPost);
 		});
 	}
 

--- a/src/topics/teaser.js
+++ b/src/topics/teaser.js
@@ -114,7 +114,7 @@ module.exports = function (Topics) {
 	function handleBlocks(uid, teasers, callback) {
 		user.blocks.list(uid, function (err, blockedUids) {
 			if (err || !blockedUids.length) {
-				return callback(err);
+				return callback(err, teasers);
 			}
 			async.mapSeries(teasers, function (postData, nextPost) {
 				if (blockedUids.includes(parseInt(postData.uid, 10))) {

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -113,6 +113,7 @@ module.exports = function (Topics) {
 					uid: uid,
 					tids: data.tids,
 					counts: data.counts,
+					tidsByFilter: data.tidsByFilter,
 					cid: params.cid,
 					filter: params.filter,
 				}, next);

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -233,7 +233,11 @@ module.exports = function (Topics) {
 					}
 				});
 
-				next(null, { counts: counts, tids: tidsByFilter[params.filter] });
+				next(null, {
+					counts: counts,
+					tids: tidsByFilter[params.filter],
+					tidsByFilter: tidsByFilter,
+				});
 			},
 		], callback);
 	}

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -76,6 +76,8 @@ module.exports = function (Topics) {
 			return callback(null, params.count ? counts : []);
 		}
 
+		params.filter = params.filter || '';
+
 		var cutoff = params.cutoff || Topics.unreadCutoff();
 
 		if (params.cid && !Array.isArray(params.cid)) {
@@ -153,13 +155,7 @@ module.exports = function (Topics) {
 			return !userRead[recentTopic.value] || recentTopic.score > userRead[recentTopic.value];
 		});
 
-		// convert topics to tids
-		tids = tids.map(function (topic) {
-			return topic.value;
-		});
-
-		// make sure tids are unique
-		tids = _.uniq(tids);
+		tids = _.uniq(tids.map(topic => topic.value));
 
 		var cid = params.cid;
 		var uid = params.uid;
@@ -214,7 +210,7 @@ module.exports = function (Topics) {
 							tidsByFilter.watched.push(topic.tid);
 						}
 
-						if (parseInt(topic.postcount, 10) === 1) {
+						if (parseInt(topic.postcount, 10) <= 1) {
 							counts.unreplied += 1;
 							tidsByFilter.unreplied.push(topic.tid);
 						}

--- a/src/topics/unread.js
+++ b/src/topics/unread.js
@@ -176,6 +176,7 @@ module.exports = function (Topics) {
 			function (_blockedUids, next) {
 				blockedUids = _blockedUids;
 				filterTidsThatHaveBlockedPosts({
+					uid: uid,
 					tids: tids,
 					blockedUids: blockedUids,
 					recentTids: results.recentTids,


### PR DESCRIPTION
- fix unread filters to use the correct links (/unread?filter=new vs /unread/new)
- add `unreplied` filter to unread counts
- if user doesn't have anyone blocked do not try to filter teasers and unread topics
- do not call getUnreadTids 3 times to calculate unread counts, one call with `count: true` returns all counts
- dont load all pids since your last visit to topic to figure out if topic should be marked as unread
- don't increment unread counter if a new reply is made to topic and you have ignored the user who posted that topic(ie topic is not visible in /unread)