### PR TITLE
add filename to less render call

### DIFF
--- a/install/web.js
+++ b/install/web.js
@@ -223,12 +223,15 @@ function launch(req, res) {
 }
 
 function compileLess(callback) {
-	fs.readFile(path.join(__dirname, '../public/less/install.less'), function (err, style) {
+	var installSrc = path.join(__dirname, '../public/less/install.less');
+	fs.readFile(installSrc, function (err, style) {
 		if (err) {
 			return winston.error('Unable to read LESS install file: ', err.stack);
 		}
 
-		less.render(style.toString(), function (err, css) {
+		less.render(style.toString(), {
+			filename: path.resolve(installSrc),
+		}, function (err, css) {
 			if (err) {
 				return winston.error('Unable to compile LESS: ', err.stack);
 			}


### PR DESCRIPTION
I got this LESS compiling issue when running Nodebb in a docker container.

```
info: Launching web installer on port 4567
error: Unable to compile LESS: 
```

Since the less compiler is being given a string with LESS contents, relative imports won't work unless the option "filename" is being passed as well as an option.

My result with this fix:

```
Launching web installer on port 4567
Web installer listening on http://0.0.0.0:4567
```