### PR TITLE
refactor: navigator up/down to navigate by post/topic index, use anchor instead of jQuery.animate

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -126,7 +126,7 @@ define('forum/topic', [
 
 		if (postIndex > 1) {
 			if (components.get('post/anchor', postIndex - 1).length) {
-				return navigator.scrollToPostIndex(postIndex - 1, true, 0);
+				return navigator.scrollToPostIndex(postIndex - 1, true);
 			}
 		} else if (bookmark && (!config.usePagination || (config.usePagination && ajaxify.data.pagination.currentPage === 1)) && ajaxify.data.postcount > ajaxify.data.bookmarkThreshold) {
 			app.alert({
@@ -205,10 +205,6 @@ define('forum/topic', [
 	Topic.navigatorCallback = function (index, elementCount) {
 		var path = ajaxify.removeRelativePath(window.location.pathname.slice(1));
 		if (!path.startsWith('topic')) {
-			return;
-		}
-
-		if (navigator.scrollActive) {
 			return;
 		}
 

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -223,7 +223,7 @@ define('forum/topic/posts', [
 	}
 
 	Posts.loadMorePosts = function (direction) {
-		if (!components.get('topic').length || navigator.scrollActive) {
+		if (!components.get('topic').length) {
 			return;
 		}
 

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -383,7 +383,7 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 		// Temporarily disable navigator update on scroll
 		$(window).off('scroll', navigator.update);
 
-		const anchorId = scrollTo.find('[component="post/anchor"]').prop('id');
+		const anchorId = scrollTo.find('[component="post/anchor"], [component="topic/anchor"]').prop('id');
 		window.location.hash = anchorId;
 
 		highlightPost();


### PR DESCRIPTION
**This PR is a combination of #8553 and a fix to #8654 **

Two issues are resolved here:

* Navigator `scrollUp` and `scrollDown` now navigate to the previous/next post or topic in DOM instead of a page up/down effect
* The call to jQuery's `.animate()` is removed as it likely interferes with native browser scroll anchoring

Still need to test/fix:

* [ ] behaviour with IS/pagination is maintained
* [ ] navigator is stuck on "2" at the top of the category (topic list), and you currently cannot navigate to the bottom of a topic... likely needs hard-coding for the top/bottom.