### PR TITLE
feat(email): don't escape html in notification bodies.

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -245,7 +245,7 @@ function pushToUids(uids, notification, callback) {
 				path: notification.path,
 				subject: utils.stripHTMLTags(notification.subject || '[[notifications:new_notification_from, ' + meta.config.title + ']]'),
 				intro: utils.stripHTMLTags(notification.bodyShort),
-				body: utils.stripHTMLTags(notification.bodyLong || ''),
+				body: notification.bodyLong || '',
 				notification: notification,
 				showUnsubscribe: true,
 			}, next);


### PR DESCRIPTION
Allows for post replies, etc. to show the formatting of the original post, rather than looking garbled.

Closes #7034, see screenshots there.