### PR TITLE
fix: more graceful error handling and output for cli/reset

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -242,7 +242,10 @@ resetCommand
 		}
 
 		require('./reset').reset(options, function (err) {
-			if (err) { throw err; }
+			if (err) {
+				return process.exit(1);
+			}
+
 			require('../meta/build').buildAll(function (err) {
 				if (err) { throw err; }
 

--- a/src/cli/reset.js
+++ b/src/cli/reset.js
@@ -77,8 +77,8 @@ exports.reset = function (options, callback) {
 
 	async.series([db.init].concat(tasks), function (err) {
 		if (err) {
-			winston.error('[reset] Errors were encountered during reset', err);
-			throw err;
+			winston.error('[reset] Errors were encountered during reset -- ' + err.message);
+			return callback(err);
 		}
 
 		winston.info('[reset] Reset complete');


### PR DESCRIPTION
``` bash
$ ./nodebb reset -p derp                                                                                                             
2019-04-08T14:42:51.871Z [4567/21429] - warn: [reset] Plugin `nodebb-plugin-derp` was not active on this forum                                                                                   
2019-04-08T14:42:51.872Z [4567/21429] - info: [reset] No action taken.                                                                                                                           
2019-04-08T14:42:51.872Z [4567/21429] - error: [reset] Errors were encountered during reset -- plugin-not-active 
```

```
$ ./nodebb reset -t missingtheme                                                                                                                  
2019-04-08T14:42:30.902Z [4567/21346] - warn: [reset] Theme `nodebb-theme-missingtheme` is not installed on this forum                                                                            
2019-04-08T14:42:30.903Z [4567/21346] - error: [reset] Errors were encountered during reset -- theme-not-found
```