### PR TITLE
fix: do not overwrite `config.port` from URL, if it's already set

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -175,7 +175,7 @@ async function completeConfigSetup(config) {
 		config.url = `http://${config.url}`;
 	}
 	const urlObj = url.parse(config.url);
-	if (urlObj.port) {
+	if (urlObj.port && (!install.values || !install.values.hasOwnProperty('port'))) {
 		config.port = urlObj.port;
 	}
 


### PR DESCRIPTION
If URL was set to something like `http://example.com:8080`, and port
was set to 4567, keep listening on port 4567 and keep linking through
URL that was specified.
This allows to listen on port 4567, while having NGINX (or any proxy)
set to listen on port 8080 and route traffic to port 4567.
So NodeBB can be "hidden" behind proxy while URL can still contain
non-standard port, i.e., port different than 80 and 443.