### PR TITLE
feat: allow picture in update user account api call

### DIFF
--- a/public/openapi/write/users/uid.yaml
+++ b/public/openapi/write/users/uid.yaml
@@ -109,6 +109,10 @@ put:
                 This is a paragraph all about how my life got twist-turned upside-down
                 and I'd like to take a minute and sit right here,
                 to tell you all about how I because the administrator of NodeBB
+            picture:
+              type: string
+              description: A URL pointing to a picture to be used as the user's avatar. Maximum length is 255 characters.
+              example: https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80
   responses:
     '200':
       description: user profile updated

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -17,7 +17,7 @@ module.exports = function (User) {
 	User.updateProfile = async function (uid, data, extraFields) {
 		let fields = [
 			'username', 'email', 'fullname', 'website', 'location',
-			'groupTitle', 'birthday', 'signature', 'aboutme',
+			'groupTitle', 'birthday', 'signature', 'aboutme', 'picture'
 		];
 		if (Array.isArray(extraFields)) {
 			fields = _.uniq(fields.concat(extraFields));
@@ -76,6 +76,7 @@ module.exports = function (User) {
 		await isWebsiteValid(callerUid, data);
 		await isAboutMeValid(callerUid, data);
 		await isSignatureValid(callerUid, data);
+		await isPictureValid(callerUid, data);
 		isFullnameValid(data);
 		isLocationValid(data);
 		isBirthdayValid(data);
@@ -175,6 +176,16 @@ module.exports = function (User) {
 			throw new Error(`[[error:signature-too-long, ${meta.config.maximumSignatureLength}]]`);
 		}
 		await User.checkMinReputation(callerUid, data.uid, 'min:rep:signature');
+	}
+
+	async function isPictureValid(callerUid, data) {
+		if (!data.picture) {
+			return;
+		}
+		if (data.picture.length > 255) {
+			throw new Error('[[error:invalid-picture]]');
+		}
+		await User.checkMinReputation(callerUid, data.uid, 'min:rep:profile-picture');
 	}
 
 	function isFullnameValid(data) {


### PR DESCRIPTION
Hi NodeBB team

A little change to the https://docs.nodebb.org/api/write/#tag/users/paths/~1users~1{uid}/put api call. This commit allows you to pass 'picture' to the request body.

I tested this change as a patch to v1.17.1. I changed picture with api call, then refreshing user profile on nodebb showed updated picture.

Little backstory: We were previously changing user avatar with the session-sharing plugin, but it doesn't work when you edit your profile from mobile app and then go to community from pc. Old session-sharing cookie even reverses your new changes. I decided to use session-sharing for login purposes only. Editing profile will be done with api calls. So I need to update picture with api too.

I did not test this with latest HEAD and I did not test to generate documentation.

Thanks,
Tomas