### PR TITLE
Use topics:read privilege for topic filtering use cases

### DIFF
--- a/src/categories/recentreplies.js
+++ b/src/categories/recentreplies.js
@@ -21,7 +21,7 @@ module.exports = function (Categories) {
 				db.getSortedSetRevRange('cid:' + cid + ':pids', 0, count - 1, next);
 			},
 			function (pids, next) {
-				privileges.posts.filter('read', pids, uid, next);
+				privileges.posts.filter('topics:read', pids, uid, next);
 			},
 			function (pids, next) {
 				posts.getPostSummaryByPids(pids, uid, { stripTags: true }, next);
@@ -92,7 +92,7 @@ module.exports = function (Categories) {
 			function (results, next) {
 				var tids = _.uniq(_.flatten(results).filter(Boolean));
 
-				privileges.topics.filterTids('read', tids, uid, next);
+				privileges.topics.filterTids('topics:read', tids, uid, next);
 			},
 			function (tids, next) {
 				getTopics(tids, uid, next);

--- a/src/controllers/posts.js
+++ b/src/controllers/posts.js
@@ -18,7 +18,7 @@ postsController.redirectToPost = function (req, res, next) {
 		function (next) {
 			async.parallel({
 				canRead: function (next) {
-					privileges.posts.can('read', pid, req.uid, next);
+					privileges.posts.can('topics:read', pid, req.uid, next);
 				},
 				path: function (next) {
 					posts.generatePostPath(pid, req.uid, next);

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -349,7 +349,7 @@ topicsController.teaser = function (req, res, next) {
 
 	async.waterfall([
 		function (next) {
-			privileges.topics.can('read', tid, req.uid, next);
+			privileges.topics.can('topics:read', tid, req.uid, next);
 		},
 		function (canRead, next) {
 			if (!canRead) {

--- a/src/groups/posts.js
+++ b/src/groups/posts.js
@@ -55,7 +55,7 @@ module.exports = function (Groups) {
 				db.getSortedSetRevRange('group:' + groupName + ':member:pids', 0, max - 1, next);
 			},
 			function (pids, next) {
-				privileges.posts.filter('read', pids, uid, next);
+				privileges.posts.filter('topics:read', pids, uid, next);
 			},
 			function (pids, next) {
 				posts.getPostSummaryByPids(pids, uid, { stripTags: false }, next);

--- a/src/posts/recent.js
+++ b/src/posts/recent.js
@@ -27,7 +27,7 @@ module.exports = function (Posts) {
 				db.getSortedSetRevRangeByScore('posts:pid', start, count, '+inf', min, next);
 			},
 			function (pids, next) {
-				privileges.posts.filter('read', pids, uid, next);
+				privileges.posts.filter('topics:read', pids, uid, next);
 			},
 			function (pids, next) {
 				Posts.getPostSummaryByPids(pids, uid, { stripTags: true }, next);

--- a/src/search.js
+++ b/src/search.js
@@ -90,7 +90,7 @@ function searchInContent(data, callback) {
 		function (mainPids, next) {
 			pids = mainPids.concat(pids).filter(Boolean);
 
-			privileges.posts.filter('read', pids, data.uid, next);
+			privileges.posts.filter('topics:read', pids, data.uid, next);
 		},
 		function (pids, next) {
 			filterAndSort(pids, data, next);

--- a/src/sitemap.js
+++ b/src/sitemap.js
@@ -137,7 +137,7 @@ sitemap.getTopicPage = function (page, callback) {
 			db.getSortedSetRevRange('topics:recent', min, max, next);
 		},
 		function (tids, next) {
-			privileges.topics.filterTids('read', tids, 0, next);
+			privileges.topics.filterTids('topics:read', tids, 0, next);
 		},
 		function (tids, next) {
 			topics.getTopicsFields(tids, ['tid', 'title', 'slug', 'lastposttime'], next);

--- a/src/socket.io/helpers.js
+++ b/src/socket.io/helpers.js
@@ -30,7 +30,7 @@ SocketHelpers.notifyNew = function (uid, type, result) {
 		},
 		function (uids, next) {
 			uids = uids.filter(toUid => parseInt(toUid, 10) !== uid);
-			privileges.topics.filterUids('read', tid, uids, next);
+			privileges.topics.filterUids('topics:read', tid, uids, next);
 		},
 		function (uids, next) {
 			watchStateUids = uids;
@@ -100,7 +100,7 @@ SocketHelpers.sendNotificationToPostOwner = function (pid, fromuid, command, not
 		function (_postData, next) {
 			postData = _postData;
 			async.parallel({
-				canRead: async.apply(privileges.posts.can, 'read', pid, postData.uid),
+				canRead: async.apply(privileges.posts.can, 'topics:read', pid, postData.uid),
 				isIgnoring: async.apply(topics.isIgnoring, [postData.tid], postData.uid),
 			}, next);
 		},

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -75,7 +75,7 @@ function postReply(socket, data, callback) {
 SocketPosts.getRawPost = function (socket, pid, callback) {
 	async.waterfall([
 		function (next) {
-			privileges.posts.can('read', pid, socket.uid, next);
+			privileges.posts.can('topics:read', pid, socket.uid, next);
 		},
 		function (canRead, next) {
 			if (!canRead) {
@@ -112,7 +112,7 @@ SocketPosts.getTimestampByIndex = function (socket, data, callback) {
 			if (!pid) {
 				return callback(null, 0);
 			}
-			privileges.posts.can('read', pid, socket.uid, next);
+			privileges.posts.can('topics:read', pid, socket.uid, next);
 		},
 		function (canRead, next) {
 			if (!canRead) {

--- a/src/socket.io/topics.js
+++ b/src/socket.io/topics.js
@@ -65,7 +65,7 @@ function postTopic(socket, data, callback) {
 SocketTopics.postcount = function (socket, tid, callback) {
 	async.waterfall([
 		function (next) {
-			privileges.topics.can('read', tid, socket.uid, next);
+			privileges.topics.can('topics:read', tid, socket.uid, next);
 		},
 		function (canRead, next) {
 			if (!canRead) {

--- a/src/topics/follow.js
+++ b/src/topics/follow.js
@@ -225,7 +225,7 @@ module.exports = function (Topics) {
 					followers.splice(index, 1);
 				}
 
-				privileges.topics.filterUids('read', postData.topic.tid, followers, next);
+				privileges.topics.filterUids('topics:read', postData.topic.tid, followers, next);
 			},
 			function (_followers, next) {
 				followers = _followers;

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -59,7 +59,7 @@ Topics.getTopics = function (tids, options, callback) {
 	}
 	async.waterfall([
 		function (next) {
-			privileges.topics.filterTids('read', tids, uid, next);
+			privileges.topics.filterTids('topics:read', tids, uid, next);
 		},
 		function (tids, next) {
 			Topics.getTopicsByTids(tids, options, next);

--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -148,7 +148,7 @@ module.exports = function (Topics) {
 				}
 			},
 			function (tids, next) {
-				privileges.topics.filterTids('read', tids, uid, next);
+				privileges.topics.filterTids('topics:read', tids, uid, next);
 			},
 			function (tids, next) {
 				Topics.getTopicsFields(tids, ['uid', 'tid', 'cid'], next);

--- a/src/topics/suggested.js
+++ b/src/topics/suggested.js
@@ -37,7 +37,7 @@ module.exports = function (Topics) {
 			},
 			function (categoryTids, next) {
 				tids = _.uniq(tids.concat(categoryTids)).slice(start, stop !== -1 ? stop + 1 : undefined);
-				privileges.topics.filterTids('read', tids, uid, next);
+				privileges.topics.filterTids('topics:read', tids, uid, next);
 			},
 			function (tids, next) {
 				Topics.getTopicsByTids(tids, uid, next);

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1584,12 +1584,12 @@ describe('Controllers', function () {
 		});
 
 		it('should 403 if user does not have read privilege', function (done) {
-			privileges.categories.rescind(['read'], category.cid, 'registered-users', function (err) {
+			privileges.categories.rescind(['topics:read'], category.cid, 'registered-users', function (err) {
 				assert.ifError(err);
 				request(nconf.get('url') + '/api/post/' + pid, { jar: jar }, function (err, res) {
 					assert.ifError(err);
 					assert.equal(res.statusCode, 403);
-					privileges.categories.give(['read'], category.cid, 'registered-users', done);
+					privileges.categories.give(['topics:read'], category.cid, 'registered-users', done);
 				});
 			});
 		});

--- a/test/posts.js
+++ b/test/posts.js
@@ -669,7 +669,7 @@ describe('Post\'s', function () {
 			}, function (err, postData) {
 				assert.ifError(err);
 				pid = postData.pid;
-				privileges.categories.rescind(['read'], cid, 'guests', done);
+				privileges.categories.rescind(['topics:read'], cid, 'guests', done);
 			});
 		});
 


### PR DESCRIPTION
While testing the open graph debugger for #7444, I granted spiders access to `topics:read` in the Testing Ground, temporarily.

I then discovered that Facebook was then able to scrape `/topics/:tid/:slug/:index`, but it was always redirected to `/login` when attempting to go to `/post/:pid`

I discovered numerous places in core where we check for `read`, which is **category** access, and not topic read access.

Would appreciate a second set of eyes on this, thanks.