### PR TITLE
Update Node.js Version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Our minimalist "Persona" theme gets you going right away, no coding experience r
 
 NodeBB requires the following software to be installed:
 
-* A version of Node.js at least 6 or greater ([installation/upgrade instructions](https://github.com/nodesource/distributions))
+* A version of Node.js at least 8 or greater ([installation/upgrade instructions](https://github.com/nodesource/distributions))
 * Redis, version 2.8.9 or greater **or** MongoDB, version 2.6 or greater
 * nginx, version 1.3.13 or greater (**only if** intending to use nginx to proxy requests to a NodeBB)
 


### PR DESCRIPTION
Just noticed this while reading the README.

Just a question out of curiosity:
Do you plan to (slowly) migrate await from callback-based approaches to the ECMA 17 async/await features in a future breaking release?
I haven't really written a NodeBB plugin for a long time now, but async/await is so much easier to use than callbacks (and a lot more readable), so I think this is a huge boost to code quality.