### PR TITLE
difference between protocol and scheme absolute/relative urls check logic, also node vs browser

### DIFF
--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -530,9 +530,14 @@ var isBrowser = false;
 
 		// scheme-absolute seems to win the people's consensus
 		// https://stackoverflow.com/questions/15581445/are-protocol-relative-urls-relative-urls
-		// but protocol-absolute might be needed as well when checking is external url or not
+		// BUT the behavior is different from the server and the client
+		// so we use isProtocolAbsoluteUrl()
 		isAbsoluteUrl: function (url) {
-			return utils.isSchemeAbsoluteUrl(url);
+			return utils.isProtocolAbsoluteUrl(url);
+		},
+
+		isRelativeUrl: function (url) {
+			return !utils.isAbsoluteUrl(url);
 		},
 
 		makeNumbersHumanReadable: function (elements) {


### PR DESCRIPTION
Scheme-absolute seems to win the people's consensus
* https://stackoverflow.com/questions/15581445/are-protocol-relative-urls-relative-urls
* https://github.com/sindresorhus/is-absolute-url/issues/2

**BUT the behavior is different from the server (node environment) and the browser**, so remember, there are 2 factors with 2 possible values each, here's a table

#### For example:  `//google.com`

ENV/TYPE      | Protocol Absolute | Scheme Absolute
------------ | ------------------ | -----------------
Node             | TRUE                      | FALSE   
BROWSER   | TRUE                       | TRUE                   

#### For example for `////google.com`

ENV/TYPE      | Protocol Absolute | Scheme Absolute
------------ | ------------------ | -----------------
Node             | FALSE                      | FALSE   
BROWSER   | TRUE                       | TRUE           

In order to mitigate this in the results below, we replace all 3+ leading slashes with 2 slashes, [`url.replace(/^\/{3,}/, '//');`](https://github.com/NodeBB/NodeBB/blob/bbb03a08e93f2f6826a4ecf08c49ce365e8c7c9d/public/src/utils.js#L507)

## Reason of different behavior node vs browser 

Since there is no equivalent, on the browser, using `document.createElement('a')`, to the `slashesDenoteHost` of [`URL.parse(str, parseQueryString, slashesDenoteHost))`](https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost), on the browser, `slashesDenoteHost` is as always set to `true`.

Also, the browser treats 3+ leading i.e `////google.com` slashes as 2 leading slashes, and sets a `host` value on the result from [`parseUrl()`](https://github.com/NodeBB/NodeBB/blob/bbb03a08e93f2f6826a4ecf08c49ce365e8c7c9d/public/src/utils.js#L497), while node, using `URL.parse('////google.com', true, true)` does not set a `host` value to it, so we think it's a relative url, while but `res.redirect` redirects it externally without an issue.

## Why are we using protocol-absolute?
Unlike the others.

Because for our purposes, we want to consider any redirect attempts to `//example.com` or attempts to set an img src, to be external. Maybe we should use a different function name? i.e. `isUrlExternal()` instead?

### in Node

```bash

url:                    c:\aaa.aaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    ./aaaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    ../aaaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    aaa...aaaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    aaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    aaa.aaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    /aaa.aaa
protocol-absolute:              FALSE
scheme-absolute:                FALSE

url:                    //aaa.aaa
protocol-absolute:              TRUE      <--- different here
scheme-absolute:                FALSE

url:                    ///aaa.aaa/bbb
protocol-absolute:              TRUE      <--- different here
scheme-absolute:                FALSE

url:                    ////aaa.aaa/bbb
protocol-absolute:              TRUE      <--- different here
scheme-absolute:                FALSE

url:                    ///////aaa.aaa/bbb
protocol-absolute:              TRUE      <--- different here
scheme-absolute:                FALSE

url:                    http://aaa.aa
protocol-absolute:              TRUE
scheme-absolute:                TRUE

url:                    https://aaa.aa///
protocol-absolute:              TRUE
scheme-absolute:                TRUE

url:                    ftp://aaa.aa
protocol-absolute:              TRUE
scheme-absolute:                TRUE

url:                    smb://aaa.aa
protocol-absolute:              TRUE
scheme-absolute:                TRUE

url:                    git+ssh://aaa.aa
protocol-absolute:              TRUE
scheme-absolute:                TRUE
```

### in Browser

https://jsfiddle.net/hm129g0r/15/

```bash
url: c:\aaa.aaa
protocol-absolute: TRUE
scheme-absolute: TRUE

url: ./aaaa
protocol-absolute: FALSE
scheme-absolute: FALSE

url: ../aaaa
protocol-absolute: FALSE
scheme-absolute: FALSE

url: aaa...aaaa
protocol-absolute: FALSE
scheme-absolute: FALSE

url: aaa
protocol-absolute: FALSE
scheme-absolute: FALSE

url: aaa.aaa
protocol-absolute: FALSE
scheme-absolute: FALSE

url: /aaa.aaa
protocol-absolute: FALSE
scheme-absolute: FALSE

url: //aaa.aaa
protocol-absolute: TRUE       <--- not different here
scheme-absolute: TRUE

url: ///aaa.aaa/bbb
protocol-absolute: TRUE       <--- not different here
scheme-absolute: TRUE

url: ////aaa.aaa/bbb
protocol-absolute: TRUE       <--- not different here
scheme-absolute: TRUE

url: ///////aaa.aaa/bbb
protocol-absolute: TRUE       <--- not different here
scheme-absolute: TRUE

url: http://aaa.aa
protocol-absolute: TRUE
scheme-absolute: TRUE

url: https://aaa.aa///
protocol-absolute: TRUE
scheme-absolute: TRUE

url: ftp://aaa.aa
protocol-absolute: TRUE
scheme-absolute: TRUE

url: smb://aaa.aa
protocol-absolute: TRUE
scheme-absolute: TRUE

url: git+ssh://aaa.aa
protocol-absolute: TRUE
scheme-absolute: TRUE
```