### PR TITLE
fix: build step defaults to series instead of parallel

### DIFF
--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -203,7 +203,7 @@ exports.build = function (targets, options, callback) {
 				require('./minifier').maxThreads = threads - 1;
 			}
 
-			if (series) {
+			if (!series) {
 				winston.info('[build] Building in parallel mode');
 			} else {
 				winston.info('[build] Building in series mode');


### PR DESCRIPTION
- The logic for the build step now defaults to series instead of
  parallel, unless more than 4 CPU cores are detected by the os
  library.
- The `--series` flag still exists, and will enforce build in
  series, as before.