### PR TITLE
feat: (resolve #8109) Add hooks for user blocks

### DIFF
--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -64,7 +64,7 @@ module.exports = function (User) {
 		await User.incrementUserFieldBy(uid, 'blocksCount', 1);
 		User.blocks._cache.del(parseInt(uid, 10));
 		pubsub.publish('user:blocks:cache:del', parseInt(uid, 10));
-		plugins.fireHook('action:user.block.add', { uid: uid, targetUid: targetUid });
+		plugins.fireHook('action:user.blocks.add', { uid: uid, targetUid: targetUid });
 	};
 
 	User.blocks.remove = async function (targetUid, uid) {
@@ -73,7 +73,7 @@ module.exports = function (User) {
 		await User.decrementUserFieldBy(uid, 'blocksCount', 1);
 		User.blocks._cache.del(parseInt(uid, 10));
 		pubsub.publish('user:blocks:cache:del', parseInt(uid, 10));
-		plugins.fireHook('action:user.block.remove', { uid: uid, targetUid: targetUid });
+		plugins.fireHook('action:user.blocks.remove', { uid: uid, targetUid: targetUid });
 	};
 
 	User.blocks.applyChecks = async function (type, targetUid, uid) {
@@ -118,7 +118,7 @@ module.exports = function (User) {
 		set = set.filter(function (item) {
 			return !blockedSet.has(parseInt(isPlain ? item : item[property], 10));
 		});
-		set = await plugins.fireHook('filter:user.block.filter', { set: set, property: property, uid: uid, blockedSet: blockedSet });
+		set = await plugins.fireHook('filter:user.blocks.filter', { set: set, property: property, uid: uid, blockedSet: blockedSet });
 
 		return set;
 	};

--- a/src/user/blocks.js
+++ b/src/user/blocks.js
@@ -118,8 +118,8 @@ module.exports = function (User) {
 		set = set.filter(function (item) {
 			return !blockedSet.has(parseInt(isPlain ? item : item[property], 10));
 		});
-		set = await plugins.fireHook('filter:user.blocks.filter', { set: set, property: property, uid: uid, blockedSet: blockedSet });
+		const data = await plugins.fireHook('filter:user.blocks.filter', { set: set, property: property, uid: uid, blockedSet: blockedSet });
 
-		return set;
+		return data.set;
 	};
 };


### PR DESCRIPTION
Added 3 hooks:
`action:user.blocks.add` fired when user is blocking another user
`action:user.blocks.remove` fired on the opposite event
`filter:user.blocks.filter` fired at the end of `User.blocks.filter` that's used in most places to filter out content by blocked users.

Alongside this PR I created a simple plugin that implements 2 way blocking as was asked in #8109 - https://github.com/oplik0/nodebb-plugin-two-way-block
One flaw with this solution is that teasers are using custom function fetching blocked uids from `User.blocks.list`, so teasers can't be blocked using these hooks. My only idea for handling this is to add another optional argument to `User.blocks.filter` - a function that would be called for every item that was filtered out - but I'm not sure if it's the best idea.