### PR TITLE
fix: Docker - remove tagging by sha

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,
             type=raw,value=latest
 
       - name: Build and push Docker images


### PR DESCRIPTION
Done:
- Removed SHA-based tag generation

TBD:
- Remove SHA-tags from [docker tags](https://hub.docker.com/r/nodebb/docker/tags?page=1&ordering=last_updated&name=sha) (cc @julianlam)