### PR TITLE
Make _csrf a secure cookie if the website is using https

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -32,7 +32,7 @@ middleware.regexes = {
 };
 
 middleware.applyCSRF = csrf({
-	cookie: nconf.get('url_parsed').protocol==="https:"? {
+	cookie: nconf.get('url_parsed').protocol === 'https:' ? {
 		secure: true,
 		sameSite: 'Strict',
 		httpOnly: true,

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -32,7 +32,11 @@ middleware.regexes = {
 };
 
 middleware.applyCSRF = csrf({
-	cookie: true,
+	cookie: nconf.get('url_parsed').protocol==="https:"? {
+		secure: true,
+		sameSite: 'Strict',
+		httpOnly: true,
+	} : true,
 });
 
 middleware.ensureLoggedIn = ensureLoggedIn.ensureLoggedIn(nconf.get('relative_path') + '/login');

--- a/test/mocks/databasemock.js
+++ b/test/mocks/databasemock.js
@@ -119,6 +119,7 @@ before(async function () {
 	// Parse out the relative_url and other goodies from the configured URL
 	const urlObject = url.parse(nconf.get('url'));
 	const relativePath = urlObject.pathname !== '/' ? urlObject.pathname : '';
+	nconf.set('url_parsed', urlObject);
 	nconf.set('base_url', urlObject.protocol + '//' + urlObject.host);
 	nconf.set('secure', urlObject.protocol === 'https:');
 	nconf.set('use_port', !!urlObject.port);


### PR DESCRIPTION
Despite what @julianlam said in #7982 - there is a side-effect to using `csrf({cookie: true})`. Namely - if this method is used the cookie is always an insecure one.

csurf library that NodeBB is using does actually provide a way to secure a cookie - instead of passing `true`, you need to pass an object with the parameters you want to be diffrent from their defaults. 

Unfortunately, just setting it to secure isn't a good idea, as modern browsers will not let a website set a secure cookie when using an insecure connection. So I added a basic check (using `nconf`) to see if the config is using `https:` as the protocol in the website url.