### PR TITLE
Only show email confirm warning toast on pages that it applies

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -35,7 +35,7 @@
 	"email-taken": "Email taken",
 	"email-nochange": "The email entered is the same as the email already on file.",
 	"email-invited": "Email was already invited",
-	"email-not-confirmed": "You are unable to post until your email is confirmed, please click here to confirm your email.",
+	"email-not-confirmed": "Posting in some categories or topics is enabled once your email is confirmed, please click here to send a confirmation email.",
 	"email-not-confirmed-chat": "You are unable to chat until your email is confirmed, please click here to confirm your email.",
 	"email-not-confirmed-email-sent": "Your email has not been confirmed yet, please check your inbox for the confirmation email. You won't be able to post or chat until your email is confirmed.",
 	"no-email-to-confirm": "Your account does not have an email set. An email is necessary for account recovery. Please click here to enter an email.",

--- a/public/src/app.js
+++ b/public/src/app.js
@@ -774,6 +774,7 @@ app.cacheBuster = null;
 				app.removeAlert('email_confirm');
 				ajaxify.go('user/' + app.user.userslug + '/edit/email');
 			};
+			app.alert(msg);
 		} else if (!app.user['email:confirmed'] && !app.user.isEmailConfirmSent) {
 			msg.message = err ? err.message : '[[error:email-not-confirmed]]';
 			msg.clickfn = function () {
@@ -785,11 +786,11 @@ app.cacheBuster = null;
 					app.alertSuccess('[[notifications:email-confirm-sent]]');
 				});
 			};
+			app.alert(msg);
 		} else if (!app.user['email:confirmed'] && app.user.isEmailConfirmSent) {
 			msg.message = '[[error:email-not-confirmed-email-sent]]';
+			app.alert(msg);
 		}
-
-		app.alert(msg);
 	};
 
 	app.parseAndTranslate = function (template, blockName, data, callback) {

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -48,6 +48,8 @@ define('forum/category', [
 			},
 		});
 
+		app.showEmailConfirmWarning();
+
 		hooks.fire('action:topics.loaded', { topics: ajaxify.data.topics });
 		hooks.fire('action:category.loaded', { cid: ajaxify.data.cid });
 	};

--- a/public/src/client/recent.js
+++ b/public/src/client/recent.js
@@ -7,6 +7,7 @@ define('forum/recent', ['topicList'], function (topicList) {
 		app.enterRoom('recent_topics');
 
 		topicList.init('recent');
+		app.showEmailConfirmWarning();
 	};
 
 	return Recent;

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -74,6 +74,7 @@ define('forum/topic', [
 		$(window).on('scroll', updateTopicTitle);
 
 		handleTopicSearch();
+		app.showEmailConfirmWarning();
 
 		hooks.fire('action:topic.loaded', ajaxify.data);
 	};


### PR DESCRIPTION
- fix: updated email confirm warning to be more positive
- fix: only show email confirmation warning toast on pages that it applies
