### PR TITLE
fix: group cover upload not working for s3 upload

### DIFF
--- a/src/groups/cover.js
+++ b/src/groups/cover.js
@@ -38,6 +38,7 @@ module.exports = function (Groups) {
 				image.uploadImage(filename, 'files', {
 					path: tempPath,
 					uid: uid,
+					name: 'groupCover',
 				}, next);
 			},
 			function (uploadData, next) {
@@ -54,6 +55,7 @@ module.exports = function (Groups) {
 				image.uploadImage('groupCoverThumb-' + data.groupName + path.extname(tempPath), 'files', {
 					path: tempPath,
 					uid: uid,
+					name: 'groupCover',
 				}, next);
 			},
 			function (uploadData, next) {


### PR DESCRIPTION
I am getting this error when uploading a cover photo for groups when `nodebb-plugin-s3-uploads-updated` plugin is enabled: 

`error: uncaughtException: Path must be a string. Received undefined 
TypeError: Path must be a string. Received undefined`

I found a similar issue that was resolved 4 years ago: https://github.com/NodeBB/NodeBB/issues/3669

The file that contained the fix does not exist anymore (I assume it has been refactored). So I added the `name: 'groupCover'` back to the new upload group cover file.