### PR TITLE
Fix: ACP > manage > group: save disableLeave

### DIFF
--- a/public/src/admin/manage/group.js
+++ b/public/src/admin/manage/group.js
@@ -110,7 +110,7 @@ define('admin/manage/group', [
 					private: $('#group-private').is(':checked'),
 					hidden: $('#group-hidden').is(':checked'),
 					disableJoinRequests: $('#group-disableJoinRequests').is(':checked'),
-					disableLeave: $('#group-disableLeave').is(':checked')
+					disableLeave: $('#group-disableLeave').is(':checked'),
 				},
 			}, function (err) {
 				if (err) {

--- a/public/src/admin/manage/group.js
+++ b/public/src/admin/manage/group.js
@@ -110,6 +110,7 @@ define('admin/manage/group', [
 					private: $('#group-private').is(':checked'),
 					hidden: $('#group-hidden').is(':checked'),
 					disableJoinRequests: $('#group-disableJoinRequests').is(':checked'),
+					disableLeave: $('#group-disableLeave').is(':checked')
 				},
 			}, function (err) {
 				if (err) {


### PR DESCRIPTION
This is a simple fix for the unfortunate fact that the ACP currently doesn't save the `disableLeave` setting of groups.