### PR TITLE
 fix: #8103, fix advanced menu not displaying in ACP

### DIFF
--- a/src/views/admin/partials/menu.tpl
+++ b/src/views/admin/partials/menu.tpl
@@ -257,6 +257,7 @@
 					</li>
 					{{{end}}}
 					{{{end}}}
+					<!-- ENDIF authentication.length -->
 					<li class="divider"></li>
 					<li data-link="1">
 						<a href="{relative_path}/admin/extend/plugins">[[admin/menu:extend/plugins.install]]</a>


### PR DESCRIPTION
### Before

![NodeBB-Admin-Advanced-Menu-Incorrect](https://user-images.githubusercontent.com/2523293/71756148-0dc91a00-2e86-11ea-935e-68160a86777a.png)

^ **Advanced** drop-down is not visible, instead appearing at the bottom of the **Plugins** drop-down.

### After

![Expected-1](https://user-images.githubusercontent.com/2523293/71756156-13266480-2e86-11ea-8792-8f86a9794be5.png)

^ The **Install Plugins** item is visible again in the **Plugins** drop-down.

![Expected-2](https://user-images.githubusercontent.com/2523293/71756158-16b9eb80-2e86-11ea-897f-fa9d980620cb.png)

^ The **Advanced** drop-down is visible again and expands as expected.

### Additional Notes

The side-panel menu view is unaffected, hence no changes were required in that area:

![Unaffected-1](https://user-images.githubusercontent.com/2523293/71756268-d149ee00-2e86-11ea-9349-ff7c602c0291.png)