### PR TITLE
Add Disallow: /compose to robots.txt

### DIFF
--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -252,6 +252,7 @@ Controllers.robots = function (req, res) {
 		res.send('User-agent: *\n' +
 			'Disallow: ' + nconf.get('relative_path') + '/admin/\n' +
 			'Disallow: ' + nconf.get('relative_path') + '/reset/\n' +
+			'Disallow: ' + nconf.get('relative_path') + '/compose\n' +
 			'Sitemap: ' + nconf.get('url') + '/sitemap.xml');
 	}
 };


### PR DESCRIPTION
On my site, there are many hits to `/compose` by various bots. Disallowing this page should reduce those useless requests.