### PR TITLE
fix: privileges added by plugins

### DIFF
--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -71,16 +71,19 @@ categoriesAPI.setPrivilege = async (caller, data) => {
 		throw new Error('[[error:invalid-data]]');
 	}
 	if (parseInt(data.cid, 10) === 0) {
-		const adminPrivs = privs.filter(priv => privileges.admin.privilegeList.includes(priv));
-		const globalPrivs = privs.filter(priv => privileges.global.privilegeList.includes(priv));
+		const adminPrivList = await privileges.admin.getPrivilegeList();
+		const adminPrivs = privs.filter(priv => adminPrivList.includes(priv));
 		if (adminPrivs.length) {
 			await privileges.admin[type](adminPrivs, data.member);
 		}
+		const globalPrivList = await privileges.global.getPrivilegeList();
+		const globalPrivs = privs.filter(priv => globalPrivList.includes(priv));
 		if (globalPrivs.length) {
 			await privileges.global[type](globalPrivs, data.member);
 		}
 	} else {
-		const categoryPrivs = privs.filter(priv => privileges.categories.privilegeList.includes(priv));
+		const categoryPrivList = await privileges.categories.getPrivilegeList();
+		const categoryPrivs = privs.filter(priv => categoryPrivList.includes(priv));
 		await privileges.categories[type](categoryPrivs, data.cid, data.member);
 	}
 

--- a/src/categories/create.js
+++ b/src/categories/create.js
@@ -203,9 +203,10 @@ module.exports = function (Categories) {
 		group = group || '';
 		let privsToCopy;
 		if (group) {
-			privsToCopy = privileges.categories.groupPrivilegeList.slice(...filter);
+			const groupPrivilegeList = await privileges.categories.getGroupPrivilegeList();
+			privsToCopy = groupPrivilegeList.slice(...filter);
 		} else {
-			const privs = privileges.categories.privilegeList.slice();
+			const privs = await privileges.categories.getPrivilegeList();
 			const halfIdx = privs.length / 2;
 			privsToCopy = privs.slice(0, halfIdx).slice(...filter).concat(privs.slice(halfIdx).slice(...filter));
 		}

--- a/src/categories/delete.js
+++ b/src/categories/delete.js
@@ -48,7 +48,8 @@ module.exports = function (Categories) {
 			`cid:${cid}:tag:whitelist`,
 			`category:${cid}`,
 		]);
-		await groups.destroy(privileges.categories.privilegeList.map(privilege => `cid:${cid}:privileges:${privilege}`));
+		const privilegeList = await privileges.categories.getPrivilegeList();
+		await groups.destroy(privilegeList.map(privilege => `cid:${cid}:privileges:${privilege}`));
 	}
 
 	async function removeFromParent(cid) {

--- a/src/controllers/admin/admins-mods.js
+++ b/src/controllers/admin/admins-mods.js
@@ -19,10 +19,11 @@ AdminsMods.get = async function (req, res, next) {
 	if (!selectedCategory) {
 		return next();
 	}
-	const [admins, globalMods, moderators] = await Promise.all([
+	const [admins, globalMods, moderators, categoryPrivList] = await Promise.all([
 		groups.get('administrators', { uid: req.uid }),
 		groups.get('Global Moderators', { uid: req.uid }),
 		getModeratorsOfCategories(selectedCategory),
+		privileges.categories.getUserPrivilegeList(),
 	]);
 
 	res.render('admin/manage/admins-mods', {
@@ -30,7 +31,7 @@ AdminsMods.get = async function (req, res, next) {
 		globalMods: globalMods,
 		categoryMods: [moderators],
 		selectedCategory: selectedCategory,
-		allPrivileges: privileges.categories.userPrivilegeList,
+		allPrivileges: categoryPrivList,
 	});
 };
 

--- a/src/privileges/admin.js
+++ b/src/privileges/admin.js
@@ -216,6 +216,6 @@ privsAdmin.userPrivileges = async function (uid) {
 };
 
 privsAdmin.groupPrivileges = async function (groupName) {
-	const groupPrivilegeList = await privsAdmin.groupPrivilegeList();
+	const groupPrivilegeList = await privsAdmin.getGroupPrivilegeList();
 	return await helpers.userOrGroupPrivileges(0, groupName, groupPrivilegeList);
 };

--- a/src/privileges/admin.js
+++ b/src/privileges/admin.js
@@ -37,6 +37,16 @@ privsAdmin.groupPrivilegeList = privsAdmin.userPrivilegeList.map(privilege => `g
 
 privsAdmin.privilegeList = privsAdmin.userPrivilegeList.concat(privsAdmin.groupPrivilegeList);
 
+privsAdmin.getUserPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.admin.list', privsAdmin.userPrivilegeList.slice());
+privsAdmin.getGroupPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.admin.groups.list', privsAdmin.groupPrivilegeList.slice());
+privsAdmin.getPrivilegeList = async () => {
+	const [user, group] = await Promise.all([
+		privsAdmin.getUserPrivilegeList(),
+		privsAdmin.getGroupPrivilegeList(),
+	]);
+	return user.concat(group);
+};
+
 // Mapping for a page route (via direct match or regexp) to a privilege
 privsAdmin.routeMap = {
 	dashboard: 'admin:dashboard',
@@ -159,13 +169,14 @@ privsAdmin.list = async function (uid) {
 };
 
 privsAdmin.get = async function (uid) {
+	const userPrivilegeList = await privsAdmin.getUserPrivilegeList();
 	const [userPrivileges, isAdministrator] = await Promise.all([
-		helpers.isAllowedTo(privsAdmin.userPrivilegeList, uid, 0),
+		helpers.isAllowedTo(userPrivilegeList, uid, 0),
 		user.isAdministrator(uid),
 	]);
 
 	const combined = userPrivileges.map(allowed => allowed || isAdministrator);
-	const privData = _.zipObject(privsAdmin.userPrivilegeList, combined);
+	const privData = _.zipObject(userPrivilegeList, combined);
 
 	privData.superadmin = isAdministrator;
 	return await plugins.hooks.fire('filter:privileges.admin.get', privData);
@@ -200,9 +211,11 @@ privsAdmin.rescind = async function (privileges, groupName) {
 };
 
 privsAdmin.userPrivileges = async function (uid) {
-	return await helpers.userOrGroupPrivileges(0, uid, privsAdmin.userPrivilegeList);
+	const userPrivilegeList = await privsAdmin.getUserPrivilegeList();
+	return await helpers.userOrGroupPrivileges(0, uid, userPrivilegeList);
 };
 
 privsAdmin.groupPrivileges = async function (groupName) {
-	return await helpers.userOrGroupPrivileges(0, groupName, privsAdmin.groupPrivilegeList);
+	const groupPrivilegeList = await privsAdmin.groupPrivilegeList();
+	return await helpers.userOrGroupPrivileges(0, groupName, groupPrivilegeList);
 };

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -54,6 +54,16 @@ privsCategories.groupPrivilegeList = privsCategories.userPrivilegeList.map(privi
 
 privsCategories.privilegeList = privsCategories.userPrivilegeList.concat(privsCategories.groupPrivilegeList);
 
+privsCategories.getUserPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.list', privsCategories.userPrivilegeList.slice());
+privsCategories.getGroupPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.groups.list', privsCategories.groupPrivilegeList.slice());
+privsCategories.getPrivilegeList = async () => {
+	const [user, group] = await Promise.all([
+		privsCategories.getUserPrivilegeList(),
+		privsCategories.getGroupPrivilegeList(),
+	]);
+	return user.concat(group);
+};
+
 // Method used in admin/category controller to show all users/groups with privs in that given cid
 privsCategories.list = async function (cid) {
 	const labels = await utils.promiseParallel({
@@ -210,9 +220,11 @@ privsCategories.canMoveAllTopics = async function (currentCid, targetCid, uid) {
 };
 
 privsCategories.userPrivileges = async function (cid, uid) {
-	return await helpers.userOrGroupPrivileges(cid, uid, privsCategories.userPrivilegeList);
+	const userPrivilegeList = await privsCategories.getUserPrivilegeList();
+	return await helpers.userOrGroupPrivileges(cid, uid, userPrivilegeList);
 };
 
 privsCategories.groupPrivileges = async function (cid, groupName) {
-	return await helpers.userOrGroupPrivileges(cid, groupName, privsCategories.groupPrivilegeList);
+	const groupPrivilegeList = await privsCategories.getGroupPrivilegeList();
+	return await helpers.userOrGroupPrivileges(cid, groupName, groupPrivilegeList);
 };

--- a/src/privileges/global.js
+++ b/src/privileges/global.js
@@ -138,6 +138,6 @@ privsGlobal.userPrivileges = async function (uid) {
 };
 
 privsGlobal.groupPrivileges = async function (groupName) {
-	const groupPrivilegeList = await privsGlobal.groupPrivilegeList();
+	const groupPrivilegeList = await privsGlobal.getGroupPrivilegeList();
 	return await helpers.userOrGroupPrivileges(0, groupName, groupPrivilegeList);
 };


### PR DESCRIPTION
when copying a categories privileges, privileges added by plugins will be copied as well
when purging a category privileges added by plugins will be purged as well
show plugin privileges in privileges.<categories/admin/global>.get
show plugin privileges in privileges.<categories/admin/global>.userPrivileges
show plugin privileges in privileges.<categories/admin/global>.groupPrivileges