### PR TITLE
Small UI fixes for ACP privileges category selector

### DIFF
--- a/public/language/en-GB/admin/manage/categories.json
+++ b/public/language/en-GB/admin/manage/categories.json
@@ -29,7 +29,8 @@
 	"select-category": "Select Category",
 	"set-parent-category": "Set Parent Category",
 
-	"privileges.description": "You can configure the access control privileges for this category in this section. Privileges can be granted on a per-user or a per-group basis. You can add a new user to this table by searching for them in the form below.",
+	"privileges.description": "You can configure the access control privileges for this category in this section. Privileges can be granted on a per-user or a per-group basis. Select the domain of effect from the dropdown below.",
+	"privileges.category-selector": "Configuring privileges for ",
 	"privileges.warning": "<strong>Note</strong>: Privilege settings take effect immediately. It is not necessary to save the category after adjusting these settings.",
 	"privileges.section-viewing": "Viewing Privileges",
 	"privileges.section-posting": "Posting Privileges",

--- a/src/controllers/admin/privileges.js
+++ b/src/controllers/admin/privileges.js
@@ -39,10 +39,10 @@ privilegesController.get = function (req, res, callback) {
 			data.allCategories.forEach(function (category) {
 				if (category) {
 					category.selected = category.cid === cid;
-				}
 
-				if (category.selected) {
-					data.selected = category;
+					if (category.selected) {
+						data.selected = category;
+					}
 				}
 			});
 

--- a/src/views/admin/manage/privileges.tpl
+++ b/src/views/admin/manage/privileges.tpl
@@ -6,9 +6,9 @@
 			</p>
 
 			<p class="lead">
-				Currently viewing privileges for
+				[[admin/manage/categories:privileges.category-selector]]
 				<button type="button" id="category-selector" class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored">
-					{selected}
+					{selected} <i class="fa fa-angle-down"></i>
 				</button>
 
 				<ul class="mdl-menu mdl-menu--bottom-left mdl-js-menu mdl-js-ripple-effect" for="category-selector">


### PR DESCRIPTION
- Add dropdown chevron
- Change translations
- Safety against `category` not an object

Looks like this now:

![image](https://user-images.githubusercontent.com/803701/48395003-ea1ba100-e6d2-11e8-9a98-5b30f41f84ea.png)
