### PR TITLE
Solve Custom  home page route error bug

### DIFF
--- a/src/controllers/home.js
+++ b/src/controllers/home.js
@@ -7,7 +7,7 @@ const meta = require('../meta');
 const user = require('../user');
 
 function adminHomePageRoute() {
-	return (meta.config.homePageRoute || meta.config.homePageCustom || '').replace(/^\/+/, '') || 'categories';
+	return ((meta.config.homePageRoute === 'custom' ? meta.config.homePageCustom : meta.config.homePageRoute) || 'categories').replace(/^\//, '');
 }
 
 async function getUserHomeRoute(uid) {


### PR DESCRIPTION
When you select Custom Route as home page you get a **404 error** "/custom not found" error.
This because _homePageRoute_ property was used instead of _homePageCustom_
[https://community.nodebb.org/topic/14647/custom-home-page?_=1610063629488](https://community.nodebb.org/topic/14647/custom-home-page?_=1610063629488)
