### PR TITLE
fix: working dir when called from another dir

### DIFF
--- a/require-main.js
+++ b/require-main.js
@@ -8,3 +8,5 @@ if (require.main !== module) {
 		return require(path);
 	};
 }
+// this forces the current working directory to always be the directory containing NodeBB
+process.chdir(__dirname);


### PR DESCRIPTION
fixes JS compilation error when `./nodebb build` is called from a different directory

Errors like this:
```
2020-11-25T05:35:04.301Z [4567/10375] - error: [build]           client js bundle  build failed
2020-11-25T05:35:04.301Z [4567/10375] - error: [build]            admin js bundle  build failed
2020-11-25T05:35:04.301Z [4567/10375] - error: [build] Encountered error during build step
Error: Error: ERROR: module path does not exist: /home/peter/Dev/node_modules/timeago/jquery.timeago.js for module named: timeago/jquery.timeago. Path is relative to: /home/peter/Dev
    at /home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:28447:35

    at /home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:28332:19
    at /home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:3059:39
    at /home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:2999:25
    at Function.prim.nextTick (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:28083:9)
    at Object.errback (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:2998:26)
    at Object.callback (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:2984:23)
    at Object.then (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:3038:23)
    at build (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:28289:12)
    at runBuild (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:30302:17)
    at Object.execCb (/home/peter/Dev/nodebb/node_modules/requirejs/bin/r.js:1946:33)
```