### PR TITLE
feat: ensure that all requests handled by NodeBB fall under the relative_path as configured

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -59,6 +59,19 @@ middleware.ensureLoggedIn = (req, res, next) => {
 	setImmediate(next);
 };
 
+middleware.ensureRelativePath = (req, res, next) => {
+	const prefix = nconf.get('relative_path');
+	if (!prefix) {
+		return setImmediate(next);
+	}
+
+	if (!req.path.startsWith(prefix)) {
+		return controllers.helpers.redirect(res, req.path);
+	}
+
+	return next();
+};
+
 Object.assign(middleware, {
 	admin: require('./admin'),
 	...require('./header'),

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -138,6 +138,8 @@ function setupExpressApp(app) {
 		app.use(compression());
 	}
 
+	app.use(middleware.ensureRelativePath);
+
 	app.get(`${relativePath}/ping`, pingController.ping);
 	app.get(`${relativePath}/sping`, pingController.ping);
 


### PR DESCRIPTION
In some circumstances, a reverse proxy may be set up so that all requests go to NodeBB, even if NodeBB itself is mounted on a subfolder/relative path.

In other cases, direct port access to NodeBB would cause issues if you tried navigating to `/` if a subfolder/relative path is configured.

Either way, the correct course of action should be to automatically redirect that request to the proper URL.﻿
