### PR TITLE
Object cache refactor

### DIFF
--- a/src/database/postgres/hash.js
+++ b/src/database/postgres/hash.js
@@ -65,7 +65,7 @@ VALUES ($1::TEXT, jsonb_build_object($2::TEXT, $3::TEXT::JSONB))
 
 	module.getObject = function (key, callback) {
 		if (!key) {
-			return callback();
+			return callback(null, null);
 		}
 
 		db.query({
@@ -122,7 +122,7 @@ SELECT h."data"
 
 	module.getObjectField = function (key, field, callback) {
 		if (!key) {
-			return callback();
+			return setImmediate(callback, null, null);
 		}
 
 		db.query({
@@ -151,7 +151,7 @@ SELECT h."data"->>$2::TEXT f
 
 	module.getObjectFields = function (key, fields, callback) {
 		if (!key) {
-			return callback();
+			return setImmediate(callback, null, null);
 		}
 
 		db.query({

--- a/src/database/redis/hash.js
+++ b/src/database/redis/hash.js
@@ -59,6 +59,9 @@ module.exports = function (redisClient, module) {
 	};
 
 	module.getObjectFields = function (key, fields, callback) {
+		if (!key) {
+			return setImmediate(callback, null, null);
+		}
 		module.getObjectsFields([key], fields, function (err, results) {
 			callback(err, results ? results[0] : null);
 		});

--- a/src/database/redis/main.js
+++ b/src/database/redis/main.js
@@ -16,6 +16,7 @@ module.exports = function (redisClient, module) {
 			if (err) {
 				return callback(err);
 			}
+			module.objectCache.resetObjectCache();
 			callback();
 		});
 	};
@@ -35,6 +36,7 @@ module.exports = function (redisClient, module) {
 	module.delete = function (key, callback) {
 		callback = callback || function () {};
 		redisClient.del(key, function (err) {
+			module.objectCache.delObjectCache(key);
 			callback(err);
 		});
 	};
@@ -46,6 +48,7 @@ module.exports = function (redisClient, module) {
 			batch.del(keys[i]);
 		}
 		batch.exec(function (err) {
+			module.objectCache.delObjectCache(keys);
 			callback(err);
 		});
 	};
@@ -72,6 +75,8 @@ module.exports = function (redisClient, module) {
 			if (err && err.message !== 'ERR no such key') {
 				return callback(err);
 			}
+			module.objectCache.delObjectCache(oldKey);
+			module.objectCache.delObjectCache(newKey);
 			callback();
 		});
 	};

--- a/test/database/hash.js
+++ b/test/database/hash.js
@@ -92,6 +92,20 @@ describe('Hash methods', function () {
 				});
 			});
 		});
+
+		it('should work for field names with "." in them when they are cached', function (done) {
+			db.setObjectField('dotObject3', 'my.dot.field', 'foo2', function (err) {
+				assert.ifError(err);
+				db.getObject('dotObject3', function (err, data) {
+					assert.ifError(err);
+					db.getObjectField('dotObject3', 'my.dot.field', function (err, value) {
+						assert.ifError(err);
+						assert.equal(value, 'foo2');
+						done();
+					});
+				});
+			});
+		});
 	});
 
 	describe('getObject()', function () {
@@ -110,6 +124,15 @@ describe('Hash methods', function () {
 				assert.equal(data.name, testData.name);
 				assert.equal(data.age, testData.age);
 				assert.equal(data.lastname, 'usakli');
+				done();
+			});
+		});
+
+		it('should return null if key is falsy', function (done) {
+			db.getObject(null, function (err, data) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 2);
+				assert.equal(data, null);
 				done();
 			});
 		});
@@ -163,6 +186,15 @@ describe('Hash methods', function () {
 				done();
 			});
 		});
+
+		it('should return null if key is falsy', function (done) {
+			db.getObjectField(null, 'test', function (err, data) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 2);
+				assert.equal(data, null);
+				done();
+			});
+		});
 	});
 
 	describe('getObjectFields()', function () {
@@ -185,6 +217,15 @@ describe('Hash methods', function () {
 				assert.equal(object.lastname, 'usakli');
 				assert.equal(object.age, 99);
 				assert.equal(!!object.field1, false);
+				done();
+			});
+		});
+
+		it('should return null if key is falsy', function (done) {
+			db.getObjectFields(null, ['test', 'foo'], function (err, data) {
+				assert.ifError(err);
+				assert.equal(arguments.length, 2);
+				assert.equal(data, null);
 				done();
 			});
 		});


### PR DESCRIPTION
bring back object cache for redis

db.getObjectField no longer loads entire object
db.getObjectsFields only clones data once