### PR TITLE
fix: disallow editing of other users' notes

### DIFF
--- a/src/socket.io/flags.js
+++ b/src/socket.io/flags.js
@@ -57,7 +57,7 @@ SocketFlags.appendNote = async function (socket, data) {
   	if (data.datetime && data.flagId) {
     		const note = await flags.getNote(data.flagId, data.datetime);
 		if (note.uid !== socket.uid) {
-  			throw new Error('[[error:no-privileges]]'));
+  			throw new Error('[[error:no-privileges]]');
 		}
 	}
 	

--- a/src/socket.io/flags.js
+++ b/src/socket.io/flags.js
@@ -59,7 +59,7 @@ SocketFlags.appendNote = async function (socket, data) {
 		if (note.uid !== socket.uid) {
   			throw new Error('[[error:no-privileges]]'));
 		}
-	  }
+	}
 	
 	await flags.appendNote(data.flagId, socket.uid, data.note, data.datetime);
 

--- a/src/socket.io/flags.js
+++ b/src/socket.io/flags.js
@@ -48,21 +48,17 @@ SocketFlags.appendNote = async function (socket, data) {
 	if (!data || !(data.flagId && data.note)) {
 		throw new Error('[[error:invalid-data]]');
 	}
-
 	const allowed = await user.isPrivileged(socket.uid);
 	if (!allowed) {
 		throw new Error('[[error:no-privileges]]');
 	}
-	
-  	if (data.datetime && data.flagId) {
-    		const note = await flags.getNote(data.flagId, data.datetime);
+	if (data.datetime && data.flagId) {
+		const note = await flags.getNote(data.flagId, data.datetime);
 		if (note.uid !== socket.uid) {
-  			throw new Error('[[error:no-privileges]]');
+			throw new Error('[[error:no-privileges]]');
 		}
 	}
-	
 	await flags.appendNote(data.flagId, socket.uid, data.note, data.datetime);
-
 	const [notes, history] = await Promise.all([
 		flags.getNotes(data.flagId),
 		flags.getHistory(data.flagId),

--- a/src/socket.io/flags.js
+++ b/src/socket.io/flags.js
@@ -51,8 +51,16 @@ SocketFlags.appendNote = async function (socket, data) {
 
 	const allowed = await user.isPrivileged(socket.uid);
 	if (!allowed) {
-		throw new Error('[[no-privileges]]');
+		throw new Error('[[error:no-privileges]]');
 	}
+	
+  	if (data.datetime && data.flagId) {
+    		const note = await flags.getNote(data.flagId, data.datetime);
+		if (note.uid !== socket.uid) {
+  			throw new Error('[[error:no-privileges]]'));
+		}
+	  }
+	
 	await flags.appendNote(data.flagId, socket.uid, data.note, data.datetime);
 
 	const [notes, history] = await Promise.all([


### PR DESCRIPTION
Feel free to close this if it is intentional, but as you are not allowed to delete other users notes I expect you shouldn't be able to edit them. Editing another users post also changes ownership, allowing you to then delete it.

I also added `error:` to the errormessage so that they display properly.