### PR TITLE
Run grunt with debugger enabled

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,14 +143,14 @@ module.exports = function (grunt) {
 		if (worker) {
 			worker.kill();
 		}
-		
-		const execArgv = [];		
+
+		const execArgv = [];
 		const inspect = process.argv.find(a => a.startsWith('--inspect'))
-		
-		if (inspect) {						
+
+		if (inspect) {
 			execArgv.push(inspect)
 		}
-		
+
 		worker = fork('app.js', args, {
 			env,
 			execArgv

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,15 +145,15 @@ module.exports = function (grunt) {
 		}
 
 		const execArgv = [];
-		const inspect = process.argv.find(a => a.startsWith('--inspect'))
+		const inspect = process.argv.find(a => a.startsWith('--inspect'));
 
 		if (inspect) {
-			execArgv.push(inspect)
+			execArgv.push(inspect);
 		}
 
 		worker = fork('app.js', args, {
 			env,
-			execArgv
+			execArgv,
 		});
 	}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,8 +143,17 @@ module.exports = function (grunt) {
 		if (worker) {
 			worker.kill();
 		}
+		
+		const execArgv = [];		
+		const inspect = process.argv.find(a => a.startsWith('--inspect'))
+		
+		if (inspect) {						
+			execArgv.push(inspect)
+		}
+		
 		worker = fork('app.js', args, {
-			env: env,
+			env,
+			execArgv
 		});
 	}
 


### PR DESCRIPTION
When forking a node.js thread we are also having the possibility to pass some node.js arguments, such as "--inspect=0.0.0.0". By providing this, we are adding the capability of doing live debugging even when the system is started with grunt.