### PR TITLE
Docker: Allow file based declaration of active modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@ ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
 COPY --chown=node:node install/package.json /usr/src/app/package.json
+COPY --chown=node:node install/launch.sh /usr/src/app/launch.sh
 
 USER node
 
 RUN npm install --only=prod && \
-    npm cache clean --force
+    npm cache clean --force && \
+    touch active_modules
 
 COPY --chown=node:node . /usr/src/app
 
@@ -22,4 +24,4 @@ ENV NODE_ENV=production \
 
 EXPOSE 4567
 
-CMD test -n "${SETUP}" && ./nodebb setup || node ./nodebb build; node ./nodebb start
+CMD ./launch.sh

--- a/install/launch.sh
+++ b/install/launch.sh
@@ -1,0 +1,18 @@
+echo "# [Optional] Install "
+if test -n "${SETUP}"
+then
+  ./nodebb setup
+fi
+
+echo "# Checking required modules from ./active_modules"
+while read -r module; do
+  echo "Installing module $module"
+  npm install "$module"
+  ./nodebb activate $module
+done < ./active_modules
+
+echo "# Building nodebb"
+node ./nodebb build
+
+echo "# Launching application"
+./nodebb start


### PR DESCRIPTION
By default, the file is empty but a user can mount a different file into the container.

In K8s it is unsafe to first run the container and then later on activate modules. This should be done before nodebb is started.
Activating modules for each pod is safe as it is an idempotent operation.