### PR TITLE
refactor: change Benchpress.parse to .render

### DIFF
--- a/public/src/admin/appearance/skins.js
+++ b/public/src/admin/appearance/skins.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('admin/appearance/skins', ['translator', 'benchpress'], function (translator, Benchpress) {
+define('admin/appearance/skins', ['translator'], function (translator) {
 	var Skins = {};
 
 	Skins.init = function () {
@@ -52,7 +52,7 @@ define('admin/appearance/skins', ['translator', 'benchpress'], function (transla
 	Skins.render = function (bootswatch) {
 		var themeContainer = $('#bootstrap_themes');
 
-		Benchpress.parse('admin/partials/theme_list', {
+		app.parseAndTranslate('admin/partials/theme_list', {
 			themes: bootswatch.themes.map(function (theme) {
 				return {
 					type: 'bootswatch',
@@ -67,17 +67,15 @@ define('admin/appearance/skins', ['translator', 'benchpress'], function (transla
 			}),
 			showRevert: true,
 		}, function (html) {
-			translator.translate(html, function (html) {
-				themeContainer.html(html);
+			themeContainer.html(html);
 
-				if (config['theme:src']) {
-					var skin = config['theme:src']
-						.match(/latest\/(\S+)\/bootstrap.min.css/)[1]
-						.replace(/(^|\s)([a-z])/g, function (m, p1, p2) { return p1 + p2.toUpperCase(); });
+			if (config['theme:src']) {
+				var skin = config['theme:src']
+					.match(/latest\/(\S+)\/bootstrap.min.css/)[1]
+					.replace(/(^|\s)([a-z])/g, function (m, p1, p2) { return p1 + p2.toUpperCase(); });
 
-					highlightSelectedTheme(skin);
-				}
-			});
+				highlightSelectedTheme(skin);
+			}
 		});
 	};
 

--- a/public/src/admin/appearance/themes.js
+++ b/public/src/admin/appearance/themes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('admin/appearance/themes', ['translator', 'benchpress'], function (translator, Benchpress) {
+define('admin/appearance/themes', ['translator'], function (translator) {
 	var Themes = {};
 
 	Themes.init = function () {
@@ -75,13 +75,11 @@ define('admin/appearance/themes', ['translator', 'benchpress'], function (transl
 			if (!themes.length) {
 				instListEl.append($('<li/ >').addClass('no-themes').translateHtml('[[admin/appearance/themes:no-themes]]'));
 			} else {
-				Benchpress.parse('admin/partials/theme_list', {
+				app.parseAndTranslate('admin/partials/theme_list', {
 					themes: themes,
 				}, function (html) {
-					translator.translate(html, function (html) {
-						instListEl.html(html);
-						highlightSelectedTheme(config['theme:id']);
-					});
+					instListEl.html(html);
+					highlightSelectedTheme(config['theme:id']);
 				});
 			}
 		});

--- a/public/src/admin/dashboard.js
+++ b/public/src/admin/dashboard.js
@@ -343,7 +343,7 @@ define('admin/dashboard', ['Chart', 'translator', 'benchpress'], function (Chart
 			$('[data-action="updateGraph"][data-units="custom"]').on('click', function () {
 				var targetEl = $(this);
 
-				Benchpress.parse('admin/partials/pageviews-range-select', {}, function (html) {
+				Benchpress.render('admin/partials/pageviews-range-select', {}).then(function (html) {
 					var modal = bootbox.dialog({
 						title: '[[admin/dashboard:page-views-custom]]',
 						message: html,

--- a/public/src/admin/extend/plugins.js
+++ b/public/src/admin/extend/plugins.js
@@ -62,7 +62,7 @@ define('admin/extend/plugins', [
 			}
 
 			if (pluginData.license && pluginData.active !== true) {
-				Benchpress.parse('admin/partials/plugins/license', pluginData, function (html) {
+				Benchpress.render('admin/partials/plugins/license', pluginData).then(function (html) {
 					bootbox.dialog({
 						title: '[[admin/extend/plugins:license.title]]',
 						message: html,

--- a/public/src/admin/extend/rewards.js
+++ b/public/src/admin/extend/rewards.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('admin/extend/rewards', ['translator', 'benchpress'], function (translator, Benchpress) {
+define('admin/extend/rewards', [], function () {
 	var rewards = {};
 
 
@@ -139,12 +139,10 @@ define('admin/extend/rewards', ['translator', 'benchpress'], function (translato
 			rewards: available,
 		};
 
-		Benchpress.parse('admin/extend/rewards', 'active', data, function (li) {
-			translator.translate(li, function (li) {
-				li = $(li);
-				ul.append(li);
-				li.find('select').val('');
-			});
+		app.parseAndTranslate('admin/extend/rewards', 'active', data, function (li) {
+			li = $(li);
+			ul.append(li);
+			li.find('select').val('');
 		});
 	}
 

--- a/public/src/admin/manage/categories.js
+++ b/public/src/admin/manage/categories.js
@@ -109,9 +109,9 @@ define('admin/manage/categories', [
 				name: '[[admin/manage/categories:parent-category-none]]',
 				icon: 'fa-none',
 			});
-			Benchpress.parse('admin/partials/categories/create', {
+			Benchpress.render('admin/partials/categories/create', {
 				categories: categories,
-			}, function (html) {
+			}).then(function (html) {
 				var modal = bootbox.dialog({
 					title: '[[admin/manage/categories:alert.create]]',
 					message: html,
@@ -261,28 +261,26 @@ define('admin/manage/categories', [
 		}
 
 		function continueRender() {
-			Benchpress.parse('admin/partials/categories/category-rows', {
+			app.parseAndTranslate('admin/partials/categories/category-rows', {
 				cid: parentId,
 				categories: categories,
 			}, function (html) {
-				translator.translate(html, function (html) {
-					container.append(html);
+				container.append(html);
 
-					// Handle and children categories in this level have
-					for (var x = 0, numCategories = categories.length; x < numCategories; x += 1) {
-						renderList(categories[x].children, $('li[data-cid="' + categories[x].cid + '"]'), categories[x].cid);
-					}
+				// Handle and children categories in this level have
+				for (var x = 0, numCategories = categories.length; x < numCategories; x += 1) {
+					renderList(categories[x].children, $('li[data-cid="' + categories[x].cid + '"]'), categories[x].cid);
+				}
 
-					// Make list sortable
-					sortables[parentId] = Sortable.create($('ul[data-cid="' + parentId + '"]')[0], {
-						group: 'cross-categories',
-						animation: 150,
-						handle: '.information',
-						dataIdAttr: 'data-cid',
-						ghostClass: 'placeholder',
-						onAdd: itemDidAdd,
-						onEnd: itemDragDidEnd,
-					});
+				// Make list sortable
+				sortables[parentId] = Sortable.create($('ul[data-cid="' + parentId + '"]')[0], {
+					group: 'cross-categories',
+					animation: 150,
+					handle: '.information',
+					dataIdAttr: 'data-cid',
+					ghostClass: 'placeholder',
+					onAdd: itemDidAdd,
+					onEnd: itemDragDidEnd,
 				});
 			});
 		}

--- a/public/src/admin/manage/category.js
+++ b/public/src/admin/manage/category.js
@@ -66,10 +66,10 @@ define('admin/manage/category', [
 		$('.purge').on('click', function (e) {
 			e.preventDefault();
 
-			Benchpress.parse('admin/partials/categories/purge', {
+			Benchpress.render('admin/partials/categories/purge', {
 				name: ajaxify.data.category.name,
 				topic_count: ajaxify.data.category.topic_count,
-			}, function (html) {
+			}).then(function (html) {
 				var modal = bootbox.dialog({
 					title: '[[admin/manage/categories:purge]]',
 					message: html,
@@ -119,9 +119,9 @@ define('admin/manage/category', [
 					return app.alertError(err.message);
 				}
 
-				Benchpress.parse('admin/partials/categories/copy-settings', {
+				Benchpress.render('admin/partials/categories/copy-settings', {
 					categories: allCategories,
-				}, function (html) {
+				}).then(function (html) {
 					var selectedCid;
 					var modal = bootbox.dialog({
 						title: '[[modules:composer.select_category]]',

--- a/public/src/admin/manage/privileges.js
+++ b/public/src/admin/manage/privileges.js
@@ -140,15 +140,13 @@ define('admin/manage/privileges', [
 
 			ajaxify.data.privileges = privileges;
 			var tpl = parseInt(cid, 10) ? 'admin/partials/privileges/category' : 'admin/partials/privileges/global';
-			Benchpress.parse(tpl, {
+			app.parseAndTranslate(tpl, {
 				privileges: privileges,
 			}, function (html) {
-				translator.translate(html, function (html) {
-					$('.privilege-table-container').html(html);
-					Privileges.exposeAssumedPrivileges();
+				$('.privilege-table-container').html(html);
+				Privileges.exposeAssumedPrivileges();
 
-					hightlightRowByDataAttr('data-group-name', groupToHighlight);
-				});
+				hightlightRowByDataAttr('data-group-name', groupToHighlight);
 			});
 		});
 	};

--- a/public/src/admin/manage/users.js
+++ b/public/src/admin/manage/users.js
@@ -76,7 +76,7 @@ define('admin/manage/users', [
 				if (err) {
 					return app.alertError(err);
 				}
-				Benchpress.parse('admin/partials/manage_user_groups', data, function (html) {
+				Benchpress.render('admin/partials/manage_user_groups', data).then(function (html) {
 					var modal = bootbox.dialog({
 						message: html,
 						title: '[[admin/manage/users:manage-groups]]',
@@ -134,7 +134,7 @@ define('admin/manage/users', [
 				return false;	// specifically to keep the menu open
 			}
 
-			Benchpress.parse('admin/partials/temporary-ban', {}, function (html) {
+			Benchpress.render('admin/partials/temporary-ban', {}).then(function (html) {
 				bootbox.dialog({
 					className: 'ban-modal',
 					title: '[[user:ban_account]]',
@@ -321,7 +321,7 @@ define('admin/manage/users', [
 
 		function handleUserCreate() {
 			$('[data-action="create"]').on('click', function () {
-				Benchpress.parse('admin/partials/create_user_modal', {}, function (html) {
+				Benchpress.render('admin/partials/create_user_modal', {}).then(function (html) {
 					var modal = bootbox.dialog({
 						message: html,
 						title: '[[admin/manage/users:alerts.create]]',
@@ -426,7 +426,7 @@ define('admin/manage/users', [
 	}
 
 	function renderSearchResults(data) {
-		Benchpress.parse('partials/paginator', { pagination: data.pagination }, function (html) {
+		Benchpress.render('partials/paginator', { pagination: data.pagination }).then(function (html) {
 			$('.pagination-container').replaceWith(html);
 		});
 

--- a/public/src/admin/settings/navigation.js
+++ b/public/src/admin/settings/navigation.js
@@ -4,11 +4,10 @@
 define('admin/settings/navigation', [
 	'translator',
 	'iconSelect',
-	'benchpress',
 	'jquery-ui/widgets/draggable',
 	'jquery-ui/widgets/droppable',
 	'jquery-ui/widgets/sortable',
-], function (translator, iconSelect, Benchpress) {
+], function (translator, iconSelect) {
 	var navigation = {};
 	var available;
 
@@ -70,20 +69,16 @@ define('admin/settings/navigation', [
 		data.title = translator.escape(data.title);
 		data.text = translator.escape(data.text);
 		data.groups = ajaxify.data.groups;
-		Benchpress.parse('admin/settings/navigation', 'navigation', { navigation: [data] }, function (li) {
-			translator.translate(li, function (li) {
-				li = $(translator.unescape(li));
-				el.after(li);
-				el.remove();
-			});
+		app.parseAndTranslate('admin/settings/navigation', 'navigation', { navigation: [data] }, function (li) {
+			li = $(translator.unescape(li));
+			el.after(li);
+			el.remove();
 		});
 
-		Benchpress.parse('admin/settings/navigation', 'enabled', { enabled: [data] }, function (li) {
-			translator.translate(li, function (li) {
-				li = $(translator.unescape(li));
-				$('#enabled').append(li);
-				componentHandler.upgradeDom();
-			});
+		app.parseAndTranslate('admin/settings/navigation', 'enabled', { enabled: [data] }, function (li) {
+			li = $(translator.unescape(li));
+			$('#enabled').append(li);
+			componentHandler.upgradeDom();
 		});
 	}
 

--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -171,11 +171,12 @@ ajaxify = window.ajaxify || {};
 	function renderTemplate(url, tpl_url, data, callback) {
 		$(window).trigger('action:ajaxify.loadingTemplates', {});
 
-		Benchpress.parse(tpl_url, data, function (template) {
-			translator.translate(template, function (translatedTemplate) {
-				translatedTemplate = translator.unescape(translatedTemplate);
+		Benchpress.render(tpl_url, data)
+			.then(rendered => translator.translate(rendered))
+			.then(function (translated) {
+				translated = translator.unescape(translated);
 				$('body').removeClass(previousBodyClass).addClass(data.bodyClass);
-				$('#content').html(translatedTemplate);
+				$('#content').html(translated);
 
 				ajaxify.end(url, tpl_url);
 
@@ -189,7 +190,6 @@ ajaxify = window.ajaxify || {};
 				updateTitle(data.title);
 				updateTags();
 			});
-		});
 	}
 
 	function updateTitle(title) {

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -727,24 +727,19 @@ app.cacheBuster = null;
 
 	app.parseAndTranslate = function (template, blockName, data, callback) {
 		require(['translator', 'benchpress'], function (translator, Benchpress) {
-			function translate(html, callback) {
-				translator.translate(html, function (translatedHTML) {
-					translatedHTML = translator.unescape(translatedHTML);
-					callback($(translatedHTML));
-				});
-			}
-
-			if (typeof blockName === 'string') {
-				Benchpress.parse(template, blockName, data, function (html) {
-					translate(html, callback);
-				});
-			} else {
+			if (typeof blockName !== 'string') {
 				callback = data;
 				data = blockName;
-				Benchpress.parse(template, data, function (html) {
-					translate(html, callback);
-				});
+				blockName = undefined;
 			}
+
+			Benchpress.render(template, data, blockName)
+				.then(rendered => translator.translate(rendered))
+				.then(translated => translator.unescape(translated))
+				.then(
+					result => setTimeout(callback, 0, result),
+					err => console.error(err)
+				);
 		});
 	};
 

--- a/public/src/client/account/edit.js
+++ b/public/src/client/account/edit.js
@@ -88,70 +88,68 @@ define('forum/account/edit', [
 					return memo || cur.type === 'uploaded';
 				}, false);
 
-				Benchpress.parse('partials/modals/change_picture_modal', {
+				app.parseAndTranslate('partials/modals/change_picture_modal', {
 					pictures: pictures,
 					uploaded: uploaded,
 					icon: { text: ajaxify.data['icon:text'], bgColor: ajaxify.data['icon:bgColor'] },
 					defaultAvatar: ajaxify.data.defaultAvatar,
 					allowProfileImageUploads: ajaxify.data.allowProfileImageUploads,
 				}, function (html) {
-					translator.translate(html, function (html) {
-						var modal = bootbox.dialog({
-							className: 'picture-switcher',
-							title: '[[user:change_picture]]',
-							message: html,
-							show: true,
-							buttons: {
-								close: {
-									label: '[[global:close]]',
-									callback: onCloseModal,
-									className: 'btn-link',
-								},
-								update: {
-									label: '[[global:save_changes]]',
-									callback: saveSelection,
-								},
+					var modal = bootbox.dialog({
+						className: 'picture-switcher',
+						title: '[[user:change_picture]]',
+						message: html,
+						show: true,
+						buttons: {
+							close: {
+								label: '[[global:close]]',
+								callback: onCloseModal,
+								className: 'btn-link',
 							},
-						});
+							update: {
+								label: '[[global:save_changes]]',
+								callback: saveSelection,
+							},
+						},
+					});
 
-						modal.on('shown.bs.modal', updateImages);
-						modal.on('click', '.list-group-item', function selectImageType() {
-							modal.find('.list-group-item').removeClass('active');
-							$(this).addClass('active');
-						});
+					modal.on('shown.bs.modal', updateImages);
+					modal.on('click', '.list-group-item', function selectImageType() {
+						modal.find('.list-group-item').removeClass('active');
+						$(this).addClass('active');
+					});
 
-						handleImageUpload(modal);
+					handleImageUpload(modal);
 
-						function updateImages() {
-							// Check to see which one is the active picture
-							if (!ajaxify.data.picture) {
-								modal.find('.list-group-item .user-icon').parents('.list-group-item').addClass('active');
-							} else {
-								modal.find('.list-group-item img').each(function () {
-									if (this.getAttribute('src') === ajaxify.data.picture) {
-										$(this).parents('.list-group-item').addClass('active');
-									}
-								});
-							}
-						}
-
-						function saveSelection() {
-							var type = modal.find('.list-group-item.active').attr('data-type');
-
-							changeUserPicture(type, function (err) {
-								if (err) {
-									return app.alertError(err.message);
+					function updateImages() {
+						// Check to see which one is the active picture
+						if (!ajaxify.data.picture) {
+							modal.find('.list-group-item .user-icon').parents('.list-group-item').addClass('active');
+						} else {
+							modal.find('.list-group-item img').each(function () {
+								if (this.getAttribute('src') === ajaxify.data.picture) {
+									$(this).parents('.list-group-item').addClass('active');
 								}
-
-								updateHeader(type === 'default' ? '' : modal.find('.list-group-item.active img').attr('src'));
-								ajaxify.refresh();
 							});
 						}
+					}
 
-						function onCloseModal() {
-							modal.modal('hide');
-						}
-					});
+					function saveSelection() {
+						var type = modal.find('.list-group-item.active').attr('data-type');
+
+						changeUserPicture(type, function (err) {
+							if (err) {
+								return app.alertError(err.message);
+							}
+
+							updateHeader(type === 'default' ? '' : modal.find('.list-group-item.active img').attr('src'));
+							ajaxify.refresh();
+						});
+					}
+
+					function onCloseModal() {
+						modal.modal('hide');
+					}
 				});
 			});
 
@@ -247,30 +245,28 @@ define('forum/account/edit', [
 
 		modal.find('[data-action="upload-url"]').on('click', function () {
 			modal.modal('hide');
-			Benchpress.parse('partials/modals/upload_picture_from_url_modal', {}, function (html) {
-				translator.translate(html, function (html) {
-					var uploadModal = $(html);
-					uploadModal.modal('show');
+			app.parseAndTranslate('partials/modals/upload_picture_from_url_modal', {}, function (html) {
+				var uploadModal = $(html);
+				uploadModal.modal('show');
 
-					uploadModal.find('.upload-btn').on('click', function () {
-						var url = uploadModal.find('#uploadFromUrl').val();
-						if (!url) {
-							return false;
-						}
-
-						uploadModal.modal('hide');
-
-						pictureCropper.handleImageCrop({
-							url: url,
-							socketMethod: 'user.uploadCroppedPicture',
-							aspectRatio: 1,
-							allowSkippingCrop: false,
-							paramName: 'uid',
-							paramValue: ajaxify.data.theirid,
-						}, onUploadComplete);
-
+				uploadModal.find('.upload-btn').on('click', function () {
+					var url = uploadModal.find('#uploadFromUrl').val();
+					if (!url) {
 						return false;
-					});
+					}
+
+					uploadModal.modal('hide');
+
+					pictureCropper.handleImageCrop({
+						url: url,
+						socketMethod: 'user.uploadCroppedPicture',
+						aspectRatio: 1,
+						allowSkippingCrop: false,
+						paramName: 'uid',
+						paramValue: ajaxify.data.theirid,
+					}, onUploadComplete);
+
+					return false;
 				});
 			});
 

--- a/public/src/client/account/header.js
+++ b/public/src/client/account/header.js
@@ -128,7 +128,7 @@ define('forum/account/header', [
 	function banAccount(theirid, onSuccess) {
 		theirid = theirid || ajaxify.data.theirid;
 
-		Benchpress.parse('admin/partials/temporary-ban', {}, function (html) {
+		Benchpress.render('admin/partials/temporary-ban', {}).then(function (html) {
 			bootbox.dialog({
 				className: 'ban-modal',
 				title: '[[user:ban_account]]',

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -219,36 +219,34 @@ define('forum/chats', [
 		var modal;
 
 		buttonEl.on('click', function () {
-			Benchpress.parse('partials/modals/manage_room', {}, function (html) {
-				translator.translate(html, function (html) {
-					modal = bootbox.dialog({
-						title: '[[modules:chat.manage-room]]',
-						message: html,
-					});
+			app.parseAndTranslate('partials/modals/manage_room', {}, function (html) {
+				modal = bootbox.dialog({
+					title: '[[modules:chat.manage-room]]',
+					message: html,
+				});
 
-					modal.attr('component', 'chat/manage-modal');
+				modal.attr('component', 'chat/manage-modal');
 
-					Chats.refreshParticipantsList(roomId, modal);
-					Chats.addKickHandler(roomId, modal);
+				Chats.refreshParticipantsList(roomId, modal);
+				Chats.addKickHandler(roomId, modal);
 
-					var searchInput = modal.find('input');
-					var errorEl = modal.find('.text-danger');
-					require(['autocomplete', 'translator'], function (autocomplete, translator) {
-						autocomplete.user(searchInput, function (event, selected) {
-							errorEl.text('');
-							socket.emit('modules.chats.addUserToRoom', {
-								roomId: roomId,
-								username: selected.item.user.name,
-							}, function (err) {
-								if (err) {
-									translator.translate(err.message, function (translated) {
-										errorEl.text(translated);
-									});
-								}
+				var searchInput = modal.find('input');
+				var errorEl = modal.find('.text-danger');
+				require(['autocomplete', 'translator'], function (autocomplete, translator) {
+					autocomplete.user(searchInput, function (event, selected) {
+						errorEl.text('');
+						socket.emit('modules.chats.addUserToRoom', {
+							roomId: roomId,
+							username: selected.item.user.name,
+						}, function (err) {
+							if (err) {
+								translator.translate(err.message, function (translated) {
+									errorEl.text(translated);
+								});
+							}
 
-								Chats.refreshParticipantsList(roomId, modal);
-								searchInput.val('');
-							});
+							Chats.refreshParticipantsList(roomId, modal);
+							searchInput.val('');
 						});
 					});
 				});
@@ -324,21 +322,19 @@ define('forum/chats', [
 		var modal;
 
 		buttonEl.on('click', function () {
-			Benchpress.parse('partials/modals/rename_room', {
+			app.parseAndTranslate('partials/modals/rename_room', {
 				name: roomName || ajaxify.data.roomName,
 			}, function (html) {
-				translator.translate(html, function (html) {
-					modal = bootbox.dialog({
-						title: '[[modules:chat.rename-room]]',
-						message: html,
-						buttons: {
-							save: {
-								label: '[[global:save]]',
-								className: 'btn-primary',
-								callback: submit,
-							},
+				modal = bootbox.dialog({
+					title: '[[modules:chat.rename-room]]',
+					message: html,
+					buttons: {
+						save: {
+							label: '[[global:save]]',
+							className: 'btn-primary',
+							callback: submit,
 						},
-					});
+					},
 				});
 			});
 		});
@@ -478,7 +474,7 @@ define('forum/chats', [
 					roomEl.addClass('unread');
 				} else {
 					var recentEl = components.get('chat/recent');
-					Benchpress.parse('partials/chats/recent_room', {
+					app.parseAndTranslate('partials/chats/recent_room', {
 						rooms: {
 							roomId: data.roomId,
 							lastUser: data.message.fromUser,
@@ -486,9 +482,7 @@ define('forum/chats', [
 							unread: true,
 						},
 					}, function (html) {
-						translator.translate(html, function (translated) {
-							recentEl.prepend(translated);
-						});
+						recentEl.prepend(html);
 					});
 				}
 			}

--- a/public/src/client/chats/messages.js
+++ b/public/src/client/chats/messages.js
@@ -102,13 +102,13 @@ define('forum/chats/messages', ['components', 'translator', 'benchpress'], funct
 		}
 
 		if (Array.isArray(data)) {
-			Benchpress.parse('partials/chats/message' + (Array.isArray(data) ? 's' : ''), {
+			Benchpress.render('partials/chats/message' + (Array.isArray(data) ? 's' : ''), {
 				messages: data,
-			}, done);
+			}).then(done);
 		} else {
-			Benchpress.parse('partials/chats/' + (data.system ? 'system-message' : 'message'), {
+			Benchpress.render('partials/chats/' + (data.system ? 'system-message' : 'message'), {
 				messages: data,
-			}, done);
+			}).then(done);
 		}
 	};
 

--- a/public/src/client/flags/detail.js
+++ b/public/src/client/flags/detail.js
@@ -144,9 +144,9 @@ define('forum/flags/detail', ['forum/flags/list', 'components', 'translator', 'b
 
 	Detail.reloadNotes = function (notes) {
 		ajaxify.data.notes = notes;
-		Benchpress.parse('flags/detail', 'notes', {
+		Benchpress.render('flags/detail', 'notes', {
 			notes: notes,
-		}, function (html) {
+		}).then(function (html) {
 			var wrapperEl = components.get('flag/notes');
 			wrapperEl.empty();
 			wrapperEl.html(html);
@@ -156,15 +156,13 @@ define('forum/flags/detail', ['forum/flags/list', 'components', 'translator', 'b
 	};
 
 	Detail.reloadHistory = function (history) {
-		Benchpress.parse('flags/detail', 'history', {
+		app.parseAndTranslate('flags/detail', 'history', {
 			history: history,
 		}, function (html) {
-			translator.translate(html, function (translated) {
-				var wrapperEl = components.get('flag/history');
-				wrapperEl.empty();
-				wrapperEl.html(translated);
-				wrapperEl.find('span.timeago').timeago();
-			});
+			var wrapperEl = components.get('flag/history');
+			wrapperEl.empty();
+			wrapperEl.html(html);
+			wrapperEl.find('span.timeago').timeago();
 		});
 	};
 

--- a/public/src/client/groups/list.js
+++ b/public/src/client/groups/list.js
@@ -41,9 +41,9 @@ define('forum/groups/list', [
 			after: $('[component="groups/container"]').attr('data-nextstart'),
 		}, function (data, done) {
 			if (data && data.groups.length) {
-				Benchpress.parse('partials/groups/list', {
+				Benchpress.render('partials/groups/list', {
 					groups: data.groups,
-				}, function (html) {
+				}).then(function (html) {
 					$('#groups-list').append(html);
 					done();
 				});
@@ -77,9 +77,9 @@ define('forum/groups/list', [
 			groups = groups.filter(function (group) {
 				return group.name !== 'registered-users' && group.name !== 'guests';
 			});
-			Benchpress.parse('partials/groups/list', {
+			Benchpress.render('partials/groups/list', {
 				groups: groups,
-			}, function (html) {
+			}).then(function (html) {
 				groupsEl.empty().append(html);
 			});
 		});

--- a/public/src/client/ip-blacklist.js
+++ b/public/src/client/ip-blacklist.js
@@ -32,7 +32,7 @@ define('forum/ip-blacklist', ['Chart', 'benchpress'], function (Chart, Benchpres
 					return app.alertError(err.message);
 				}
 
-				Benchpress.parse('admin/partials/blacklist-validate', data, function (html) {
+				Benchpress.render('admin/partials/blacklist-validate', data).then(function (html) {
 					bootbox.alert(html);
 				});
 			});

--- a/public/src/client/topic/diffs.js
+++ b/public/src/client/topic/diffs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-define('forum/topic/diffs', ['forum/topic/images', 'benchpress', 'translator'], function (Images, Benchpress, translator) {
+define('forum/topic/diffs', ['forum/topic/images'], function () {
 	var Diffs = {};
 
 	Diffs.open = function (pid) {
@@ -15,7 +15,7 @@ define('forum/topic/diffs', ['forum/topic/images', 'benchpress', 'translator'], 
 				return app.alertError(err.message);
 			}
 
-			Benchpress.parse('partials/modals/post_history', {
+			app.parseAndTranslate('partials/modals/post_history', {
 				diffs: data.revisions.map(function (revision) {
 					var timestamp = parseInt(revision.timestamp, 10);
 
@@ -28,34 +28,32 @@ define('forum/topic/diffs', ['forum/topic/images', 'benchpress', 'translator'], 
 				numDiffs: data.timestamps.length,
 				editable: data.editable,
 			}, function (html) {
-				translator.translate(html, function (html) {
-					var modal = bootbox.dialog({
-						title: '[[topic:diffs.title]]',
-						message: html,
-						size: 'large',
-					});
+				var modal = bootbox.dialog({
+					title: '[[topic:diffs.title]]',
+					message: html,
+					size: 'large',
+				});
 
-					if (!data.timestamps.length) {
-						return;
-					}
+				if (!data.timestamps.length) {
+					return;
+				}
 
-					var selectEl = modal.find('select');
-					var revertEl = modal.find('button[data-action="restore"]');
-					var postContainer = modal.find('ul.posts-list');
+				var selectEl = modal.find('select');
+				var revertEl = modal.find('button[data-action="restore"]');
+				var postContainer = modal.find('ul.posts-list');
 
-					selectEl.on('change', function () {
-						Diffs.load(pid, this.value, postContainer);
-						revertEl.prop('disabled', data.timestamps.indexOf(this.value) === 0);
-					});
+				selectEl.on('change', function () {
+					Diffs.load(pid, this.value, postContainer);
+					revertEl.prop('disabled', data.timestamps.indexOf(this.value) === 0);
+				});
 
-					revertEl.on('click', function () {
-						Diffs.restore(pid, selectEl.val(), modal);
-					});
+				revertEl.on('click', function () {
+					Diffs.restore(pid, selectEl.val(), modal);
+				});
 
-					modal.on('shown.bs.modal', function () {
-						Diffs.load(pid, selectEl.val(), postContainer);
-						revertEl.prop('disabled', true);
-					});
+				modal.on('shown.bs.modal', function () {
+					Diffs.load(pid, selectEl.val(), postContainer);
+					revertEl.prop('disabled', true);
 				});
 			});
 		});

--- a/public/src/client/topic/events.js
+++ b/public/src/client/topic/events.js
@@ -139,19 +139,17 @@ define('forum/topic/events', [
 					editedISO: utils.toISOString(data.post.edited),
 				};
 
-				Benchpress.parse('partials/topic/post-editor', editData, function (html) {
-					translator.translate(html, function (translated) {
-						html = $(translated);
-						editorEl.replaceWith(html);
-						$('[data-pid="' + data.post.pid + '"] [component="post/editor"] .timeago').timeago();
-						$(window).trigger('action:posts.edited', data);
-					});
+				app.parseAndTranslate('partials/topic/post-editor', editData, function (html) {
+					html = $(html);
+					editorEl.replaceWith(html);
+					$('[data-pid="' + data.post.pid + '"] [component="post/editor"] .timeago').timeago();
+					$(window).trigger('action:posts.edited', data);
 				});
 			});
 		}
 
 		if (data.topic.tags && tagsUpdated(data.topic.tags)) {
-			Benchpress.parse('partials/topic/tags', { tags: data.topic.tags }, function (html) {
+			Benchpress.render('partials/topic/tags', { tags: data.topic.tags }).then(function (html) {
 				var tags = $('.tags');
 
 				tags.fadeOut(250, function () {

--- a/public/src/client/topic/votes.js
+++ b/public/src/client/topic/votes.js
@@ -80,18 +80,16 @@ define('forum/topic/votes', [
 				return app.alertError(err.message);
 			}
 
-			Benchpress.parse('partials/modals/votes_modal', data, function (html) {
-				translator.translate(html, function (translated) {
-					var dialog = bootbox.dialog({
-						title: '[[global:voters]]',
-						message: translated,
-						className: 'vote-modal',
-						show: true,
-					});
+			app.parseAndTranslate('partials/modals/votes_modal', data, function (html) {
+				var dialog = bootbox.dialog({
+					title: '[[global:voters]]',
+					message: html,
+					className: 'vote-modal',
+					show: true,
+				});
 
-					dialog.on('click', function () {
-						dialog.modal('hide');
-					});
+				dialog.on('click', function () {
+					dialog.modal('hide');
 				});
 			});
 		});

--- a/public/src/client/users.js
+++ b/public/src/client/users.js
@@ -103,7 +103,7 @@ define('forum/users', [
 	}
 
 	function renderSearchResults(data) {
-		Benchpress.parse('partials/paginator', { pagination: data.pagination }, function (html) {
+		Benchpress.render('partials/paginator', { pagination: data.pagination }).then(function (html) {
 			$('.pagination-container').replaceWith(html);
 		});
 
@@ -112,13 +112,11 @@ define('forum/users', [
 		}
 
 		data.isAdminOrGlobalMod = app.user.isAdmin || app.user.isGlobalMod;
-		Benchpress.parse('users', 'users', data, function (html) {
-			translator.translate(html, function (translated) {
-				translated = $(translated);
-				$('#users-container').html(translated);
-				translated.find('span.timeago').timeago();
-				$('[component="user/search/icon"]').addClass('fa-search').removeClass('fa-spinner fa-spin');
-			});
+		app.parseAndTranslate('users', 'users', data, function (translated) {
+			translated = $(translated);
+			$('#users-container').html(translated);
+			translated.find('span.timeago').timeago();
+			$('[component="user/search/icon"]').addClass('fa-search').removeClass('fa-spinner fa-spin');
 		});
 	}
 

--- a/public/src/modules/alerts.js
+++ b/public/src/modules/alerts.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('alerts', ['translator', 'components', 'benchpress'], function (translator, components, Benchpress) {
+define('alerts', ['translator', 'components'], function (translator, components) {
 	var module = {};
 
 	module.alert = function (params) {
@@ -19,42 +19,40 @@ define('alerts', ['translator', 'components', 'benchpress'], function (translato
 	};
 
 	function createNew(params) {
-		Benchpress.parse('alert', params, function (alertTpl) {
-			translator.translate(alertTpl, function (translatedHTML) {
-				var alert = $('#' + params.alert_id);
-				if (alert.length) {
-					return updateAlert(alert, params);
-				}
-				alert = $(translatedHTML);
-				alert.fadeIn(200);
+		app.parseAndTranslate('alert', params, function (html) {
+			var alert = $('#' + params.alert_id);
+			if (alert.length) {
+				return updateAlert(alert, params);
+			}
+			alert = $(html);
+			alert.fadeIn(200);
 
-				components.get('toaster/tray').prepend(alert);
+			components.get('toaster/tray').prepend(alert);
 
-				if (typeof params.closefn === 'function') {
-					alert.find('button').on('click', function () {
-						params.closefn();
+			if (typeof params.closefn === 'function') {
+				alert.find('button').on('click', function () {
+					params.closefn();
+					fadeOut(alert);
+					return false;
+				});
+			}
+
+			if (params.timeout) {
+				startTimeout(alert, params);
+			}
+
+			if (typeof params.clickfn === 'function') {
+				alert
+					.addClass('pointer')
+					.on('click', function (e) {
+						if (!$(e.target).is('.close')) {
+							params.clickfn(alert, params);
+						}
 						fadeOut(alert);
-						return false;
 					});
-				}
+			}
 
-				if (params.timeout) {
-					startTimeout(alert, params);
-				}
-
-				if (typeof params.clickfn === 'function') {
-					alert
-						.addClass('pointer')
-						.on('click', function (e) {
-							if (!$(e.target).is('.close')) {
-								params.clickfn(alert, params);
-							}
-							fadeOut(alert);
-						});
-				}
-
-				$(window).trigger('action:alert.new', { alert: alert, params: params });
-			});
+			$(window).trigger('action:alert.new', { alert: alert, params: params });
 		});
 	}
 

--- a/public/src/modules/categorySelector.js
+++ b/public/src/modules/categorySelector.js
@@ -48,33 +48,31 @@ define('categorySelector', ['benchpress', 'translator', 'categorySearch'], funct
 			callback = categories;
 			categories = ajaxify.data.allCategories;
 		}
-		Benchpress.parse('admin/partials/categories/select-category', {
+		app.parseAndTranslate('admin/partials/categories/select-category', {
 			categories: categories,
 		}, function (html) {
-			translator.translate(html, function (html) {
-				var modal = bootbox.dialog({
-					title: '[[modules:composer.select_category]]',
-					message: html,
-					buttons: {
-						save: {
-							label: '[[global:select]]',
-							className: 'btn-primary',
-							callback: submit,
-						},
+			var modal = bootbox.dialog({
+				title: '[[modules:composer.select_category]]',
+				message: html,
+				buttons: {
+					save: {
+						label: '[[global:select]]',
+						className: 'btn-primary',
+						callback: submit,
 					},
-				});
-				var selector = categorySelector.init(modal.find('[component="category-selector"]'));
-				function submit(ev) {
-					ev.preventDefault();
-					if (selector.selectedCategory) {
-						callback(selector.selectedCategory.cid);
-						modal.modal('hide');
-					}
-					return false;
-				}
-
-				modal.find('form').on('submit', submit);
+				},
 			});
+			var selector = categorySelector.init(modal.find('[component="category-selector"]'));
+			function submit(ev) {
+				ev.preventDefault();
+				if (selector.selectedCategory) {
+					callback(selector.selectedCategory.cid);
+					modal.modal('hide');
+				}
+				return false;
+			}
+
+			modal.find('form').on('submit', submit);
 		});
 	};
 

--- a/public/src/modules/iconSelect.js
+++ b/public/src/modules/iconSelect.js
@@ -19,7 +19,7 @@ define('iconSelect', ['benchpress'], function (Benchpress) {
 			}
 		}
 
-		Benchpress.parse('partials/fontawesome', {}, function (html) {
+		Benchpress.render('partials/fontawesome', {}).then(function (html) {
 			html = $(html);
 			html.find('.fa-icons').prepend($('<i class="fa fa-nbb-none"></i>'));
 

--- a/public/src/modules/notifications.js
+++ b/public/src/modules/notifications.js
@@ -27,8 +27,8 @@ define('notifications', [
 					notifs[i].timeago = $.timeago(new Date(parseInt(notifs[i].datetime, 10)));
 				}
 				translator.toggleTimeagoShorthand();
-				Benchpress.parse('partials/notifications_list', { notifications: notifs }, function (html) {
-					notifList.translateHtml(html);
+				app.parseAndTranslate('partials/notifications_list', { notifications: notifs }, function (html) {
+					notifList.html(html);
 					notifList.off('click').on('click', '[data-nid]', function (ev) {
 						var notifEl = $(this);
 						if (scrollToPostIndexIfOnPage(notifEl)) {

--- a/public/src/modules/settings/sorted-list.js
+++ b/public/src/modules/settings/sorted-list.js
@@ -29,7 +29,7 @@ define('settings/sorted-list', [
 			var key = $container.attr('data-sorted-list');
 			var formTpl = $container.attr('data-form-template');
 
-			benchpress.parse(formTpl, {}, function (formHtml) {
+			benchpress.render(formTpl, {}).then(function (formHtml) {
 				var addBtn = $('[data-sorted-list="' + key + '"] [data-type="add"]');
 
 				addBtn.on('click', function () {

--- a/public/src/modules/taskbar.js
+++ b/public/src/modules/taskbar.js
@@ -7,7 +7,7 @@ define('taskbar', ['benchpress', 'translator'], function (Benchpress, translator
 	taskbar.init = function () {
 		var self = this;
 
-		Benchpress.parse('modules/taskbar', {}, function (html) {
+		Benchpress.render('modules/taskbar', {}).then(function (html) {
 			self.taskbar = $(html);
 			self.tasklist = self.taskbar.find('ul');
 			$(document.body).append(self.taskbar);

--- a/public/src/modules/uploader.js
+++ b/public/src/modules/uploader.js
@@ -1,12 +1,12 @@
 'use strict';
 
 
-define('uploader', ['translator', 'benchpress', 'jquery-form'], function (translator, Benchpress) {
+define('uploader', ['jquery-form'], function () {
 	var module = {};
 
 	module.show = function (data, callback) {
 		var fileSize = data.hasOwnProperty('fileSize') && data.fileSize !== undefined ? parseInt(data.fileSize, 10) : false;
-		parseModal({
+		app.parseAndTranslate('partials/modals/upload_file_modal', {
 			showHelp: data.hasOwnProperty('showHelp') && data.showHelp !== undefined ? data.showHelp : true,
 			fileSize: fileSize,
 			title: data.title || '[[global:upload_file]]',
@@ -95,12 +95,6 @@ define('uploader', ['translator', 'benchpress', 'jquery-form'], function (transl
 			},
 		});
 	};
-
-	function parseModal(tplVals, callback) {
-		Benchpress.parse('partials/modals/upload_file_modal', tplVals, function (html) {
-			translator.translate(html, callback);
-		});
-	}
 
 	function maybeParse(response) {
 		if (typeof response === 'string') {


### PR DESCRIPTION
It has been deprecated with no warning message for a while
Changing these over before enabling the warning message to reduce spam