### PR TITLE
Translate language keys in API v3 responses

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -230,5 +230,16 @@
 	"topic-event-unrecognized": "Topic event '%1' unrecognized",
 
 	"cant-set-child-as-parent": "Can't set child as parent category",
-	"cant-set-self-as-parent": "Can't set self as parent category"
+	"cant-set-self-as-parent": "Can't set self as parent category",
+
+	"api.master-token-no-uid": "A master token was received without a corresponding `_uid` in the request body",
+	"api.400": "Something was wrong with the request payload you passed in.",
+	"api.401": "A valid login session was not found. Please log in and try again.",
+	"api.403": "You are not authorised to make this call",
+	"api.404": "Invalid API call",
+	"api.426": "HTTPS is required for requests to the write api, please re-send your request via HTTPS",
+	"api.429": "You have made too many requests, please try again later",
+	"api.500": "An unexpected error was encountered while attempting to service your request.",
+	"api.501": "The route you are trying to call is not implemented yet, please try again tomorrow",
+	"api.503": "The route you are trying to call is not currently available due to a server configuration"
 }

--- a/src/controllers/errors.js
+++ b/src/controllers/errors.js
@@ -3,6 +3,7 @@
 const nconf = require('nconf');
 const winston = require('winston');
 const validator = require('validator');
+const translator = require('../translator');
 const plugins = require('../plugins');
 const middleware = require('../middleware');
 const middlewareHelpers = require('../middleware/helpers');
@@ -57,7 +58,12 @@ exports.handleErrors = function handleErrors(err, req, res, next) { // eslint-di
 		const path = String(req.path || '');
 
 		if (path.startsWith(`${nconf.get('relative_path')}/api/v3`)) {
-			return helpers.formatApiResponse(err.message.startsWith('[[') ? 400 : 500, res, err);
+			let status = 500;
+			if (err.message.startsWith('[[')) {
+				status = 400;
+				err.message = await translator.translate(err.message);
+			}
+			return helpers.formatApiResponse(status, res, err);
 		}
 
 		winston.error(`${req.path}\n${err.stack}`);

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -493,6 +493,10 @@ async function generateBannedResponse(res) {
 }
 
 helpers.generateError = async (statusCode, message) => {
+	if (message && message.startsWith('[[')) {
+		message = await translator.translate(message);
+	}
+
 	const payload = {
 		status: {
 			code: 'internal-server-error',

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -6,6 +6,7 @@ const validator = require('validator');
 const querystring = require('querystring');
 const _ = require('lodash');
 
+const translator = require('../translator');
 const user = require('../user');
 const privileges = require('../privileges');
 const categories = require('../categories');
@@ -456,7 +457,7 @@ helpers.formatApiResponse = async (statusCode, res, payload) => {
 				break;
 		}
 
-		const returnPayload = helpers.generateError(statusCode, message);
+		const returnPayload = await helpers.generateError(statusCode, message);
 		returnPayload.response = response;
 
 		if (global.env === 'development') {
@@ -467,7 +468,8 @@ helpers.formatApiResponse = async (statusCode, res, payload) => {
 		res.status(statusCode).json(returnPayload);
 	} else if (!payload) {
 		// Non-2xx statusCode, generate predefined error
-		res.status(statusCode).json(helpers.generateError(statusCode));
+		const returnPayload = await helpers.generateError(statusCode);
+		res.status(statusCode).json(returnPayload);
 	}
 };
 
@@ -490,60 +492,50 @@ async function generateBannedResponse(res) {
 	return response;
 }
 
-helpers.generateError = (statusCode, message) => {
+helpers.generateError = async (statusCode, message) => {
 	const payload = {
 		status: {
 			code: 'internal-server-error',
-			message: 'An unexpected error was encountered while attempting to service your request.',
+			message: message || await translator.translate(`[[error:api.${statusCode}]]`),
 		},
 		response: {},
 	};
 
-	// Need to turn all these into translation strings
 	switch (statusCode) {
 		case 400:
 			payload.status.code = 'bad-request';
-			payload.status.message = message || 'Something was wrong with the request payload you passed in.';
 			break;
 
 		case 401:
 			payload.status.code = 'not-authorised';
-			payload.status.message = message || 'A valid login session was not found. Please log in and try again.';
 			break;
 
 		case 403:
 			payload.status.code = 'forbidden';
-			payload.status.message = message || 'You are not authorised to make this call';
 			break;
 
 		case 404:
 			payload.status.code = 'not-found';
-			payload.status.message = message || 'Invalid API call';
 			break;
 
 		case 426:
 			payload.status.code = 'upgrade-required';
-			payload.status.message = message || 'HTTPS is required for requests to the write api, please re-send your request via HTTPS';
 			break;
 
 		case 429:
 			payload.status.code = 'too-many-requests';
-			payload.status.message = message || 'You have made too many requests, please try again later';
 			break;
 
 		case 500:
 			payload.status.code = 'internal-server-error';
-			payload.status.message = message || payload.status.message;
 			break;
 
 		case 501:
 			payload.status.code = 'not-implemented';
-			payload.status.message = message || 'The route you are trying to call is not implemented yet, please try again tomorrow';
 			break;
 
 		case 503:
 			payload.status.code = 'service-unavailable';
-			payload.status.message = message || 'The route you are trying to call is not currently available due to a server configuration';
 			break;
 	}
 

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -65,7 +65,7 @@ module.exports = function (middleware) {
 					return true;
 				}
 
-				throw new Error('A master token was received without a corresponding `_uid` in the request body');
+				throw new Error('[[errors:api.master-token-no-uid]]');
 			} else {
 				winston.warn('[api/authenticate] Unable to find user after verifying token');
 				return true;
@@ -84,6 +84,7 @@ module.exports = function (middleware) {
 		return !res.headersSent;
 	}
 
+	// TODO: Remove in v1.18.0
 	middleware.authenticate = helpers.try(async (req, res, next) => {
 		winston.warn(`[middleware] middleware.authenticate has been deprecated, page and API routes are now automatically authenticated via setup(Page|API)Route. Use middleware.authenticateRequest (if not using route helper) and middleware.ensureLoggedIn instead. (request path: ${req.path})`);
 		if (!await authenticate(req, res)) {

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -65,7 +65,7 @@ module.exports = function (middleware) {
 					return true;
 				}
 
-				throw new Error('[[errors:api.master-token-no-uid]]');
+				throw new Error('[[error:api.master-token-no-uid]]');
 			} else {
 				winston.warn('[api/authenticate] Unable to find user after verifying token');
 				return true;

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -825,7 +825,7 @@ describe('Controllers', () => {
 				assert.deepStrictEqual(parsedResponse.response, {});
 				assert.deepStrictEqual(parsedResponse.status, {
 					code: 'not-found',
-					message: '[[error:no-user]]',
+					message: 'User does not exist',
 				});
 				done();
 			});

--- a/test/topicThumbs.js
+++ b/test/topicThumbs.js
@@ -350,7 +350,7 @@ describe('Topic thumbs', () => {
 				assert.ifError(err);
 				assert.strictEqual(res.statusCode, 503);
 				assert(body && body.status);
-				assert.strictEqual(body.status.message, '[[error:topic-thumbnails-are-disabled]]');
+				assert.strictEqual(body.status.message, 'Topic thumbnails are disabled.');
 				done();
 			});
 		});
@@ -362,7 +362,7 @@ describe('Topic thumbs', () => {
 				assert.ifError(err);
 				assert.strictEqual(res.statusCode, 500);
 				assert(body && body.status);
-				assert.strictEqual(body.status.message, '[[error:invalid-file]]');
+				assert.strictEqual(body.status.message, 'Invalid File');
 				done();
 			});
 		});

--- a/test/topics.js
+++ b/test/topics.js
@@ -139,7 +139,7 @@ describe('Topic\'s', () => {
 				},
 				json: true,
 			});
-			assert.strictEqual(result.body.status.message, '[[error:no-privileges]]');
+			assert.strictEqual(result.body.status.message, 'You do not have enough privileges for this action.');
 		});
 
 		it('should post a topic as guest if guest group has privileges', async () => {

--- a/test/user.js
+++ b/test/user.js
@@ -2123,14 +2123,14 @@ describe('User', () => {
 			it('should error if user does not have invite privilege', async () => {
 				const { res } = await helpers.invite({ emails: 'invite1@test.com', groupsToJoin: [] }, notAnInviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, '[[error:no-privileges]]');
+				assert.strictEqual(res.body.status.message, 'You do not have enough privileges for this action.');
 			});
 
 			it('should error out if user tries to use an inviter\'s uid via the API', async () => {
 				const { res } = await helpers.invite({ emails: 'invite1@test.com', groupsToJoin: [] }, inviterUid, jar, csrf_token);
 				const numInvites = await User.getInvitesNumber(inviterUid);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, '[[error:no-privileges]]');
+				assert.strictEqual(res.body.status.message, 'You do not have enough privileges for this action.');
 				assert.strictEqual(numInvites, 0);
 			});
 		});
@@ -2159,14 +2159,14 @@ describe('User', () => {
 			it('should error with invalid data', async () => {
 				const { res } = await helpers.invite({}, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 400);
-				assert.strictEqual(res.body.status.message, '[[error:invalid-data]]');
+				assert.strictEqual(res.body.status.message, 'Invalid Data');
 			});
 
 			it('should error if user is not admin and type is admin-invite-only', async () => {
 				meta.config.registrationType = 'admin-invite-only';
 				const { res } = await helpers.invite({ emails: 'invite1@test.com', groupsToJoin: [] }, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, '[[error:no-privileges]]');
+				assert.strictEqual(res.body.status.message, 'You do not have enough privileges for this action.');
 			});
 
 			it('should send invitation email (without groups to be joined)', async () => {
@@ -2183,13 +2183,13 @@ describe('User', () => {
 			it('should error if the user has not permission to invite to the group', async () => {
 				const { res } = await helpers.invite({ emails: 'invite4@test.com', groupsToJoin: [PRIVATE_GROUP] }, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, '[[error:no-privileges]]');
+				assert.strictEqual(res.body.status.message, 'You do not have enough privileges for this action.');
 			});
 
 			it('should error if a non-admin tries to invite to the administrators group', async () => {
 				const { res } = await helpers.invite({ emails: 'invite4@test.com', groupsToJoin: ['administrators'] }, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, '[[error:no-privileges]]');
+				assert.strictEqual(res.body.status.message, 'You do not have enough privileges for this action.');
 			});
 
 			it('should to invite to own private group', async () => {
@@ -2211,7 +2211,7 @@ describe('User', () => {
 				meta.config.maximumInvites = 1;
 				const { res } = await helpers.invite({ emails: 'invite6@test.com', groupsToJoin: [] }, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, `[[error:invite-maximum-met, ${5}, ${1}]]`);
+				assert.strictEqual(res.body.status.message, `You have invited the maximum amount of people (${5} out of ${1}).`);
 				meta.config.maximumInvites = 10;
 			});
 
@@ -2224,14 +2224,14 @@ describe('User', () => {
 				const { res } = await helpers.invite({ emails: 'inviter@nodebb.org', groupsToJoin: [] }, adminUid, jar, csrf_token);
 				const numInvites = await User.getInvitesNumber(adminUid);
 				assert.strictEqual(res.statusCode, 403);
-				assert.strictEqual(res.body.status.message, '[[error:no-privileges]]');
+				assert.strictEqual(res.body.status.message, 'You do not have enough privileges for this action.');
 				assert.strictEqual(numInvites, 0);
 			});
 
 			it('should error if email exists', async () => {
 				const { res } = await helpers.invite({ emails: 'inviter@nodebb.org', groupsToJoin: [] }, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 400);
-				assert.strictEqual(res.body.status.message, '[[error:email-taken]]');
+				assert.strictEqual(res.body.status.message, 'Email taken');
 			});
 		});
 


### PR DESCRIPTION
- fix: return proper API-style response if exception caught by error handler on v3 routes [breaking]
- feat: internationalize API error messages
- fix: translate language keys if passed in to formatApiResponse
