### PR TITLE
Fix single-host-cluster socket.io

### DIFF
--- a/src/socket.io/index.js
+++ b/src/socket.io/index.js
@@ -28,9 +28,7 @@ Sockets.init = function (server) {
 	});
 
 	if (nconf.get('singleHostCluster')) {
-		io.adapter(require('socket.io-adapter-cluster')({
-			client: require('./single-host-cluster'),
-		}));
+		io.adapter(require('./single-host-cluster'));
 	} else if (nconf.get('redis')) {
 		io.adapter(require('../database/redis').socketAdapter());
 	} else {

--- a/src/socket.io/single-host-cluster.js
+++ b/src/socket.io/single-host-cluster.js
@@ -51,4 +51,17 @@ process.on('message', function (message) {
 	}
 });
 
-module.exports = Client;
+var adapter = require('socket.io-adapter-cluster')({
+	client: Client,
+});
+// Otherwise, every node thinks it is the master node and ignores messages
+// because they are from "itself".
+Object.defineProperty(adapter.prototype, 'id', {
+	get: function () {
+		return process.pid;
+	},
+	set: function (id) {
+		// ignore
+	},
+});
+module.exports = adapter;


### PR DESCRIPTION
It was silently dropping every message because every node thought it was the master node.