### PR TITLE
fix:#8274 Don't escape HTML in manage users

### DIFF
--- a/public/src/admin/manage/users.js
+++ b/public/src/admin/manage/users.js
@@ -73,7 +73,7 @@ define('admin/manage/users', ['translator', 'benchpress', 'autocomplete'], funct
 				}
 				Benchpress.parse('admin/partials/manage_user_groups', data, function (html) {
 					var modal = bootbox.dialog({
-						message: utils.escapeHTML(html),
+						message: html,
 						title: '[[admin/manage/users:manage-groups]]',
 						onEscape: true,
 					});


### PR DESCRIPTION
Perhaps the HTML for managing groups should ba actually rendered as HTML to serve its function. fixes #8274