### PR TITLE
fix: `action:plugins.firehook` sends params prior to filter, even though it is fired afterwards

### DIFF
--- a/src/plugins/hooks.js
+++ b/src/plugins/hooks.js
@@ -96,13 +96,14 @@ Hooks.fire = async function (hook, params) {
 		winston.warn(`[plugins] Unknown hookType: ${hookType}, hook : ${hook}`);
 		return;
 	}
-	const result = await hookTypeToMethod[hookType](hook, hookList, params);
+
+	params = await hookTypeToMethod[hookType](hook, hookList, params);
 
 	if (hook !== 'action:plugins.firehook') {
 		Hooks.fire('action:plugins.firehook', { hook: hook, params: params });
 	}
-	if (result !== undefined) {
-		return result;
+	if (params !== undefined) {
+		return params;
 	}
 };
 


### PR DESCRIPTION
…ugh it is fired afterwards