### PR TITLE
fix: replace image urls to absolute when sending notification

### DIFF
--- a/src/socket.io/helpers.js
+++ b/src/socket.io/helpers.js
@@ -98,6 +98,9 @@ SocketHelpers.sendNotificationToPostOwner = async function (pid, fromuid, comman
 	const title = utils.decodeHTMLEntities(topicTitle);
 	const titleEscaped = title.replace(/%/g, '&#37;').replace(/,/g, '&#44;');
 
+	postObj.content = posts.relativeToAbsolute(postObj.content, posts.urlRegex);
+	postObj.content = posts.relativeToAbsolute(postObj.content, posts.imgRegex);
+
 	const notifObj = await notifications.create({
 		type: command,
 		bodyShort: '[[' + notification + ', ' + username + ', ' + titleEscaped + ']]',

--- a/src/user/notifications.js
+++ b/src/user/notifications.js
@@ -10,6 +10,7 @@ var notifications = require('../notifications');
 var privileges = require('../privileges');
 var plugins = require('../plugins');
 var utils = require('../utils');
+var posts = require('../posts');
 
 var UserNotifications = module.exports;
 
@@ -176,6 +177,9 @@ UserNotifications.sendTopicNotificationToFollowers = async function (uid, topicD
 			title = utils.decodeHTMLEntities(title);
 			title = title.replace(/,/g, '\\,');
 		}
+
+		postData.content = posts.relativeToAbsolute(postData.content, posts.urlRegex);
+		postData.content = posts.relativeToAbsolute(postData.content, posts.imgRegex);
 
 		const notifObj = await notifications.create({
 			type: 'new-topic',


### PR DESCRIPTION
Hi!

This pr replace image src and a href urls to absolute. It is needed to display them correctly in emails.

Currently when a new topic is created by followed user image is not displayed correctly in email notification.

