### PR TITLE
Replace avatar conditional code with buildAvatar helper

### DIFF
--- a/public/less/generics.less
+++ b/public/less/generics.less
@@ -75,6 +75,7 @@
 	text-align: center;
 	color: @gray-lighter;
 	font-weight: normal;
+	overflow: hidden;	/* stops alt text from overflowing past boundaries if image does not load */
 
 	&:before {
 		content: '';

--- a/public/less/generics.less
+++ b/public/less/generics.less
@@ -117,12 +117,6 @@
 		height: 128px;
 		.user-icon-style(128px, 7.5rem);
 	}
-	
-	&.avatar-xl {
-		width: 128px;
-		height: 128px;
-		.user-icon-style(128px, 7.5rem);
-	}
 
 	&.avatar-rounded {
 		border-radius: 50%;
@@ -147,7 +141,7 @@
 	#cropped-image {
 		max-width: 100%;
 	}
-	
+
 	.cropper-container.cropper-bg {
 		max-width: 100%;
 	}

--- a/public/src/client/account/edit.js
+++ b/public/src/client/account/edit.js
@@ -65,10 +65,10 @@ define('forum/account/edit', ['forum/account/header', 'translator', 'components'
 		if (!picture && ajaxify.data.defaultAvatar) {
 			picture = ajaxify.data.defaultAvatar;
 		}
-		components.get('header/userpicture')[picture ? 'show' : 'hide']();
-		components.get('header/usericon')[!picture ? 'show' : 'hide']();
+		$('#header [component="avatar/picture"]')[picture ? 'show' : 'hide']();
+		$('#header [component="avatar/icon"]')[!picture ? 'show' : 'hide']();
 		if (picture) {
-			components.get('header/userpicture').attr('src', picture);
+			$('#header [component="avatar/picture"]').attr('src', picture);
 		}
 	}
 

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -26,6 +26,7 @@
 		renderTopicImage: renderTopicImage,
 		renderDigestAvatar: renderDigestAvatar,
 		userAgentIcons: userAgentIcons,
+		buildAvatar: buildAvatar,
 		register: register,
 		__escape: identity,
 	};
@@ -267,6 +268,15 @@
 		}
 
 		return icons;
+	}
+
+	function buildAvatar(userObj, size, rounded) {
+		rounded = !!parseInt(rounded, 10);
+		if (userObj.picture) {
+			return '<img class="avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '" src="' + userObj.picture + '" />';
+		}
+
+		return '<div class="avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '" style="background-color: ' + userObj['icon:bgColor'] + ';">' + userObj['icon:text'] + '</div>';
 	}
 
 	function register() {

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -273,21 +273,20 @@
 		return icons;
 	}
 
-	function buildAvatar(userObj, size, rounded, classNames, componentPrefix) {
+	function buildAvatar(userObj, size, rounded, classNames) {
 		/**
 		 * userObj requires:
 		 *   - picture, icon:bgColor, icon:text (getUserField w/ "picture" should return all 3), username
 		 * size: one of "xs", "sm", "md", "lg", or "xl" (required)
 		 * rounded: true or false (optional, default false)
 		 * classNames: additional class names to prepend (optional, default none)
-		 * componentPrefix: string prepended to the generated component value (optional, default none)
 		 */
 
 		var attributes = [
 			'class="' + (classNames || '') + ' avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '"',
 			'alt="' + userObj.username + '"',
 			'title="' + userObj.username + '"',
-			'component="' + (componentPrefix ? componentPrefix + '/' : '') + 'avatar/' + (userObj.picture ? 'picture' : 'icon') + '"',
+			'component="avatar/' + (userObj.picture ? 'picture' : 'icon') + '"',
 		];
 		if (userObj.picture) {
 			return '<img ' + attributes.join(' ') + ' src="' + userObj.picture + '" />';

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -276,7 +276,7 @@
 	function buildAvatar(userObj, size, rounded, classNames, component) {
 		/**
 		 * userObj requires:
-		 *   - picture, icon:bgColor, icon:text (getUserField w/ "picture" should return all 3), username
+		 *   - uid, picture, icon:bgColor, icon:text (getUserField w/ "picture" should return all 4), username
 		 * size: one of "xs", "sm", "md", "lg", or "xl" (required), or an integer
 		 * rounded: true or false (optional, default false)
 		 * classNames: additional class names to prepend (optional, default none)

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -10,6 +10,9 @@
 		});
 	}
 }(function (utils, Benchpress, relative_path) {
+	Benchpress.setGlobal('true', true);
+	Benchpress.setGlobal('false', false);
+
 	var helpers = {
 		displayMenuItem: displayMenuItem,
 		buildMetaTag: buildMetaTag,
@@ -270,13 +273,27 @@
 		return icons;
 	}
 
-	function buildAvatar(userObj, size, rounded) {
-		rounded = !!parseInt(rounded, 10);
+	function buildAvatar(userObj, size, rounded, classNames, componentPrefix) {
+		/**
+		 * userObj requires:
+		 *   - picture, icon:bgColor, icon:text (getUserField w/ "picture" should return all 3), username
+		 * size: one of "xs", "sm", "md", "lg", or "xl" (required)
+		 * rounded: true or false (optional, default false)
+		 * classNames: additional class names to prepend (optional, default none)
+		 * componentPrefix: string prepended to the generated component value (optional, default none)
+		 */
+
+		var attributes = [
+			'class="' + (classNames || '') + ' avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '"',
+			'alt="' + userObj.username + '"',
+			'title="' + userObj.username + '"',
+			'component="' + (componentPrefix ? componentPrefix + '/' : '') + 'avatar/' + (userObj.picture ? 'picture' : 'icon') + '"',
+		];
 		if (userObj.picture) {
-			return '<img class="avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '" src="' + userObj.picture + '" />';
+			return '<img ' + attributes.join(' ') + ' src="' + userObj.picture + '" />';
 		}
 
-		return '<div class="avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '" style="background-color: ' + userObj['icon:bgColor'] + ';">' + userObj['icon:text'] + '</div>';
+		return '<div ' + attributes.join(' ') + ' style="background-color: ' + userObj['icon:bgColor'] + ';">' + userObj['icon:text'] + '</div>';
 	}
 
 	function register() {

--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -273,26 +273,47 @@
 		return icons;
 	}
 
-	function buildAvatar(userObj, size, rounded, classNames) {
+	function buildAvatar(userObj, size, rounded, classNames, component) {
 		/**
 		 * userObj requires:
 		 *   - picture, icon:bgColor, icon:text (getUserField w/ "picture" should return all 3), username
-		 * size: one of "xs", "sm", "md", "lg", or "xl" (required)
+		 * size: one of "xs", "sm", "md", "lg", or "xl" (required), or an integer
 		 * rounded: true or false (optional, default false)
 		 * classNames: additional class names to prepend (optional, default none)
+		 * component: overrides the default component (optional, default none)
 		 */
 
 		var attributes = [
-			'class="' + (classNames || '') + ' avatar avatar-' + size + (rounded ? ' avatar-rounded' : '') + '"',
 			'alt="' + userObj.username + '"',
 			'title="' + userObj.username + '"',
-			'component="avatar/' + (userObj.picture ? 'picture' : 'icon') + '"',
+			'data-uid="' + userObj.uid + '"',
 		];
-		if (userObj.picture) {
-			return '<img ' + attributes.join(' ') + ' src="' + userObj.picture + '" />';
+		var styles = [];
+		classNames = classNames || '';
+
+		// Validate sizes, handle integers, otherwise fall back to `avatar-sm`
+		if (['xs', 'sm', 'md', 'lg', 'xl'].includes(size)) {
+			classNames += ' avatar-' + size;
+		} else if (!isNaN(parseInt(size, 10))) {
+			styles.push('width: ' + size + 'px;', 'height: ' + size + 'px;', 'line-height: ' + size + 'px;', 'font-size: ' + (parseInt(size, 10) / 16) + 'rem;');
+		} else {
+			classNames += ' avatar-sm';
+		}
+		attributes.unshift('class="avatar ' + classNames + (rounded ? ' avatar-rounded' : '') + '"');
+
+		// Component override
+		if (component) {
+			attributes.push('component="' + component + '"');
+		} else {
+			attributes.push('component="avatar/' + (userObj.picture ? 'picture' : 'icon') + '"');
 		}
 
-		return '<div ' + attributes.join(' ') + ' style="background-color: ' + userObj['icon:bgColor'] + ';">' + userObj['icon:text'] + '</div>';
+		if (userObj.picture) {
+			return '<img ' + attributes.join(' ') + ' src="' + userObj.picture + '" style="' + styles.join(' ') + '" />';
+		}
+
+		styles.push('background-color: ' + userObj['icon:bgColor'] + ';');
+		return '<div ' + attributes.join(' ') + ' style="' + styles.join(' ') + '">' + userObj['icon:text'] + '</div>';
 	}
 
 	function register() {


### PR DESCRIPTION
Old method of generating an avatar/icon:
```
<!-- IF categories.posts.user.picture -->
<img class="user-avatar" src="{categories.posts.user.picture}" alt="{categories.posts.user.username}" title="{categories.posts.user.username}"/>
<!-- ELSE -->
<div class="user-icon" title="{categories.posts.user.username}" style="background-color: {categories.posts.user.icon:bgColor};">{categories.posts.user.icon:text}</div>
<!-- ENDIF categories.posts.user.picture -->
```

New method of generating an avatar/icon:
`{buildAvatar(categories.posts.user, "sm", roundedBoolean, "additionalClassNames", "componentOverride")}`

 * userObj requires:
 *   - picture, icon:bgColor, icon:text (getUserField w/ "picture" should return all 3), username, uid
 * size: one of "xs", "sm", "md", "lg", or "xl" (required), or an integer
 * rounded: true or false (optional, default false)
 * classNames: additional class names to prepend (optional, default none)
 * component: overrides the default component (optional, default none)