### PR TITLE
fix(#8828): web install templates now compiled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pidfile
 /public/acp.min.js.map
 /public/installer.css
 /public/installer.min.js
+/public/bootstrap.min.css
 /public/logo.png
 
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio


### PR DESCRIPTION
Checking to make sure web installer works on a clean install should be added to the pre-release checklist