### PR TITLE
refactor: navigator up/down to navigate by post index, #5321

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -127,7 +127,7 @@ define('forum/topic', [
 
 		if (postIndex > 1) {
 			if (components.get('post/anchor', postIndex - 1).length) {
-				return navigator.scrollToPostIndex(postIndex - 1, true, 0);
+				return navigator.scrollToPostIndex(postIndex, true, 0);
 			}
 		} else if (bookmark && (!config.usePagination || (config.usePagination && ajaxify.data.pagination.currentPage === 1)) && ajaxify.data.postcount > ajaxify.data.bookmarkThreshold) {
 			app.alert({

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -279,12 +279,10 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 	};
 
 	navigator.scrollUp = function () {
-		console.log('index is', index, 'scrolling to', index > 1 ? index - 1 : 1);
 		navigator.scrollToIndex(index > 1 ? index - 1 : 1, true);
 	};
 
 	navigator.scrollDown = function () {
-		console.log('index is', index, 'scrolling to', count > index ? index + 1 : count);
 		navigator.scrollToIndex(count > index ? index + 1 : count, true);
 	};
 
@@ -384,7 +382,6 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 					var scrollToRect = scrollTo.get(0).getBoundingClientRect();
 					navigator.update(scrollToRect.top);
 					index = parseInt(scrollTo.get(0).getAttribute('data-index'), 10);
-					console.log('index is now', index);
 					return;
 				}
 				done = true;

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -207,7 +207,7 @@ async function getMainPostAndReplies(topic, set, uid, start, stop, reverse) {
 	}
 	var replies = postData;
 	if (topic.mainPid && start === 0) {
-		postData[0].index = 0;
+		postData[0].index = 1;
 		replies = postData.slice(1);
 	}
 

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -128,7 +128,7 @@ module.exports = function (Topics) {
 	Topics.calculatePostIndices = function (posts, start) {
 		posts.forEach(function (post, index) {
 			if (post) {
-				post.index = start + index + 1;
+				post.index = start + index + 2;
 			}
 		});
 	};

--- a/src/topics/sorted.js
+++ b/src/topics/sorted.js
@@ -168,7 +168,7 @@ module.exports = function (Topics) {
 	Topics.calculateTopicIndices = function (topicData, start) {
 		topicData.forEach((topic, index) => {
 			if (topic) {
-				topic.index = start + index;
+				topic.index = start + index + 1;
 			}
 		});
 	};


### PR DESCRIPTION
The original behaviour of the up/down buttons in the navigator
approximated the page up and page down keys on the desktop. It was
determined (by me, mostly) that this was not useful, and a better
behaviour would be to update the selected index instead.

While updating this behaviour, I ran into a number of buggy code
that needed fixing:

- Off-by-one errors since server referred to post indices as an
  array starting at 0, while the client referred to them as an
  array starting at 1
- Code that caused scroll behaviour to continue adding more and
  more handlers the more you interacted with the navigator (that
  was a fun one to debug...)