### PR TITLE
Fix 'TypeError [ERR_INVALID_ARG_TYPE]' issue when pass 'Data' argumen…

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -226,7 +226,7 @@ fs.open(path.join(__dirname, 'config.json'), 'r', function (err) {
 				cwd: process.cwd(),
 			});
 
-			fs.writeFileSync(pidFilePath, process.pid);
+			fs.writeFileSync(pidFilePath, parseInt(process.pid, 10).toString());
 		}
 
 		async.series([


### PR DESCRIPTION
…t as Number to fs.writeFileSync method But need a string instead