### PR TITLE
Stop header render crashing Express if headers are already sent

### DIFF
--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -178,7 +178,9 @@ module.exports = function (middleware) {
 	}
 
 	middleware.renderHeader = async function renderHeader(req, res, data) {
-		return await req.app.renderAsync('header', await generateHeader(req, res, data));
+		const header = await generateHeader(req, res, data);
+		if (res.headersSent) return;
+		return await req.app.renderAsync('header', header);
 	};
 
 	middleware.renderFooter = async function renderFooter(req, res, templateValues) {


### PR DESCRIPTION
This error has been terrorizing my NodeBB instance for a long time. It crashed express during banned user log in attempt due to express headers being sent twice.
```
2020-11-04T08:34:17.563Z [4567/29766] - error: uncaughtException: Cannot read property '_locals' of undefined
TypeError: Cannot read property '_locals' of undefined
    at Function.render (/path/to/nodebb/node_modules/express/lib/application.js:549:12)
    at Function.<anonymous> (/path/to/nodebb/src/webserver.js:118:64)
    at node:internal/util:297:30
    at new Promise (<anonymous>)
    at Function.renderAsync (node:internal/util:296:12)
    at Object.renderHeader (/path/to/nodebb/src/middleware/header.js:181:24)
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
    at async renderHeaderFooter (/path/to/nodebb/src/middleware/render.js:94:11)
    at async Promise.all (index 0)
    at async ServerResponse.renderOverride [as render] (/path/to/nodebb/src/middleware/render.js:63:20)
```

[This redirect](https://github.com/NodeBB/NodeBB/blob/v1.14.x/src/middleware/header.js#L82) sends the headers to client, while rendering forum header but later [this `renderAsync`](https://github.com/NodeBB/NodeBB/blob/v1.14.x/src/middleware/header.js#L181) is trying to send them again. Doing simple check we're preventing this