### PR TITLE
Solve "ERR_TOO_MANY_REDIRECTS and wrong URI"

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -26,7 +26,7 @@ categoryController.get = async function (req, res, next) {
 	}
 
 	const [categoryFields, userPrivileges, userSettings, rssToken] = await Promise.all([
-		categories.getCategoryFields(cid, ['slug', 'disabled']),
+		categories.getCategoryFields(cid, ['slug', 'disabled', 'link']),
 		privileges.categories.get(cid, req.uid),
 		user.getSettings(req.uid),
 		user.auth.getFeedToken(req.uid),
@@ -43,6 +43,14 @@ categoryController.get = async function (req, res, next) {
 
 	if (!userPrivileges.read) {
 		return helpers.notAllowed(req, res);
+	}
+
+	if (categoryFields.link) {
+		if (/^http(?:s)?:\/\//.test(categoryFields.link)) {
+			return res.redirect(utils.decodeHTMLEntities(categoryFields.link));
+		} else {
+			return res.redirect(nconf.get('relative_path') + utils.decodeHTMLEntities(categoryFields.link));
+		}
 	}
 
 	if (!res.locals.isAPI && (!req.params.slug || categoryFields.slug !== cid + '/' + req.params.slug) && (categoryFields.slug && categoryFields.slug !== cid + '/')) {

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -46,11 +46,11 @@ categoryController.get = async function (req, res, next) {
 	}
 
 	if (categoryFields.link) {
-		if (/^http(?:s)?:\/\//.test(categoryFields.link)) {
-			return res.redirect(utils.decodeHTMLEntities(categoryFields.link));
-		} else {
-			return res.redirect(nconf.get('relative_path') + utils.decodeHTMLEntities(categoryFields.link));
+		let link = utils.decodeHTMLEntities(categoryFields.link);
+		if (!/^http(?:s)?:\/\//.test(categoryFields.link)) {
+			link = nconf.get('relative_path') + link;
 		}
+		return res.redirect(link);
 	}
 
 	if (!res.locals.isAPI && (!req.params.slug || categoryFields.slug !== cid + '/' + req.params.slug) && (categoryFields.slug && categoryFields.slug !== cid + '/')) {


### PR DESCRIPTION
Category routes where the category has the "link" field filled redirect to a bad formatted URI resulting in an ERR_TOO_MANY_REDIRECTS error.
These routes appear in _sitemap/categories.xml_ causing. Consider also adding a handler function for the _filter:privileges:isUserAllowedTo_ hook.
```
handlerIsUserAllowedTo = function(data, callback) {
//	Hook handler:	filter:privileges:isUserAllowedTo
//	Trigged in:		/src/privileges/helpers.js
//	Hook data:		{ allowed, privilege, uid, cid }
	var Categories require('./src/categories');
	if (data.privilege!='find') return callback(null, data);
	Categories.getCategoriesFields(data.cid, ['link'], function(err, result) {
		data.allowed = data.allowed.map(function(e, i) {
			return result[i].link ? false : e;
		});
		callback(err, data);
	});
}
```

