### PR TITLE
fix: #8142, broken site if no server-side session

### DIFF
--- a/public/src/client/login.js
+++ b/public/src/client/login.js
@@ -41,6 +41,7 @@ define('forum/login', [], function () {
 
 						app.updateHeader(data, function () {
 							ajaxify.go(data.next);
+							app.flags._sessionRefresh = false;
 							$(window).trigger('action:app.loggedIn', data);
 						});
 					},

--- a/src/meta/configs.js
+++ b/src/meta/configs.js
@@ -147,6 +147,27 @@ Configs.remove = async function (field) {
 	await db.deleteObjectField('config', field);
 };
 
+Configs.cookie = {
+	get: () => {
+		const cookie = {};
+
+		if (nconf.get('cookieDomain') || Meta.config.cookieDomain) {
+			cookie.domain = nconf.get('cookieDomain') || Meta.config.cookieDomain;
+		}
+
+		if (nconf.get('secure')) {
+			cookie.secure = true;
+		}
+
+		var relativePath = nconf.get('relative_path');
+		if (relativePath !== '') {
+			cookie.path = relativePath;
+		}
+
+		return cookie;
+	},
+};
+
 async function processConfig(data) {
 	ensurePositiveInteger(data, 'maximumUsernameLength');
 	ensurePositiveInteger(data, 'minimumUsernameLength');

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -3,6 +3,7 @@
 var os = require('os');
 var winston = require('winston');
 var _ = require('lodash');
+const nconf = require('nconf');
 
 var meta = require('../meta');
 var languages = require('../languages');
@@ -56,7 +57,7 @@ module.exports = function (middleware) {
 
 		// Validate session
 		if (!req.session.meta) {
-			res.clearCookie('express.sid');
+			res.clearCookie(nconf.get('sessionKey'), meta.configs.cookie.get());
 		}
 
 		for (var key in headers) {

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -54,6 +54,11 @@ module.exports = function (middleware) {
 			headers['X-Upstream-Hostname'] = os.hostname();
 		}
 
+		// Validate session
+		if (!req.session.meta) {
+			res.clearCookie('express.sid');
+		}
+
 		for (var key in headers) {
 			if (headers.hasOwnProperty(key) && headers[key]) {
 				res.setHeader(key, headers[key]);

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -56,7 +56,7 @@ module.exports = function (middleware) {
 		}
 
 		// Validate session
-		if (!req.session.meta) {
+		if (!req.session.meta && !res.get('Set-Cookie')) {
 			res.clearCookie(nconf.get('sessionKey'), meta.configs.cookie.get());
 		}
 

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -206,24 +206,9 @@ function configureBodyParser(app) {
 }
 
 function setupCookie() {
-	var ttl = meta.getSessionTTLSeconds() * 1000;
-
-	var cookie = {
-		maxAge: ttl,
-	};
-
-	if (nconf.get('cookieDomain') || meta.config.cookieDomain) {
-		cookie.domain = nconf.get('cookieDomain') || meta.config.cookieDomain;
-	}
-
-	if (nconf.get('secure')) {
-		cookie.secure = true;
-	}
-
-	var relativePath = nconf.get('relative_path');
-	if (relativePath !== '') {
-		cookie.path = relativePath;
-	}
+	const cookie = meta.configs.cookie.get();
+	const ttl = meta.getSessionTTLSeconds() * 1000;
+	cookie.maxAge = ttl;
 
 	return cookie;
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -66,8 +66,9 @@ helpers.logoutUser = function (jar, callback) {
 
 helpers.connectSocketIO = function (res, callback) {
 	var io = require('socket.io-client');
-
-	var cookie = res.headers['set-cookie'][0].split(';')[0];
+	let cookies = res.headers['set-cookie'];
+	cookies = cookies.filter(c => /express.sid=[^;]+;/.test(c));
+	const cookie = cookies[0];
 	var socket = io(nconf.get('base_url'), {
 		path: nconf.get('relative_path') + '/socket.io',
 		extraHeaders: {


### PR DESCRIPTION
During the `addHeader` middleware, a check is now done to see if
`req.session.meta` is present. This value is only present if the user
has a valid server-side session.  If it is missing, then it is probably
safe to assume that the server-side session was deleted (either
intentionally or accidentally). In that scenario, the client-side cookie
should be cleared.

Also, there was an issue where the sessionRefresh flag was never cleared
after a successful login, so that was fixed too.