### PR TITLE
Fixed import path in install.less

### DIFF
--- a/public/less/install.less
+++ b/public/less/install.less
@@ -1,4 +1,4 @@
-@import "./admin/vars";
+@import "./public/less/admin/vars";
 
 .working {
   width: 24px;


### PR DESCRIPTION
I tried to install the NodeBB 1.14.0 release and failed. While starting the web installer, it crashes, complaining about not being able to compile LESS.
With the fixed import of vars.less into install.less it works.

Greetz
Nils