### PR TITLE
#8115 - log post owner changes

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -25,6 +25,7 @@ events.types = [
 	'post-delete',
 	'post-restore',
 	'post-purge',
+	'post-change-owner',
 	'topic-delete',
 	'topic-restore',
 	'topic-purge',

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -163,6 +163,7 @@ module.exports = function (Posts) {
 			reduceCounters(postsByUser),
 			updateTopicPosters(postData, toUid),
 		]);
+		return postData;
 	};
 
 	async function reduceCounters(postsByUser) {

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -172,6 +172,14 @@ module.exports = function (SocketPosts) {
 			throw new Error('[[error:no-privileges]]');
 		}
 
-		await posts.changeOwner(data.pids, data.toUid);
+		var postData = await posts.changeOwner(data.pids, data.toUid);
+		postData = postData.map(({ pid, tid, uid, cid, timestamp }) => ({ pid, tid, uid, cid, timestamp }));
+		await events.log({
+			type: 'post-change-owner',
+			uid: socket.uid,
+			ip: socket.ip,
+			newOwner: data.toUid,
+			originalPosts: postData,
+		});
 	};
 };

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -174,12 +174,17 @@ module.exports = function (SocketPosts) {
 
 		var postData = await posts.changeOwner(data.pids, data.toUid);
 		postData = postData.map(({ pid, tid, uid, cid, timestamp }) => ({ pid, tid, uid, cid, timestamp }));
-		await events.log({
-			type: 'post-change-owner',
-			uid: socket.uid,
-			ip: socket.ip,
-			newOwner: data.toUid,
-			originalPosts: postData,
+		var promises = [];
+		postData.forEach((post) => {
+			promises.push(events.log({
+				type: 'post-change-owner',
+				uid: socket.uid,
+				ip: socket.ip,
+				targetUid: data.toUid,
+				pid: post.pid,
+				originalUid: post.uid,
+			}));
 		});
+		await Promise.all(promises);
 	};
 };

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -173,18 +173,16 @@ module.exports = function (SocketPosts) {
 		}
 
 		var postData = await posts.changeOwner(data.pids, data.toUid);
-		postData = postData.map(({ pid, tid, uid, cid, timestamp }) => ({ pid, tid, uid, cid, timestamp }));
-		var promises = [];
-		postData.forEach((post) => {
-			promises.push(events.log({
-				type: 'post-change-owner',
-				uid: socket.uid,
-				ip: socket.ip,
-				targetUid: data.toUid,
-				pid: post.pid,
-				originalUid: post.uid,
-			}));
-		});
-		await Promise.all(promises);
+		var logs = postData.map(({ pid, uid, cid }) => (events.log({
+			type: 'post-change-owner',
+			uid: socket.uid,
+			ip: socket.ip,
+			targetUid: data.toUid,
+			pid: pid,
+			originalUid: uid,
+			cid: cid,
+		})));
+
+		await Promise.all(logs);
 	};
 };


### PR DESCRIPTION
Closes #8115:
- adds post-change-owner event type
- logs uid, ip, new post owner and original posts data (pid, tid, uid, cid and timestamp) on post owner change
- Posts.changeOwner now returns postData (it wasn't returning anything and it seemed like a better option than calling getPostsFields again).