### PR TITLE
Add loading=lazy tag to avatars

### DIFF
--- a/public/src/modules/helpers.js
+++ b/public/src/modules/helpers.js
@@ -287,6 +287,7 @@
 			'alt="' + userObj.username + '"',
 			'title="' + userObj.username + '"',
 			'data-uid="' + userObj.uid + '"',
+			'loading="lazy"',
 		];
 		var styles = [];
 		classNames = classNames || '';


### PR DESCRIPTION
There is no reason why avatars should be a blocking reasorce, and browsers are now adding support for lazy loading of images (and iframes). According to [caniuse.com](https://caniuse.com/#feat=loading-lazy-attr) 62% of users use a browser that supports this attribute.

So there doesn't seem to be any downside to just adding this attribute here. It won't affect browsers that don't support it and might speed up page loads on browsers that do.