### PR TITLE
fix: #7038, autoLocale logic not playing nicely with no-refresh auths

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -284,6 +284,8 @@ function continueLogin(req, res, next) {
 				});
 			});
 		} else {
+			delete req.query.lang;
+
 			async.parallel({
 				doLogin: async.apply(authenticationController.doLogin, req, userData.uid),
 				header: async.apply(middleware.generateHeader, req, res, {}),


### PR DESCRIPTION
- on login, req.query.lang is deleted (since it seems to be left over)
- on logout, the middleware.autoLocale is executed, which resets
  req.query.lang
- middleware.autoLocale is new, just refactored existing logic in
  webserver.js into new middleware method.