### PR TITLE
fix: #9127, scope service worker to relative_path for the forum

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -788,7 +788,7 @@ app.cacheBuster = null;
 
 	function registerServiceWorker() {
 		if ('serviceWorker' in navigator) {
-			navigator.serviceWorker.register(config.relative_path + '/assets/src/service-worker.js')
+			navigator.serviceWorker.register(config.relative_path + '/assets/src/service-worker.js', { scope: config.relative_path + '/' })
 				.then(function () {
 					console.info('ServiceWorker registration succeeded.');
 				}).catch(function (err) {

--- a/src/routes/meta.js
+++ b/src/routes/meta.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const nconf = require('nconf');
 
 module.exports = function (app, middleware, controllers) {
 	app.get('/sitemap.xml', controllers.sitemap.render);
@@ -11,7 +12,7 @@ module.exports = function (app, middleware, controllers) {
 	app.get('/manifest.webmanifest', controllers.manifest);
 	app.get('/css/previews/:theme', controllers.admin.themes.get);
 	app.get('/osd.xml', controllers.osd.handle);
-	app.get('/service-worker.js', function (req, res) {
-		res.status(200).type('application/javascript').sendFile(path.join(__dirname, '../../public/src/service-worker.js'));
+	app.get('/assets/src/service-worker.js', function (req, res) {
+		res.status(200).type('application/javascript').set('Service-Worker-Allowed', nconf.get('relative_path') + '/').sendFile(path.join(__dirname, '../../public/src/service-worker.js'));
 	});
 };


### PR DESCRIPTION
Adds a `Service-Worker-Allowed` header set to forum url (`nconf.get('relative_path')`) on `assets/src/service-worker.js` URL and uses `scope` option during its registration to ensure the service worker is correctly scoped to the entire forum and only the forum.

This is the implementation of what I described in https://github.com/NodeBB/NodeBB/issues/9127#issuecomment-765807348 - sorry it took so long, had some other stuff to do and I was actually kinda afraid I'll waste my time as someone will do it a bit faster than me (well, I had it happen here once with a pretty simple fix that I wasn't fast enough to make into a PR before one of the maintainers managed it and here I basically described all changes :)

Should fix #9127 and this issue was also mentioned in #9193. I found it [thanks to this thread on the community forum](https://community.nodebb.org/topic/8497/is-there-any-mobile-client-for-nodebb/15)

I can confirm that Chrome now asks user to install the page (on the desktop it's in the right part of the address bar) with these changes, when it didn't do so before. Haven't tested with other/mobile browsers though, but I'd be very surprised if it was different.