### PR TITLE
fix: #6438 only apply whitelist when fields request empty

### DIFF
--- a/src/user/data.js
+++ b/src/user/data.js
@@ -86,6 +86,9 @@ module.exports = function (User) {
 			function (results, next) {
 				if (!fields.length) {
 					fields = results.whitelist;
+				} else {
+					// Never allow password retrieval via this method
+					fields = fields.filter(value => value !== 'password');
 				}
 
 				db.getObjectsFields(uidsToUserKeys(uniqueUids), fields, next);

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -3,7 +3,6 @@
 var async = require('async');
 var validator = require('validator');
 var nconf = require('nconf');
-var winston = require('winston');
 var _ = require('lodash');
 
 var db = require('../database');
@@ -85,16 +84,7 @@ module.exports = function (User) {
 				plugins.fireHook('filter:user.whitelistFields', { uids: uids, whitelist: fieldWhitelist.slice() }, next);
 			},
 			function (results, next) {
-				if (fields.length) {
-					const whitelistSet = new Set(results.whitelist);
-					fields = fields.filter(function (field) {
-						var isFieldWhitelisted = field && whitelistSet.has(field);
-						if (!isFieldWhitelisted) {
-							winston.verbose('[user/getUsersFields] ' + field + ' removed because it is not whitelisted, see `filter:user.whitelistFields`');
-						}
-						return isFieldWhitelisted;
-					});
-				} else {
+				if (!fields.length) {
 					fields = results.whitelist;
 				}
 

--- a/test/user.js
+++ b/test/user.js
@@ -578,6 +578,14 @@ describe('User', function () {
 			});
 		});
 
+		it('should not return password even if explicitly requested', function (done) {
+			User.getUserFields(testUid, ['password'], function (err, payload) {
+				assert.ifError(err);
+				assert(!payload.hasOwnProperty('password'));
+				done();
+			});
+		});
+
 		it('should return private data if field is whitelisted', function (done) {
 			function filterMethod(data, callback) {
 				data.whitelist.push('another_secret');


### PR DESCRIPTION
A simple fix that inverts the whitelist logic and only uses the whitelist if `getUsersFields` is called with an empty `fields` argument. If discrete fields are passed in, it should simply return them as requested.

... except passwords.

More info in #6438 