### PR TITLE
Let theme know if downvoting is disabled.

### DIFF
--- a/src/socket.io/posts/votes.js
+++ b/src/socket.io/posts/votes.js
@@ -50,10 +50,9 @@ module.exports = function (SocketPosts) {
 					downvoteCount: function (next) {
 						next(null, results.downvoteUids.length);
 					},
-					showDownvotes: function (next) { 
+					showDownvotes: function (next) {
 						next(null, !meta.config['downvote:disabled'] || Boolean(results.downvoteUids.length));
-					}
-
+					},
 				}, next);
 			},
 		], callback);

--- a/src/socket.io/posts/votes.js
+++ b/src/socket.io/posts/votes.js
@@ -50,6 +50,10 @@ module.exports = function (SocketPosts) {
 					downvoteCount: function (next) {
 						next(null, results.downvoteUids.length);
 					},
+					showDownvotes: function (next) { 
+						next(null, !meta.config['downvote:disabled'] || Boolean(results.downvoteUids.length));
+					}
+
 				}, next);
 			},
 		], callback);


### PR DESCRIPTION
I have found that in forums who choose to disable downvoting, users find it confusing when "Downvoters(0)" is shown in the votes_modal.
This pull request allows the theme to know that there are no downvotes AND downvoting is disabled. The theme can then remove downvotes from the votes modal.
If this accepted, a change can be made to nodebb-theme-persona to add `<!-- IF showDownvotes -->` into `votes_modal.tpl`.