### PR TITLE
feat: use yarn when detected, even if not set in config.json

### DIFF
--- a/src/cli/upgrade-plugins.js
+++ b/src/cli/upgrade-plugins.js
@@ -12,7 +12,7 @@ var nconf = require('nconf');
 var paths = require('./paths');
 
 var packageManager = nconf.get('package_manager');
-var packageManagerExecutable = packageManager === 'yarn' ? 'yarn' : 'npm';
+var packageManagerExecutable = packageManager;
 var packageManagerInstallArgs = packageManager === 'yarn' ? ['add'] : ['install', '--save'];
 
 if (process.platform === 'win32') {

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -13,7 +13,7 @@ var meta = require('../meta');
 var pubsub = require('../pubsub');
 var events = require('../events');
 
-var packageManager = nconf.get('package_manager') === 'yarn' ? 'yarn' : 'npm';
+var packageManager = nconf.get('package_manager');
 var packageManagerExecutable = packageManager;
 var packageManagerCommands = {
 	yarn: {


### PR DESCRIPTION
`package_manager` in `config.json` now functions as an override, but the default is `npm`.

If `package-lock.json` is found, it defaults to npm. Otherwise, `yarn` is used.