### PR TITLE
Client-side Hooks (asynchronous filter/static hooks)

### DIFF
--- a/public/src/admin/admin.js
+++ b/public/src/admin/admin.js
@@ -30,9 +30,11 @@
 		}, 3600000);
 	}
 
-	$(window).on('action:ajaxify.end', function () {
-		showCorrectNavTab();
-		startLogoutTimer();
+	require(['hooks'], (hooks) => {
+		hooks.on('action:ajaxify.end', () => {
+			showCorrectNavTab();
+			startLogoutTimer();
+		});
 	});
 
 	function showCorrectNavTab() {
@@ -66,12 +68,12 @@
 	});
 
 	function setupNProgress() {
-		require(['nprogress'], function (NProgress) {
+		require(['nprogress', 'hooks'], function (NProgress, hooks) {
 			$(window).on('action:ajaxify.start', function () {
 				NProgress.set(0.7);
 			});
 
-			$(window).on('action:ajaxify.end', function () {
+			hooks.on('action:ajaxify.end', function () {
 				NProgress.done();
 			});
 		});

--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -319,15 +319,38 @@ ajaxify = window.ajaxify || {};
 		if (tpl_url.startsWith('admin')) {
 			location = '';
 		}
+
+		require(['hooks', location + tpl_url], (hooks, module) => {
+			if (module && module.init) {
+				module.init();
+			}
+
+			hooks.fire('static:script.init', { tpl_url }).then(ajaxify.loadExtraScripts.bind(null, tpl_url, callback));
+		}, function () {
+			// ignore 404 error
+		});
+	};
+
+	ajaxify.loadExtraScripts = (tpl_url, callback) => {
 		var data = {
 			tpl_url: tpl_url,
-			scripts: [location + tpl_url],
+			scripts: [],
 		};
 
 		$(window).trigger('action:script.load', data);
 
 		// Require and parse modules
 		var outstanding = data.scripts.length;
+
+		if (outstanding && !app.flags.actionScriptLoadDeprecation) {
+			console.group('Deprecation Notice');
+			console.warn('The "action:script.load" event has been deprecated and will be removed in NodeBB v1.18.0. Please attach a listener to the "static:script.init" client-side hook instead');
+			data.scripts.forEach((script) => {
+				console.info(`Affected script: ${typeof script === 'function' ? script.name || 'anonymous ' + script.toString() : script}`);
+			});
+			console.groupEnd();
+			app.flags.actionScriptLoadDeprecation = 1;
+		}
 
 		data.scripts.map(function (script) {
 			if (typeof script === 'function') {

--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -342,6 +342,10 @@ ajaxify = window.ajaxify || {};
 		// Require and parse modules
 		var outstanding = data.scripts.length;
 
+		if (!outstanding) {
+			return callback();
+		}
+
 		if (outstanding && !app.flags.actionScriptLoadDeprecation) {
 			console.group('Deprecation Notice');
 			console.warn('The "action:script.load" event has been deprecated and will be removed in NodeBB v1.18.0. Please attach a listener to the "static:script.init" client-side hook instead');

--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -52,7 +52,9 @@ ajaxify = window.ajaxify || {};
 
 		// If any listeners alter url and set it to an empty string, abort the ajaxification
 		if (url === null) {
-			$(window).trigger('action:ajaxify.end', { url: url, tpl_url: ajaxify.data.template.name, title: ajaxify.data.title });
+			require(['hooks'], function (hooks) {
+				hooks.fire('action:ajaxify.end', { url: url, tpl_url: ajaxify.data.template.name, title: ajaxify.data.title });
+			});
 			return false;
 		}
 
@@ -281,7 +283,9 @@ ajaxify = window.ajaxify || {};
 			window.scrollTo(0, 0);
 		}
 		ajaxify.loadScript(tpl_url, function done() {
-			$(window).trigger('action:ajaxify.end', { url: url, tpl_url: tpl_url, title: ajaxify.data.title });
+			require(['hooks'], function (hooks) {
+				hooks.fire('action:ajaxify.end', { url: url, tpl_url: tpl_url, title: ajaxify.data.title });
+			});
 		});
 		ajaxify.widgets.render(tpl_url);
 

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -55,12 +55,14 @@ app.cacheBuster = null;
 				}
 			};
 			document.body.addEventListener('click', earlyClick);
-			$(window).on('action:ajaxify.end', function () {
-				document.body.removeEventListener('click', earlyClick);
-				earlyQueue.forEach(function (el) {
-					el.click();
+			require(['hooks'], function (hooks) {
+				hooks.on('action:ajaxify.end', function () {
+					document.body.removeEventListener('click', earlyClick);
+					earlyQueue.forEach(function (el) {
+						el.click();
+					});
+					earlyQueue = [];
 				});
-				earlyQueue = [];
 			});
 		} else {
 			setTimeout(app.handleEarlyClicks, 50);

--- a/public/src/modules/hooks.js
+++ b/public/src/modules/hooks.js
@@ -9,6 +9,7 @@ define('hooks', [], () => {
 		Hooks.loaded[hookName] = Hooks.loaded[hookName] || new Set();
 		Hooks.loaded[hookName].add(listener);
 	};
+	Hooks.on = Hooks.register;
 
 	Hooks.hasListeners = hookName => Hooks.loaded[hookName] && Hooks.loaded[hookName].length > 0;
 
@@ -19,6 +20,9 @@ define('hooks', [], () => {
 
 	const _fireActionHook = (hookName, data) => {
 		Hooks.loaded[hookName].forEach(listener => listener(data));
+
+		// Backwards compatibility (remove this when we eventually remove jQuery from NodeBB core)
+		$(window).trigger(hookName, data);
 	};
 
 	const _fireStaticHook = (hookName, data) => {

--- a/public/src/modules/hooks.js
+++ b/public/src/modules/hooks.js
@@ -11,7 +11,7 @@ define('hooks', [], () => {
 	};
 	Hooks.on = Hooks.register;
 
-	Hooks.hasListeners = hookName => Hooks.loaded[hookName] && Hooks.loaded[hookName].length > 0;
+	Hooks.hasListeners = hookName => Hooks.loaded[hookName] && Hooks.loaded[hookName].size > 0;
 
 	const _onHookError = (e, listener, data) => {
 		console.warn(`[hooks] Exception encountered in ${listener.name ? listener.name : 'anonymous function'}, stack trace follows.`);
@@ -20,6 +20,10 @@ define('hooks', [], () => {
 	};
 
 	const _fireFilterHook = (hookName, data) => {
+		if (!Hooks.hasListeners(hookName)) {
+			return Promise.resolve(data);
+		}
+
 		const listeners = Array.from(Hooks.loaded[hookName]);
 		return listeners.reduce((promise, listener) => promise.then((data) => {
 			try {
@@ -39,6 +43,10 @@ define('hooks', [], () => {
 	};
 
 	const _fireStaticHook = (hookName, data) => {
+		if (!Hooks.hasListeners(hookName)) {
+			return Promise.resolve(data);
+		}
+
 		const listeners = Array.from(Hooks.loaded[hookName]);
 		return Promise.allSettled(listeners.map((listener) => {
 			try {

--- a/public/src/modules/hooks.js
+++ b/public/src/modules/hooks.js
@@ -1,0 +1,45 @@
+'use strict';
+
+define('hooks', [], () => {
+	const Hooks = {
+		loaded: {},
+	};
+
+	Hooks.register = (hookName, listener) => {
+		Hooks.loaded[hookName] = Hooks.loaded[hookName] || new Set();
+		Hooks.loaded[hookName].add(listener);
+	};
+
+	Hooks.hasListeners = hookName => Hooks.loaded[hookName] && Hooks.loaded[hookName].length > 0;
+
+	const _fireFilterHook = (hookName, data) => {
+		const listeners = Array.from(Hooks.loaded[hookName]);
+		return listeners.reduce((promise, listener) => promise.then(data => listener(data)), Promise.resolve(data));
+	};
+
+	const _fireActionHook = (hookName, data) => {
+		Hooks.loaded[hookName].forEach(listener => listener(data));
+	};
+
+	const _fireStaticHook = (hookName, data) => {
+		const listeners = Array.from(Hooks.loaded[hookName]);
+		return Promise.allSettled(listeners.map(listener => listener(data))).then(() => Promise.resolve(data));
+	};
+
+	Hooks.fire = (hookName, data) => {
+		const type = hookName.split(':').shift();
+
+		switch (type) {
+			case 'filter':
+				return _fireFilterHook(hookName, data);
+
+			case 'action':
+				return _fireActionHook(hookName, data);
+
+			case 'static':
+				return _fireStaticHook(hookName, data);
+		}
+	};
+
+	return Hooks;
+});

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -1,6 +1,6 @@
 'use strict';
 
-define('navigator', ['forum/pagination', 'components'], function (pagination, components) {
+define('navigator', ['forum/pagination', 'components', 'hooks'], function (pagination, components, hooks) {
 	var navigator = {};
 	var index = 0;
 	var count = 0;
@@ -142,7 +142,7 @@ define('navigator', ['forum/pagination', 'components'], function (pagination, co
 		}
 
 		var mouseDragging = false;
-		$(window).on('action:ajaxify.end', function () {
+		hooks.on('action:ajaxify.end', function () {
 			renderPostIndex = null;
 		});
 		$('.pagination-block .dropdown-menu').parent().on('shown.bs.dropdown', function () {

--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -312,7 +312,7 @@ async function getBundleScriptList(target) {
 
 	let scripts = JS.scripts.base;
 
-	if (target === 'client' && process.env.NODE_ENV !== 'development') {
+	if (target === 'client') {
 		scripts = scripts.concat(JS.scripts.rjs);
 	} else if (target === 'acp') {
 		scripts = scripts.concat(JS.scripts.admin);

--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -64,6 +64,7 @@ JS.scripts = {
 
 		'public/src/modules/translator.js',
 		'public/src/modules/components.js',
+		'public/src/modules/hooks.js',
 		'public/src/modules/sort.js',
 		'public/src/modules/navigator.js',
 		'public/src/modules/topicSelect.js',


### PR DESCRIPTION
Up until now we've been piggybacking off of jQuery's `$(window).on()/.trigger()` as sort of a poor man's hook system.

We _may_ eventually want to remove jQuery, and it makes sense to write a system utilising Promises so we can also fix issues where we hand-roll bespoke async handler logic.

This PR adds a new "hooks" client-side module that allows you to register and fire hooks just like we can on the server-side.

Example hook registration:

``` js
require(['hooks'], (hooks) => {
  hooks.register('filter:foo.bar', (data) => {
    return Promise.resolve(data + 1);
  });
});
```

Example hook fire:

``` js
require(['hooks'], (hooks) => {
  hooks.fire('filter:foo.bar', 5).then((value) => {
    console.log(value);  // 6
  });
});
```
