### PR TITLE
fix: #7604 shortened CTA text and added custom text for some notifs

### DIFF
--- a/public/language/en-GB/email.json
+++ b/public/language/en-GB/email.json
@@ -37,14 +37,13 @@
 	"digest.subject": "Digest for %1",
 	"digest.title": "Your Daily Digest",
 
-	"notif.chat.subject": "New chat message received from %1",
-	"notif.chat.cta": "Click here to continue the conversation",
-	"notif.chat.unsub.info": "This chat notification was sent to you due to your subscription settings.",
-
-	"notif.post.cta": "Click here to read the full topic",
 	"notif.post.unsub.info": "This post notification was sent to you due to your subscription settings.",
 
-	"notif.cta": "Click here to go to forum",
+	"notif.cta": "To the forum",
+	"notif.cta-new-reply": "View Post",
+	"notif.cta-new-chat": "View Chat",
+	"notif.test.short": "Testing Notifications",
+	"notif.test.long": "This is a test of the notifications email. Send help!",
 
 	"test.text1": "This is a test email to verify that the emailer is set up correctly for your NodeBB.",
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -241,6 +241,11 @@ function pushToUids(uids, notification, callback) {
 	}
 
 	function sendEmail(uids, callback) {
+		// Update CTA messaging (as not all notification types need custom text)
+		if (['new-reply', 'new-chat'].some(type => notification.type === type)) {
+			notification['cta-type'] = notification.type;
+		}
+
 		async.eachLimit(uids, 3, function (uid, next) {
 			emailer.send('notification', uid, {
 				path: notification.path,

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -242,7 +242,7 @@ function pushToUids(uids, notification, callback) {
 
 	function sendEmail(uids, callback) {
 		// Update CTA messaging (as not all notification types need custom text)
-		if (['new-reply', 'new-chat'].some(type => notification.type === type)) {
+		if (['new-reply', 'new-chat'].includes(notification.type)) {
 			notification['cta-type'] = notification.type;
 		}
 

--- a/src/socket.io/admin.js
+++ b/src/socket.io/admin.js
@@ -279,8 +279,8 @@ SocketAdmin.email.test = function (socket, data, callback) {
 			function (next) {
 				notifications.create({
 					type: 'test',
-					bodyShort: '[[admin-settings-email:testing]]',
-					bodyLong: '[[admin-settings-email:testing.send-help]]',
+					bodyShort: '[[email:notif.test.short]]',
+					bodyLong: '[[email:notif.test.long]]',
 					nid: 'uid:' + socket.uid + ':test',
 					path: '/',
 					from: socket.uid,

--- a/src/views/emails/notification.tpl
+++ b/src/views/emails/notification.tpl
@@ -31,7 +31,7 @@
 							<tr>
 								<td style="border-radius: 3px; background: #222222; text-align: center;" class="button-td">
 									<a href="{url}{path}" style="background: #222222; border: 15px solid #222222; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; font-size: 13px; line-height: 1.1; text-align: center; text-decoration: none; display: block; border-radius: 3px; font-weight: bold;" class="button-a">
-										<span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;[[email:notif.cta]]&nbsp;&nbsp;&nbsp;&nbsp;</span>
+										<span style="color:#ffffff;" class="button-link">&nbsp;&nbsp;&nbsp;&nbsp;[[email:notif.cta<!-- IF notification.cta-type -->-{notification.cta-type}<!-- END -->]] &rarr;&nbsp;&nbsp;&nbsp;&nbsp;</span>
 									</a>
 								</td>
 							</tr>


### PR DESCRIPTION
Specifically, new-reply and new-chat have different CTA text as they
do not go to the forum home like other email templates send users to.