### PR TITLE
readding socket.io mongodb adapter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -160,7 +160,7 @@ jobs:
           CI: >-
             {
               "host": "127.0.0.1",
-              "port": 27017,
+              "port": 27018,
               "database": "ci_test",
               "username": "ci_test",
               "password": "nodebb"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [12, 14]
-        database: [mongo-dev, mongo, redis, postgres]
+        database: [mongo-dev, mongo, rs-mongo, redis, postgres]
         include:
           # only run coverage once
           - os: ubuntu-latest
@@ -70,10 +70,32 @@ jobs:
 
       mongo:
         image: 'mongo:3.2'
+        options: >-
+          --health-cmd "mongo --quiet 'localhost/test' --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
         ports:
           # Maps port 27017 on service container to the host
           - 27017:27017
-
+      mongo-rs:
+        image: 'bitnami/mongodb:5.0'
+        ports:
+          # Maps port 27017 on service container to port 27018 of the host
+          - 27018:27017
+        options: >-
+          --health-cmd "mongo -u healthcheck -p healthcheck --quiet 'localhost/test' --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          MONGODB_REPLICA_SET_MODE: primary
+          MONGODB_REPLICA_SET_KEY: nodebb
+          MONGODB_ROOT_PASSWORD: nodebb
+          MONGODB_EXTRA_USERNAMES: nodebb,ci_test,healthcheck
+          MONGODB_EXTRA_PASSWORDS: nodebb,nodebb,healthcheck
+          MONGODB_EXTRA_DATABASES: nodebb,ci_test,test
+      
     steps:
       - uses: actions/checkout@v2
 
@@ -116,7 +138,35 @@ jobs:
             }
         run: |
           node app --setup="${SETUP}" --ci="${CI}"
+      - name: Setup on MongoDB Replica Set
+        if: startsWith(matrix.database, 'rs-mongo')
+        env:
+          SETUP: >-
+            {
+              "url": "http://127.0.0.1:4567",
+              "secret": "abcdef",
+              "admin:username": "admin",
+              "admin:email": "test@example.org",
+              "admin:password": "hAN3Eg8W",
+              "admin:password:confirm": "hAN3Eg8W",
 
+              "database": "mongo",
+              "mongo:host": "127.0.0.1",
+              "mongo:port": 27018,
+              "mongo:username": "nodebb",
+              "mongo:password": "nodebb",
+              "mongo:database": "nodebb"
+            }
+          CI: >-
+            {
+              "host": "127.0.0.1",
+              "port": 27017,
+              "database": "ci_test",
+              "username": "ci_test",
+              "password": "nodebb"
+            }
+        run: |
+          node app --setup="${SETUP}" --ci="${CI}"
       - name: Setup on PostgreSQL
         if: startsWith(matrix.database, 'postgres')
         env:

--- a/install/package.json
+++ b/install/package.json
@@ -81,7 +81,7 @@
         "mongodb": "4.1.3",
         "morgan": "^1.10.0",
         "mousetrap": "^1.6.5",
-        "@nodebb/mubsub": "github:NodeBB/mubsub",
+        "@nodebb/mubsub": "^1.8.0",
         "multiparty": "4.2.2",
         "@nodebb/bootswatch": "3.4.2",
         "nconf": "^0.11.2",

--- a/install/package.json
+++ b/install/package.json
@@ -123,6 +123,7 @@
         "socket.io-adapter-cluster": "^1.0.1",
         "socket.io-client": "4.3.2",
         "@socket.io/redis-adapter": "7.0.0",
+        "@socket.io/mongo-adapter": "0.1.0",
         "sortablejs": "1.14.0",
         "spdx-license-list": "^6.4.0",
         "spider-detector": "2.0.0",

--- a/install/package.json
+++ b/install/package.json
@@ -81,6 +81,7 @@
         "mongodb": "4.1.3",
         "morgan": "^1.10.0",
         "mousetrap": "^1.6.5",
+        "@nodebb/mubsub": "github:NodeBB/mubsub",
         "multiparty": "4.2.2",
         "@nodebb/bootswatch": "3.4.2",
         "nconf": "^0.11.2",

--- a/src/database/mongo/pubsub.js
+++ b/src/database/mongo/pubsub.js
@@ -1,0 +1,11 @@
+'use strict';
+
+
+const mubsub = require('@nodebb/mubsub');
+const connection = require('./connection');
+
+const client = mubsub(connection.getConnectionString(), connection.getConnectionOptions());
+client.on('error', err => console.error(err));
+const channel = client.channel('pubsub');
+channel.on('error', err => console.error(err));
+module.exports = channel;

--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -47,6 +47,8 @@ function get() {
 		pubsub = singleHost;
 	} else if (nconf.get('redis')) {
 		pubsub = require('./database/redis/pubsub');
+	} else if (nconf.get('mongo')) {
+		pubsub = require('./database/mongo/pubsub');
 	} else {
 		throw new Error('[[error:redis-required-for-pubsub]]');
 	}

--- a/src/socket.io/index.js
+++ b/src/socket.io/index.js
@@ -29,8 +29,13 @@ Sockets.init = async function (server) {
 		if (nconf.get('redis')) {
 			const adapter = await require('../database/redis').socketAdapter();
 			io.adapter(adapter);
+		} else if (nconf.get('mongo')) {
+			const adapter = await require('../database/mongo').socketAdapter();
+			if (adapter) {
+				io.adapter(adapter);
+			}
 		} else {
-			winston.warn('clustering detected, you should setup redis!');
+			winston.warn('clustering detected, you should setup redis or a MongoDB replica set!');
 		}
 	}
 


### PR DESCRIPTION
Adds the now official [mongodb adapter for socket.io](https://github.com/socketio/socket.io-mongo-adapter), and some basic code for handling clustering with just mongodb.

Redis is still probably preferred, but [sometimes running it might require additional costs](https://community.nodebb.org/topic/15517/nodebb-mongodb-scaling-k8s) (@Antosik you probably made your setup work already, but if you're still interested in running without Redis it should be possible now), and it seems [people are interested in possibility of running without it](https://community.nodebb.org/topic/16077/multiple-processes-is-redis-required).

Additionally, due to this and #9916 I added current version MongoDB Replica Set tests, but I later realized that there are no tests for clustering. I can remove them or let them stay for the transactions and also just as a way of ensuring things work with rs setups and on current mongo versions.