### PR TITLE
Fix [MONGODB DRIVER] `remove` has been deprecated

### DIFF
--- a/src/database/mongo/sorted/remove.js
+++ b/src/database/mongo/sorted/remove.js
@@ -57,7 +57,7 @@ module.exports = function (module) {
 			return;
 		}
 		const bulk = module.client.collection('objects').initializeUnorderedBulkOp();
-		data.forEach(item => bulk.find({ _key: item[0], value: String(item[1]) }).remove());
+		data.forEach(item => bulk.find({ _key: item[0], value: String(item[1]) }).delete());
 		await bulk.execute();
 	};
 };


### PR DESCRIPTION
Fix for [MONGODB DRIVER] Warning: bulk operation `remove` has been deprecated, please use `delete`

I believe this was added in Mongo 2.6 which is the minimum version stated in the NodeBB readme.