### PR TITLE
Loading manifest failed with 404 when deploying basic auth, add cross…

### DIFF
--- a/src/meta/tags.js
+++ b/src/meta/tags.js
@@ -66,6 +66,7 @@ Tags.parse = async (req, data, meta, link) => {
 	}, {
 		rel: 'manifest',
 		href: `${relative_path}/manifest.webmanifest`,
+		crossorigin: `use-credentials`,
 	}];
 
 	if (plugins.hooks.hasListeners('filter:search.query')) {


### PR DESCRIPTION
…origin use-credentials.

See also:
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
https://stackoverflow.com/questions/40985833/is-it-possible-to-load-the-progressive-web-app-manifest-file-from-authenticated

Signed-off-by: corbolais <corbolais@gmail.com>