### PR TITLE
Clear cache before firing hook. 

### DIFF
--- a/src/meta/settings.js
+++ b/src/meta/settings.js
@@ -85,6 +85,8 @@ Settings.set = async function (hash, values, quiet) {
 		await db.setObject('settings:' + hash, values);
 	}
 
+	cache.del('settings:' + hash);
+
 	plugins.fireHook('action:settings.set', {
 		plugin: hash,
 		settings: values,
@@ -92,7 +94,6 @@ Settings.set = async function (hash, values, quiet) {
 
 	pubsub.publish('action:settings.set.' + hash, values);
 	Meta.reloadRequired = !quiet;
-	cache.del('settings:' + hash);
 };
 
 Settings.setOne = async function (hash, field, value) {


### PR DESCRIPTION
As the settings are cached now, we need to remove the cache before the `plugin.fireHook` event is called. Otherwise, plugins listening to this hook, can receive old data if they are fetching the settings from the cache again. See for example this https://github.com/ninenine/nodebb-plugin-beep/blob/master/index.js#L34
