### PR TITLE
Remove deprecated mongodb connection options, fixes #8079

### DIFF
--- a/src/database/mongo/connection.js
+++ b/src/database/mongo/connection.js
@@ -45,9 +45,6 @@ connection.getConnectionOptions = function (mongo) {
 	mongo = mongo || nconf.get('mongo');
 	var connOptions = {
 		poolSize: 10,
-		reconnectTries: 3600,
-		reconnectInterval: 1000,
-		autoReconnect: true,
 		connectTimeoutMS: 90000,
 		useNewUrlParser: true,
 		useUnifiedTopology: true,


### PR DESCRIPTION
fix #8079 
Unified Topology changes the concept of connecting and causes isConnected to always return true, making any reconnection options useless. Next major version of the driver will remove isConnected entirely.
So:
- reconnect tries
- reconnectInterval
- autoReconnect

Are deprecated and don't really do anything anymore (when unified topology is used at least) other than causing warnings at startup since the 3.4 version of the driver (the current version used by NodeBB is 3.5).

Reference: http://mongodb.github.io/node-mongodb-native/3.5/reference/unified-topology/

TL;DR: just deleting the options that are referenced in the warning fixes everything without actually affecting functionality.