### PR TITLE
fix: handle undefined returnTo on registerAbort

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -220,7 +220,7 @@ authenticationController.registerAbort = function (req, res) {
 	if (req.uid) {
 		// Clear interstitial data and continue on...
 		delete req.session.registration;
-		res.redirect(nconf.get('relative_path') + req.session.returnTo);
+		res.redirect(nconf.get('relative_path') + (req.session.returnTo || '/'));
 	} else {
 		// End the session and redirect to home
 		req.session.destroy(() => {


### PR DESCRIPTION
A falsy returnTo handled in other places, but not in registerAbort method. Users end up at "/register/undefined" if req.session.returnTo missed out.