### PR TITLE
fix: Post Queue for moderators in category

### DIFF
--- a/src/controllers/mods.js
+++ b/src/controllers/mods.js
@@ -165,13 +165,13 @@ modsController.postQueue = async function (req, res, next) {
 		helpers.getSelectedCategory(cid),
 	]);
 
-	if (cid && !moderatedCids.includes(String(cid)) && !isAdminOrGlobalMod) {
+	if (cid && !moderatedCids.includes(Number(cid)) && !isAdminOrGlobalMod) {
 		return next();
 	}
 
 	postData = postData.filter(p => p &&
 		(!categoriesData.selectedCids.length || categoriesData.selectedCids.includes(p.category.cid)) &&
-		(isAdminOrGlobalMod || moderatedCids.includes(String(p.category.cid))));
+		(isAdminOrGlobalMod || moderatedCids.includes(Number(p.category.cid))));
 
 	({ posts: postData } = await plugins.hooks.fire('filter:post-queue.get', {
 		posts: postData,


### PR DESCRIPTION
**Problem**:
- Moderators doesn't see the posts in a posts queue

**Cause**:
- `user.getModeratedCids` returns the array of numbers (we use `parseInt` in `Categories.getAllCidsFromSet`)
- In `postQueue` controller we check cids via `moderatedCids.includes(String(...))` instead of `Number`