### PR TITLE
fix: removal of timeago fallback middleware

### DIFF
--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -240,10 +240,12 @@ module.exports = function (middleware) {
 					scripts: async.apply(plugins.fireHook, 'filter:scripts.get', []),
 					timeagoLocale: (next) => {
 						languages.list(function (err, languages) {
+							// 1. Verify userLang is a nodebb supported language
 							if (err || !languages.some(obj => obj.code === res.locals.config.userLang)) {
 								return next(err);
 							}
 
+							// 2. If appropriate timeago translation exists on disk, allow script injection
 							const pathToLocaleFile = '/vendor/jquery/timeago/locales/jquery.timeago.' + utils.userLangToTimeagoCode(res.locals.config.userLang) + '.js';
 							file.exists(path.join(__dirname, '../../public', pathToLocaleFile), function (err, exists) {
 								next(err, exists ? (nconf.get('relative_path') + '/assets' + pathToLocaleFile) : null);

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -239,18 +239,22 @@ module.exports = function (middleware) {
 				async.parallel({
 					scripts: async.apply(plugins.fireHook, 'filter:scripts.get', []),
 					timeagoLocale: (next) => {
-						languages.list(function (err, languages) {
-							// 1. Verify userLang is a nodebb supported language
-							if (err || !languages.some(obj => obj.code === res.locals.config.userLang)) {
-								return next(err);
-							}
+						const userLang = res.locals.config.userLang;
+						const pathToLocaleFile = '/vendor/jquery/timeago/locales/jquery.timeago.' + utils.userLangToTimeagoCode(userLang) + '.js';
 
-							// 2. If appropriate timeago translation exists on disk, allow script injection
-							const pathToLocaleFile = '/vendor/jquery/timeago/locales/jquery.timeago.' + utils.userLangToTimeagoCode(res.locals.config.userLang) + '.js';
-							file.exists(path.join(__dirname, '../../public', pathToLocaleFile), function (err, exists) {
-								next(err, exists ? (nconf.get('relative_path') + '/assets' + pathToLocaleFile) : null);
-							});
-						});
+						async.waterfall([
+							async.apply(languages.list),
+							(languages, next) => {
+								if (!languages.some(obj => obj.code === userLang)) {
+									return next(null, false);
+								}
+
+								file.exists(path.join(__dirname, '../../public', pathToLocaleFile), next);
+							},
+							(exists, next) => {
+								next(null, exists ? (nconf.get('relative_path') + '/assets' + pathToLocaleFile) : null);
+							},
+						], next);
 					},
 				}, function (err, results) {
 					next(err, data, results);

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -13,7 +13,6 @@ var plugins = require('../plugins');
 var meta = require('../meta');
 var user = require('../user');
 var groups = require('../groups');
-var file = require('../file');
 
 var analytics = require('../analytics');
 
@@ -172,29 +171,6 @@ middleware.applyBlacklist = function applyBlacklist(req, res, next) {
 	meta.blacklist.test(req.ip, function (err) {
 		next(err);
 	});
-};
-
-middleware.processTimeagoLocales = function processTimeagoLocales(req, res, next) {
-	var fallback = !req.path.includes('-short') ? 'jquery.timeago.en.js' : 'jquery.timeago.en-short.js';
-	var localPath = path.join(__dirname, '../../public/vendor/jquery/timeago/locales', req.path);
-
-	async.waterfall([
-		function (next) {
-			file.exists(localPath, next);
-		},
-		function (exists, next) {
-			if (exists) {
-				next(null, localPath);
-			} else {
-				next(null, path.join(__dirname, '../../public/vendor/jquery/timeago/locales', fallback));
-			}
-		},
-		function (path) {
-			res.status(200).sendFile(path, {
-				maxAge: req.app.enabled('cache') ? 5184000000 : 0,
-			});
-		},
-	], next);
 };
 
 middleware.delayLoading = function delayLoading(req, res, next) {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -187,7 +187,6 @@ function addCoreRoutes(app, router, middleware, callback) {
 		res.redirect(relativePath + '/assets/client.css?' + meta.config['cache-buster']);
 	});
 
-	app.use(relativePath + '/assets/vendor/jquery/timeago/locales', middleware.processTimeagoLocales);
 	app.use(controllers['404'].handle404);
 	app.use(controllers.errors.handleURIErrors);
 	app.use(controllers.errors.handleErrors);

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1807,11 +1807,18 @@ describe('Controllers', function () {
 			});
 		});
 
-		it('should load timeago locale', function (done) {
-			request(nconf.get('url') + '/assets/vendor/jquery/timeago/locales/jquery.timeago.404.js', function (err, res, body) {
+		it('should return not found if NodeBB language exists but timeago locale does not exist', function (done) {
+			request(nconf.get('url') + '/assets/vendor/jquery/timeago/locales/jquery.timeago.ms.js', function (err, res, body) {
 				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body.includes('English'));
+				assert.equal(res.statusCode, 404);
+				done();
+			});
+		});
+
+		it('should return not found if NodeBB language does not exist', function (done) {
+			request(nconf.get('url') + '/assets/vendor/jquery/timeago/locales/jquery.timeago.muggle.js', function (err, res, body) {
+				assert.ifError(err);
+				assert.equal(res.statusCode, 404);
 				done();
 			});
 		});


### PR DESCRIPTION
Instead of loading English fallback on missing language, we opt
to not send a script tag for a missing language to begin with.

Timeago already loads with English as default, so it will just
continue to use English.