### PR TITLE
Fix for a typo in html tag in Polish translation (public/language/pl/notifications.json)

### DIFF
--- a/public/language/pl/notifications.json
+++ b/public/language/pl/notifications.json
@@ -35,7 +35,7 @@
     "user_posted_to_dual": "<strong>%1</strong> oraz <strong>%2</strong> dodali odpowiedzi do <strong>%3</strong>",
     "user_posted_to_multiple": "<strong>%1</strong> oraz %2 innych dodali odpowiedzi do <strong>%3</strong>",
     "user_posted_topic": "<strong>%1</strong> stworzył nowy temat: <strong>%2</strong>",
-    "user_started_following_you": "<string>%1</strong> zaczął Cię obserwować.",
+    "user_started_following_you": "<strong>%1</strong> zaczął Cię obserwować.",
     "user_started_following_you_dual": "<strong>%1</strong> oraz <strong>%2</strong> zaczęli Cię obserwować.",
     "user_started_following_you_multiple": "<strong>%1</strong> oraz %2 innych obserwują Cię.",
     "new_register": "<strong>%1</strong> wysłał(-a) żądanie rejestracji.",


### PR DESCRIPTION
It was annoying how desktop notifications when someone started following me always started with <string>. Took me long enough to realize that this wasn't the fault of the plugin, but of the translation itself. So here I am, creating a pull request with 1 character change...