### PR TITLE
Remove some deprecated/unnecessary code

### DIFF
--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -3,12 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const util = require('util');
-let mkdirp = require('mkdirp');
-// TODO: remove in 1.16.0
-if (!mkdirp.hasOwnProperty('native')) {
-	mkdirp = util.promisify(mkdirp);
-}
-
+const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
 
 const rimrafAsync = util.promisify(rimraf);

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -101,7 +101,6 @@ middleware.renderHeader = async function renderHeader(req, res, data) {
 	results.user.isEmailConfirmSent = !!results.isEmailConfirmSent;
 
 	templateValues.bootswatchSkin = (parseInt(meta.config.disableCustomUserSkins, 10) !== 1 ? res.locals.config.bootswatchSkin : '') || meta.config.bootswatchSkin || '';
-	templateValues.config.bootswatchSkin = templateValues.bootswatchSkin || 'noskin';	// TODO remove in v1.12.0+
 	templateValues.browserTitle = results.browserTitle;
 	({
 		navigation: templateValues.navigation,

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const nconf = require('nconf');
 const winston = require('winston');
 const passport = require('passport');
 const util = require('util');
 
-const meta = require('../meta');
 const user = require('../user');
 const privileges = require('../privileges');
 const plugins = require('../plugins');

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const winston = require('winston');
-const nconf = require('nconf');
-
 const helpers = require('./helpers');
 
 const { setupPageRoute } = helpers;

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -48,14 +48,6 @@ module.exports = function (app, name, middleware, controllers) {
 	setupPageRoute(app, `/${name}/:userslug/consent`, middleware, accountMiddlewares, controllers.accounts.consent.get);
 	setupPageRoute(app, `/${name}/:userslug/blocks`, middleware, accountMiddlewares, controllers.accounts.blocks.getBlocks);
 	setupPageRoute(app, `/${name}/:userslug/sessions`, middleware, accountMiddlewares, controllers.accounts.sessions.get);
-	app.delete('/api/user/:userslug/session/:uuid', [middleware.exposeUid], (req, res, next) => {
-		// TODO: Remove this entire route in v1.16.0
-		winston.warn('[router] `/api/user/:userslug/session/:uuid` has been deprecated, use `DELETE /api/v3/users/:uid/sessions/:uuid` or `DELETE /api/v3/users/bySlug/:userslug/sessions/:uuid` instead');
-		if (!res.locals.uid) {
-			return next();
-		}
-		res.redirect(`${nconf.get('relative_path')}/api/v3/users/${res.locals.uid}/sessions/${req.params.uuid}`);
-	});
 
 	setupPageRoute(app, '/notifications', middleware, [middleware.ensureLoggedIn], controllers.accounts.notifications.get);
 	setupPageRoute(app, `/${name}/:userslug/chats/:roomid?`, middleware, middlewares, controllers.accounts.chats.get);


### PR DESCRIPTION
I found a `//TODO: remove in 1.16.0` in one file and decided to look for more of this kind of thing - found 4 places in code that comments indicate should've been removed some time ago.

1. `util.promisify` call on `mkdirp` in `src/meta/js.js` (what I originally found) - was supposed to be removed in 1.16, as `mkdirp` was updated to `1.0.0` that supported promises natively.
2. `DELETE /api/user/:userslug/session/:uuid` route - was deprecated in favor of `DELETE /api/v3/users/:uid/sessions/:uuid` and `DELETE /api/v3/users/bySlug/:userslug/sessions/:uuid` and comment indicates it should've been deleted entirely in 1.16.0
3. `middleware.isAdmin` - deprecated in favor of `middleware.admin.checkPrivileges` and supposed to be removed in 1.16.0
4. `templateValues.config.bootswatchSkin` - I'm assuming it was replaced by `templateValues.bootswatchSkin`. Comment says it should've been removed more than 2 years ago in 1.12.0

Edit: also removed unused dependencies in two files since eslint was failing because of them.