### PR TITLE
Chats API

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -2,6 +2,7 @@
 	"invalid-data": "Invalid Data",
 	"invalid-json": "Invalid JSON",
 	"array-expected": "A value of type Array was expected for property `%1`, but %2 was received instead",
+	"required-parameters-missing": "Required parameters were missing from this API call: %1",
 
 	"not-logged-in": "You don't seem to be logged in.",
 	"account-locked": "Your account has been locked temporarily",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -171,7 +171,6 @@
 	"invalid-chat-message": "Invalid chat message",
 	"chat-message-too-long": "Chat messages can not be longer than %1 characters.",
 	"cant-edit-chat-message": "You are not allowed to edit this message",
-	"cant-remove-last-user": "You can't remove the last user",
 	"cant-delete-chat-message": "You are not allowed to delete this message",
 	"chat-edit-duration-expired": "You are only allowed to edit chat messages for %1 second(s) after posting",
 	"chat-delete-duration-expired": "You are only allowed to delete chat messages for %1 second(s) after posting",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -13,6 +13,7 @@
 	"invalid-tid": "Invalid Topic ID",
 	"invalid-pid": "Invalid Post ID",
 	"invalid-uid": "Invalid User ID",
+	"invalid-mid": "Invalid Chat Message ID",
 	"invalid-date": "A valid date must be provided",
 
 	"invalid-username": "Invalid Username",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -1,6 +1,7 @@
 {
 	"invalid-data": "Invalid Data",
 	"invalid-json": "Invalid JSON",
+	"array-expected": "A value of type Array was expected for property `%1`, but %2 was received instead",
 
 	"not-logged-in": "You don't seem to be logged in.",
 	"account-locked": "Your account has been locked temporarily",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -1,7 +1,7 @@
 {
 	"invalid-data": "Invalid Data",
 	"invalid-json": "Invalid JSON",
-	"array-expected": "A value of type Array was expected for property `%1`, but %2 was received instead",
+	"wrong-parameter-type": "A value of type %3 was expected for property `%1`, but %2 was received instead",
 	"required-parameters-missing": "Required parameters were missing from this API call: %1",
 
 	"not-logged-in": "You don't seem to be logged in.",

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -5,7 +5,7 @@ RoomObject:
       type: number
       description: the uid of the chat room owner (usually the user who created the room initially)
     roomId:
-      type: string
+      type: number
       description: unique identifier for the chat room
     roomName:
       type: string

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -94,6 +94,44 @@ MessageObject:
       type: boolean
     cleanedContent:
       type: string
+RoomUserList:
+  type: object
+  properties:
+    users:
+      type: array
+      items:
+        type: object
+        properties:
+          uid:
+            type: number
+            description: A user identifier
+          username:
+            type: string
+            description: A friendly name for a given user account
+          picture:
+            nullable: true
+            type: string
+          status:
+            type: string
+          displayname:
+            type: string
+            description: This is either username or fullname depending on forum and user settings
+          icon:text:
+            type: string
+            description: A single-letter representation of a username. This is used in the
+              auto-generated icon given to users
+              without an avatar
+          icon:bgColor:
+            type: string
+            description: A six-character hexadecimal colour code assigned to the user. This
+              value is used in conjunction with
+              `icon:text` for the user's
+              auto-generated icon
+            example: "#f44336"
+          isOwner:
+            type: boolean
+          canKick:
+            type: boolean
 RoomObjectFull:
   # Messaging.loadRoom
   allOf:

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -1,0 +1,14 @@
+RoomObject:
+  type: object
+  properties:
+    owner:
+      type: number
+      description: the uid of the chat room owner (usually the user who created the room initially)
+    roomId:
+      type: string
+      description: unique identifier for the chat room
+    roomName:
+      type: string
+    groupChat:
+      type: boolean
+      description: whether the chat room is a group chat or not

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -12,3 +12,71 @@ RoomObject:
     groupChat:
       type: boolean
       description: whether the chat room is a group chat or not
+MessageObject:
+  type: object
+  properties:
+    content:
+      type: string
+      description: A chat message's content, parsed like a post (so probably outputs html)
+    timestamp:
+      type: number
+    fromuid:
+      type: number
+    roomId:
+      type: number
+    deleted:
+      type: boolean
+    system:
+      type: boolean
+    edited:
+      type: number
+    timestampISO:
+      type: string
+    editedISO:
+      type: string
+    messageId:
+      type: number
+    fromUser:
+      type: object
+      properties:
+        uid:
+          type: number
+          description: A user identifier
+        username:
+          type: string
+          description: A friendly name for a given user account
+          example: Dragon Fruit
+        userslug:
+          type: string
+          description: An URL-safe variant of the username (i.e. lower-cased, spaces removed, etc.)
+          example: dragon-fruit
+        picture:
+          type: string
+          description: A URL pointing to a picture to be used as the user's avatar
+          example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
+        banned:
+          type: boolean
+          description: Whether a user is banned or not
+          example: false
+        displayname:
+          type: string
+          description: This is either username or fullname depending on forum and user settings
+          example: Dragon Fruit
+        icon:text:
+          type: string
+          description: A single-letter representation of a username. This is used in the
+            auto-generated icon given to users
+            without an avatar
+        icon:bgColor:
+          type: string
+          description: A six-character hexadecimal colour code assigned to the user. This
+            value is used in conjunction with
+            `icon:text` for the user's
+            auto-generated icon
+          example: "#f44336"
+        banned_until_readable:
+          type: string
+          description: An ISO 8601 formatted date string representing the moment a ban will be lifted, or the words "Not Banned"
+          example: Not Banned
+        deleted:
+          type: boolean

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -80,3 +80,60 @@ MessageObject:
           example: Not Banned
         deleted:
           type: boolean
+RoomObjectFull:
+  # Messaging.loadRoom
+  allOf:
+    - $ref: '#/RoomObject'
+    - $ref: '#/MessageObject'
+    - type: object
+      properties:
+        isOwner:
+          type: boolean
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              uid:
+                type: number
+                description: A user identifier
+              username:
+                type: string
+                description: A friendly name for a given user account
+              picture:
+                nullable: true
+                type: string
+              status:
+                type: string
+              displayname:
+                type: string
+                description: This is either username or fullname depending on forum and user settings
+              icon:text:
+                type: string
+                description: A single-letter representation of a username. This is used in the
+                  auto-generated icon given to users
+                  without an avatar
+              icon:bgColor:
+                type: string
+                description: A six-character hexadecimal colour code assigned to the user. This
+                  value is used in conjunction with
+                  `icon:text` for the user's
+                  auto-generated icon
+                example: "#f44336"
+              isOwner:
+                type: boolean
+        canReply:
+          type: boolean
+        groupChat:
+          type: boolean
+        usernames:
+          type: string
+          description: User-friendly depiction of the users within the chat room
+        maximumUsersInChatRoom:
+          type: number
+        maximumChatMessageLength:
+          type: number
+        showUserInput:
+          type: boolean
+        isAdminOrGlobalMod:
+          type: boolean

--- a/public/openapi/components/schemas/Chats.yaml
+++ b/public/openapi/components/schemas/Chats.yaml
@@ -52,8 +52,16 @@ MessageObject:
           example: dragon-fruit
         picture:
           type: string
+          nullable: true
           description: A URL pointing to a picture to be used as the user's avatar
           example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
+        status:
+          type: string
+          enum:
+            - online
+            - offline
+            - dnd
+            - away
         banned:
           type: boolean
           description: Whether a user is banned or not
@@ -80,6 +88,12 @@ MessageObject:
           example: Not Banned
         deleted:
           type: boolean
+    self:
+      type: number
+    newSet:
+      type: boolean
+    cleanedContent:
+      type: string
 RoomObjectFull:
   # Messaging.loadRoom
   allOf:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -140,6 +140,8 @@ paths:
     $ref: 'write/chats.yaml'
   /chats/{roomId}:
     $ref: 'write/chats/roomId.yaml'
+  /chats/{roomId}/{mid}:
+    $ref: 'write/chats/roomId/mid.yaml'
   /flags/:
     $ref: 'write/flags.yaml'
   /flags/{flagId}:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -19,7 +19,7 @@ info:
     # Authentication
 
     Please see the ["Authentication" section under the Read API](../read/#section/Overview/Authentication) for more information on how to authenticate against this API in order to make calls.
-  version: 1.15.0
+  version: 1.19.0
   contact:
     email: support@nodebb.org
   license:
@@ -39,6 +39,8 @@ tags:
     description: Topic-based calls (create, modify, delete, etc.)
   - name: posts
     description: Individual post-related calls (create, modify, delete, etc.)
+  - name: chats
+    description: Calls related to the user private messaging system
   - name: admin
     description: Administrative calls
   - name: files

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -136,6 +136,10 @@ paths:
     $ref: 'write/posts/pid/diffs/since.yaml'
   /posts/{pid}/diffs/{timestamp}:
     $ref: 'write/posts/pid/diffs/timestamp.yaml'
+  /chats/:
+    $ref: 'write/chats.yaml'
+  /chats/{roomId}:
+    $ref: 'write/chats/roomId.yaml'
   /flags/:
     $ref: 'write/flags.yaml'
   /flags/{flagId}:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -142,6 +142,8 @@ paths:
     $ref: 'write/chats/roomId.yaml'
   /chats/{roomId}/users:
     $ref: 'write/chats/roomId/users.yaml'
+  /chats/{roomId}/users/{uid}:
+    $ref: 'write/chats/roomId/users/uid.yaml'
   /chats/{roomId}/{mid}:
     $ref: 'write/chats/roomId/mid.yaml'
   /flags/:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -140,6 +140,8 @@ paths:
     $ref: 'write/chats.yaml'
   /chats/{roomId}:
     $ref: 'write/chats/roomId.yaml'
+  /chats/{roomId}/users:
+    $ref: 'write/chats/roomId/users.yaml'
   /chats/{roomId}/{mid}:
     $ref: 'write/chats/roomId/mid.yaml'
   /flags/:

--- a/public/openapi/write/chats.yaml
+++ b/public/openapi/write/chats.yaml
@@ -1,0 +1,29 @@
+post:
+  tags:
+    - chats
+  summary: create a chat room
+  description: This operation creates a new chat room and adds users to the room, if provided.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            uids:
+              type: array
+              example: [2, 3]
+          required:
+            - uids
+  responses:
+    '200':
+      description: chat room successfully created
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../components/schemas/Chats.yaml#/RoomObject

--- a/public/openapi/write/chats.yaml
+++ b/public/openapi/write/chats.yaml
@@ -1,3 +1,166 @@
+get:
+  tags:
+    - chats
+  summary: list recent chat rooms
+  description: This operation lists recently used chat rooms that the calling user is a part of
+  parameters:
+    - in: query
+      name: perPage
+      schema:
+        type: number
+      description: The number of chat rooms displayed per page
+      example: 20
+    - in: query
+      name: page
+      schema:
+        type: number
+      description: The page number
+      example: 1
+  responses:
+    '200':
+      description: chat rooms successfully listed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../components/schemas/Status.yaml#/Status
+              response:
+                allOf:
+                  - $ref: ../components/schemas/Chats.yaml#/RoomObject
+                  - type: object
+                    properties:
+                      unread:
+                        type: boolean
+                        description: Whether or not the chat has unread messages within
+                      teaser:
+                        type: object
+                        nullable: true
+                        properties:
+                          fromuid:
+                            type: number
+                          content:
+                            type: string
+                          timestamp:
+                            type: number
+                          timestampISO:
+                            type: string
+                          user:
+                            type: object
+                            properties:
+                              uid:
+                                type: number
+                                description: A user identifier
+                              username:
+                                type: string
+                                description: A friendly name for a given user account
+                              displayname:
+                                type: string
+                                description: This is either username or fullname depending on forum and user settings
+                              userslug:
+                                type: string
+                                description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                  removed, etc.)
+                              picture:
+                                nullable: true
+                                type: string
+                              status:
+                                type: string
+                              lastonline:
+                                type: number
+                              icon:text:
+                                type: string
+                                description: A single-letter representation of a username. This is used in the
+                                  auto-generated icon given to users
+                                  without an avatar
+                              icon:bgColor:
+                                type: string
+                                description: A six-character hexadecimal colour code assigned to the user. This
+                                  value is used in conjunction with
+                                  `icon:text` for the user's
+                                  auto-generated icon
+                                example: "#f44336"
+                              lastonlineISO:
+                                type: string
+                      users:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            uid:
+                              type: number
+                              description: A user identifier
+                            username:
+                              type: string
+                              description: A friendly name for a given user account
+                            displayname:
+                              type: string
+                              description: This is either username or fullname depending on forum and user settings
+                            userslug:
+                              type: string
+                              description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                removed, etc.)
+                            picture:
+                              nullable: true
+                              type: string
+                            status:
+                              type: string
+                            lastonline:
+                              type: number
+                            icon:text:
+                              type: string
+                              description: A single-letter representation of a username. This is used in the
+                                auto-generated icon given to users
+                                without an avatar
+                            icon:bgColor:
+                              type: string
+                              description: A six-character hexadecimal colour code assigned to the user. This
+                                value is used in conjunction with
+                                `icon:text` for the user's
+                                auto-generated icon
+                              example: "#f44336"
+                            lastonlineISO:
+                              type: string
+                      lastUser:
+                        type: object
+                        properties:
+                          uid:
+                            type: number
+                            description: A user identifier
+                          username:
+                            type: string
+                            description: A friendly name for a given user account
+                          displayname:
+                            type: string
+                            description: This is either username or fullname depending on forum and user settings
+                          userslug:
+                            type: string
+                            description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                              removed, etc.)
+                          picture:
+                            nullable: true
+                            type: string
+                          status:
+                            type: string
+                          lastonline:
+                            type: number
+                          icon:text:
+                            type: string
+                            description: A single-letter representation of a username. This is used in the
+                              auto-generated icon given to users
+                              without an avatar
+                          icon:bgColor:
+                            type: string
+                            description: A six-character hexadecimal colour code assigned to the user. This
+                              value is used in conjunction with
+                              `icon:text` for the user's
+                              auto-generated icon
+                            example: "#f44336"
+                          lastonlineISO:
+                            type: string
+                      usernames:
+                        type: string
 post:
   tags:
     - chats
@@ -12,7 +175,7 @@ post:
           properties:
             uids:
               type: array
-              example: [2, 3]
+              example: [2]
           required:
             - uids
   responses:

--- a/public/openapi/write/chats/roomId.yaml
+++ b/public/openapi/write/chats/roomId.yaml
@@ -1,0 +1,17 @@
+head:
+  tags:
+    - chats
+  summary: check if a chat room exists
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: room ID to check
+      example: 1
+  responses:
+    '200':
+      description: chat room found
+    '404':
+      description: chat room not found

--- a/public/openapi/write/chats/roomId.yaml
+++ b/public/openapi/write/chats/roomId.yaml
@@ -39,61 +39,7 @@ get:
               status:
                 $ref: ../../components/schemas/Status.yaml#/Status
               response:
-                allOf:
-                  - $ref: ../../components/schemas/Chats.yaml#/RoomObject
-                  - $ref: ../../components/schemas/Chats.yaml#/MessageObject
-                  - type: object
-                    properties:
-                      isOwner:
-                        type: boolean
-                      users:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            uid:
-                              type: number
-                              description: A user identifier
-                            username:
-                              type: string
-                              description: A friendly name for a given user account
-                            picture:
-                              nullable: true
-                              type: string
-                            status:
-                              type: string
-                            displayname:
-                              type: string
-                              description: This is either username or fullname depending on forum and user settings
-                            icon:text:
-                              type: string
-                              description: A single-letter representation of a username. This is used in the
-                                auto-generated icon given to users
-                                without an avatar
-                            icon:bgColor:
-                              type: string
-                              description: A six-character hexadecimal colour code assigned to the user. This
-                                value is used in conjunction with
-                                `icon:text` for the user's
-                                auto-generated icon
-                              example: "#f44336"
-                            isOwner:
-                              type: boolean
-                      canReply:
-                        type: boolean
-                      groupChat:
-                        type: boolean
-                      usernames:
-                        type: string
-                        description: User-friendly depiction of the users within the chat room
-                      maximumUsersInChatRoom:
-                        type: number
-                      maximumChatMessageLength:
-                        type: number
-                      showUserInput:
-                        type: boolean
-                      isAdminOrGlobalMod:
-                        type: boolean
+                $ref: ../../components/schemas/Chats.yaml#/RoomObjectFull
 post:
   tags:
     - chats
@@ -144,3 +90,39 @@ post:
                         type: string
                       mid:
                         type: number
+put:
+  tags:
+    - chats
+  summary: rename a chat room
+  description: This operation renames a chat room.
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid room id
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+              description: the new name of the room
+              example: 'casper the friendly room'
+  responses:
+    '200':
+      description: Chat room renamed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../components/schemas/Chats.yaml#/RoomObjectFull

--- a/public/openapi/write/chats/roomId.yaml
+++ b/public/openapi/write/chats/roomId.yaml
@@ -94,3 +94,53 @@ get:
                         type: boolean
                       isAdminOrGlobalMod:
                         type: boolean
+post:
+  tags:
+    - chats
+  summary: send a chat message
+  description: This operation sends a chat message to a chat room
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            message:
+              type: string
+              example: This is a test message
+          required:
+            - message
+  responses:
+    '200':
+      description: message successfully sent
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../components/schemas/Status.yaml#/Status
+              response:
+                allOf:
+                  - $ref: ../../components/schemas/Chats.yaml#/MessageObject
+                  - type: object
+                    properties:
+                      self:
+                        type: number
+                        description: Whether or not the message was sent by the calling user (which if you're using this route, will always be 1)
+                      newSet:
+                        type: boolean
+                        description: Whether the message is considered part of a new "set" of messages. It is used in the frontend UI for explicitly denoting that a time gap existed between messages.
+                      cleanedContent:
+                        type: string
+                      mid:
+                        type: number

--- a/public/openapi/write/chats/roomId.yaml
+++ b/public/openapi/write/chats/roomId.yaml
@@ -15,3 +15,82 @@ head:
       description: chat room found
     '404':
       description: chat room not found
+get:
+  tags:
+    - chats
+  summary: get a chat room
+  description: This operation retrieves a chat room's data including users and messages
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+  responses:
+    '200':
+      description: Chat room successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../components/schemas/Status.yaml#/Status
+              response:
+                allOf:
+                  - $ref: ../../components/schemas/Chats.yaml#/RoomObject
+                  - $ref: ../../components/schemas/Chats.yaml#/MessageObject
+                  - type: object
+                    properties:
+                      isOwner:
+                        type: boolean
+                      users:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            uid:
+                              type: number
+                              description: A user identifier
+                            username:
+                              type: string
+                              description: A friendly name for a given user account
+                            picture:
+                              nullable: true
+                              type: string
+                            status:
+                              type: string
+                            displayname:
+                              type: string
+                              description: This is either username or fullname depending on forum and user settings
+                            icon:text:
+                              type: string
+                              description: A single-letter representation of a username. This is used in the
+                                auto-generated icon given to users
+                                without an avatar
+                            icon:bgColor:
+                              type: string
+                              description: A six-character hexadecimal colour code assigned to the user. This
+                                value is used in conjunction with
+                                `icon:text` for the user's
+                                auto-generated icon
+                              example: "#f44336"
+                            isOwner:
+                              type: boolean
+                      canReply:
+                        type: boolean
+                      groupChat:
+                        type: boolean
+                      usernames:
+                        type: string
+                        description: User-friendly depiction of the users within the chat room
+                      maximumUsersInChatRoom:
+                        type: number
+                      maximumChatMessageLength:
+                        type: number
+                      showUserInput:
+                        type: boolean
+                      isAdminOrGlobalMod:
+                        type: boolean

--- a/public/openapi/write/chats/roomId/mid.yaml
+++ b/public/openapi/write/chats/roomId/mid.yaml
@@ -1,0 +1,141 @@
+get:
+  tags:
+    - chats
+  summary: get a chat message
+  description: This operation retrieves a single chat room message, by its id
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+    - in: path
+      name: mid
+      schema:
+        type: number
+      required: true
+      description: a valid message id
+      example: 1
+  responses:
+    '200':
+      description: Message successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../components/schemas/Chats.yaml#/MessageObject
+put:
+  tags:
+    - chats
+  summary: edit a chat message
+  description: This operation edits a chat message.
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+    - in: path
+      name: mid
+      schema:
+        type: number
+      required: true
+      description: a valid message id
+      example: 5
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            message:
+              type: string
+              description: message content
+              example: 'edited message'
+  responses:
+    '200':
+      description: Message successfully edited
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../components/schemas/Chats.yaml#/MessageObject
+delete:
+  tags:
+    - chats
+  summary: delete a chat message
+  description: This operation deletes a chat message
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+    - in: path
+      name: mid
+      schema:
+        type: number
+      required: true
+      description: a valid message id
+      example: 5
+  responses:
+    '200':
+      description: Message successfully deleted
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+post:
+  tags:
+    - chats
+  summary: restore a chat message
+  description: This operation restores a delete chat message
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+    - in: path
+      name: mid
+      schema:
+        type: number
+      required: true
+      description: a valid message id
+      example: 5
+  responses:
+    '200':
+      description: message successfully restored
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/openapi/write/chats/roomId/users.yaml
+++ b/public/openapi/write/chats/roomId/users.yaml
@@ -46,13 +46,52 @@ post:
             uids:
               type: array
               description: A list of valid uids
-              example: [2]
+              example: [2, 4]
               items:
                 type: number
                 description: A valid uid
   responses:
     '200':
       description: users successfully invited to chat room
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../components/schemas/Chats.yaml#/RoomUserList
+delete:
+  tags:
+    - chats
+  summary: remove users from chat room
+  description: This operation removes (kicks) a user from a chat room
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            uids:
+              type: array
+              description: A list of valid uids
+              example: [2]
+              items:
+                type: number
+                description: A valid uid
+  responses:
+    '200':
+      description: users successfully removed from chat room
       content:
         application/json:
           schema:

--- a/public/openapi/write/chats/roomId/users.yaml
+++ b/public/openapi/write/chats/roomId/users.yaml
@@ -65,8 +65,8 @@ post:
 delete:
   tags:
     - chats
-  summary: remove users from chat room
-  description: This operation removes (kicks) a user from a chat room
+  summary: leave/remove users from chat room
+  description: This operation removes (kicks) multiple user from a chat room, or leaves the chat room if the requested user is the same as the calling user.
   parameters:
     - in: path
       name: roomId

--- a/public/openapi/write/chats/roomId/users.yaml
+++ b/public/openapi/write/chats/roomId/users.yaml
@@ -22,40 +22,43 @@ get:
               status:
                 $ref: ../../../components/schemas/Status.yaml#/Status
               response:
-                type: object
-                properties:
-                  users:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        uid:
-                          type: number
-                          description: A user identifier
-                        username:
-                          type: string
-                          description: A friendly name for a given user account
-                        picture:
-                          nullable: true
-                          type: string
-                        status:
-                          type: string
-                        displayname:
-                          type: string
-                          description: This is either username or fullname depending on forum and user settings
-                        icon:text:
-                          type: string
-                          description: A single-letter representation of a username. This is used in the
-                            auto-generated icon given to users
-                            without an avatar
-                        icon:bgColor:
-                          type: string
-                          description: A six-character hexadecimal colour code assigned to the user. This
-                            value is used in conjunction with
-                            `icon:text` for the user's
-                            auto-generated icon
-                          example: "#f44336"
-                        isOwner:
-                          type: boolean
-                        canKick:
-                          type: boolean
+                $ref: ../../../components/schemas/Chats.yaml#/RoomUserList
+post:
+  tags:
+    - chats
+  summary: add users to chat room
+  description: This operation invites users to a chat room
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            uids:
+              type: array
+              description: A list of valid uids
+              example: [2]
+              items:
+                type: number
+                description: A valid uid
+  responses:
+    '200':
+      description: users successfully invited to chat room
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../components/schemas/Chats.yaml#/RoomUserList

--- a/public/openapi/write/chats/roomId/users.yaml
+++ b/public/openapi/write/chats/roomId/users.yaml
@@ -1,0 +1,61 @@
+get:
+  tags:
+    - chats
+  summary: get chat room users
+  description: This operation retrieves the users in a chat room message
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+  responses:
+    '200':
+      description: Users successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        uid:
+                          type: number
+                          description: A user identifier
+                        username:
+                          type: string
+                          description: A friendly name for a given user account
+                        picture:
+                          nullable: true
+                          type: string
+                        status:
+                          type: string
+                        displayname:
+                          type: string
+                          description: This is either username or fullname depending on forum and user settings
+                        icon:text:
+                          type: string
+                          description: A single-letter representation of a username. This is used in the
+                            auto-generated icon given to users
+                            without an avatar
+                        icon:bgColor:
+                          type: string
+                          description: A six-character hexadecimal colour code assigned to the user. This
+                            value is used in conjunction with
+                            `icon:text` for the user's
+                            auto-generated icon
+                          example: "#f44336"
+                        isOwner:
+                          type: boolean
+                        canKick:
+                          type: boolean

--- a/public/openapi/write/chats/roomId/users/uid.yaml
+++ b/public/openapi/write/chats/roomId/users/uid.yaml
@@ -1,0 +1,32 @@
+delete:
+  tags:
+    - chats
+  summary: remove one user from chat room
+  description: This operation removes (kicks) a single user from a chat room
+  parameters:
+    - in: path
+      name: roomId
+      schema:
+        type: number
+      required: true
+      description: a valid chat room id
+      example: 1
+    - in: path
+      name: uid
+      schema:
+        type: number
+      required: true
+      description: a valid user id
+      example: 4
+  responses:
+    '200':
+      description: user successfully removed from chat room
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../../components/schemas/Chats.yaml#/RoomUserList

--- a/public/openapi/write/chats/roomId/users/uid.yaml
+++ b/public/openapi/write/chats/roomId/users/uid.yaml
@@ -2,7 +2,7 @@ delete:
   tags:
     - chats
   summary: leave/remove one user from chat room
-  description: This operation removes (kicks) a single user from a chat room
+  description: This operation removes (kicks) a single user from a chat room, or leaves the chat room if the requested user is the same as the calling user.
   parameters:
     - in: path
       name: roomId

--- a/public/openapi/write/chats/roomId/users/uid.yaml
+++ b/public/openapi/write/chats/roomId/users/uid.yaml
@@ -1,7 +1,7 @@
 delete:
   tags:
     - chats
-  summary: remove one user from chat room
+  summary: leave/remove one user from chat room
   description: This operation removes (kicks) a single user from a chat room
   parameters:
     - in: path

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -264,16 +264,9 @@ define('forum/chats', [
 		modal.on('click', '[data-action="kick"]', function () {
 			const uid = parseInt(this.getAttribute('data-uid'), 10);
 
-			socket.emit('modules.chats.removeUserFromRoom', {
-				roomId: roomId,
-				uid: uid,
-			}, function (err) {
-				if (err) {
-					return alerts.error(err);
-				}
-
-				Chats.refreshParticipantsList(roomId, modal);
-			});
+			api.delete(`/chats/${roomId}/users/${uid}`, {}).then((body) => {
+				Chats.refreshParticipantsList(roomId, modal, body);
+			}).catch(alerts.error);
 		});
 	};
 

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -308,19 +308,14 @@ define('forum/chats', [
 	};
 
 	Chats.refreshParticipantsList = function (roomId, modal) {
-		socket.emit('modules.chats.getUsersInRoom', { roomId: roomId }, function (err, users) {
-			const listEl = modal.find('.list-group');
-
-			if (err) {
-				return translator.translate('[[error:invalid-data]]', function (translated) {
-					listEl.find('li').text(translated);
-				});
-			}
-
-			app.parseAndTranslate('partials/modals/manage_room_users', {
-				users: users,
-			}, function (html) {
+		const listEl = modal.find('.list-group');
+		api.get(`/chats/${roomId}/users`, {}).then(({ users }) => {
+			app.parseAndTranslate('partials/modals/manage_room_users', { users }, function (html) {
 				listEl.html(html);
+			});
+		}).catch(() => {
+			translator.translate('[[error:invalid-data]]', function (translated) {
+				listEl.find('li').text(translated);
 			});
 		});
 	};

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -278,11 +278,7 @@ define('forum/chats', [
 				message: '<p>[[modules:chat.leave-prompt]]</p><p class="help-block">[[modules:chat.leave-help]]</p>',
 				callback: function (ok) {
 					if (ok) {
-						socket.emit('modules.chats.leave', roomId, function (err) {
-							if (err) {
-								alerts.error(err);
-							}
-
+						api.delete(`/chats/${roomId}/users/${app.user.uid}`, {}).then(() => {
 							// Return user to chats page. If modal, close modal.
 							const modal = buttonEl.parents('.chat-modal');
 							if (modal.length) {
@@ -290,7 +286,7 @@ define('forum/chats', [
 							} else {
 								ajaxify.go('chats');
 							}
-						});
+						}).catch(alerts.error);
 					}
 				},
 			});
@@ -384,10 +380,7 @@ define('forum/chats', [
 
 	Chats.leave = function (el) {
 		const roomId = el.attr('data-roomid');
-		socket.emit('modules.chats.leave', roomId, function (err) {
-			if (err) {
-				return alerts.error(err);
-			}
+		api.delete(`/chats/${roomId}/users/${app.user.uid}`, {}).then(() => {
 			if (parseInt(roomId, 10) === parseInt(ajaxify.data.roomId, 10)) {
 				ajaxify.go('user/' + ajaxify.data.userslug + '/chats');
 			} else {
@@ -398,7 +391,7 @@ define('forum/chats', [
 			if (modal.length) {
 				chatModule.close(modal);
 			}
-		});
+		}).catch(alerts.error);
 	};
 
 	Chats.switchChat = function (roomid) {

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -13,10 +13,12 @@ define('forum/chats', [
 	'bootbox',
 	'alerts',
 	'chat',
+	'api',
 ], function (
 	components, translator, mousetrap,
 	recentChats, search, messages,
-	autocomplete, hooks, bootbox, alerts, chatModule
+	autocomplete, hooks, bootbox, alerts, chatModule,
+	api
 ) {
 	const Chats = {
 		initialised: false,
@@ -345,14 +347,9 @@ define('forum/chats', [
 		});
 
 		function submit() {
-			socket.emit('modules.chats.renameRoom', {
-				roomId: roomId,
-				newName: modal.find('#roomName').val(),
-			}, function (err) {
-				if (err) {
-					alerts.error(err);
-				}
-			});
+			api.put(`/chats/${roomId}`, {
+				name: modal.find('#roomName').val(),
+			}).catch(alerts.error);
 		}
 	};
 

--- a/public/src/client/chats/messages.js
+++ b/public/src/client/chats/messages.js
@@ -8,27 +8,21 @@ define('forum/chats/messages', [
 	const messages = {};
 
 	messages.sendMessage = function (roomId, inputEl) {
-		const msg = inputEl.val();
+		const message = inputEl.val();
 		const mid = inputEl.attr('data-mid');
 
-		if (!msg.trim().length) {
+		if (!message.trim().length) {
 			return;
 		}
 
 		inputEl.val('');
 		inputEl.removeAttr('data-mid');
 		messages.updateRemainingLength(inputEl.parent());
-		hooks.fire('action:chat.sent', {
-			roomId: roomId,
-			message: msg,
-			mid: mid,
-		});
+		hooks.fire('action:chat.sent', { roomId, message, mid });
 
 		if (!mid) {
-			api.post(`/chats/${roomId}`, {
-				message: msg,
-			}).catch((err) => {
-				inputEl.val(msg);
+			api.post(`/chats/${roomId}`, { message }).catch((err) => {
+				inputEl.val(message);
 				messages.updateRemainingLength(inputEl.parent());
 				if (err.message === '[[error:email-not-confirmed-chat]]') {
 					return messagesModule.showEmailConfirmWarning(err.message);
@@ -43,17 +37,11 @@ define('forum/chats/messages', [
 				});
 			});
 		} else {
-			socket.emit('modules.chats.edit', {
-				roomId: roomId,
-				mid: mid,
-				message: msg,
-			}, function (err) {
-				if (err) {
-					inputEl.val(msg);
-					inputEl.attr('data-mid', mid);
-					messages.updateRemainingLength(inputEl.parent());
-					return alerts.error(err);
-				}
+			api.put(`/chats/${roomId}/${mid}`, { message }).catch((err) => {
+				inputEl.val(message);
+				inputEl.attr('data-mid', mid);
+				messages.updateRemainingLength(inputEl.parent());
+				return alerts.error(err);
 			});
 		}
 	};

--- a/public/src/client/chats/messages.js
+++ b/public/src/client/chats/messages.js
@@ -190,31 +190,17 @@ define('forum/chats/messages', [
 					return;
 				}
 
-				socket.emit('modules.chats.delete', {
-					messageId: messageId,
-					roomId: roomId,
-				}, function (err) {
-					if (err) {
-						return alerts.error(err);
-					}
-
+				api.delete(`/chats/${roomId}/${messageId}`, {}).then(() => {
 					components.get('chat/message', messageId).toggleClass('deleted', true);
-				});
+				}).catch(alerts.error);
 			});
 		});
 	};
 
 	messages.restore = function (messageId, roomId) {
-		socket.emit('modules.chats.restore', {
-			messageId: messageId,
-			roomId: roomId,
-		}, function (err) {
-			if (err) {
-				return alerts.error(err);
-			}
-
+		api.post(`/chats/${roomId}/${messageId}`, {}).then(() => {
 			components.get('chat/message', messageId).toggleClass('deleted', false);
-		});
+		}).catch(alerts.error);
 	};
 
 	return messages;

--- a/public/src/client/chats/messages.js
+++ b/public/src/client/chats/messages.js
@@ -2,8 +2,9 @@
 
 
 define('forum/chats/messages', [
-	'components', 'translator', 'benchpress', 'hooks', 'bootbox', 'alerts', 'messages',
-], function (components, translator, Benchpress, hooks, bootbox, alerts, messagesModule) {
+	'components', 'translator', 'benchpress', 'hooks',
+	'bootbox', 'alerts', 'messages', 'api',
+], function (components, translator, Benchpress, hooks, bootbox, alerts, messagesModule, api) {
 	const messages = {};
 
 	messages.sendMessage = function (roomId, inputEl) {
@@ -24,25 +25,22 @@ define('forum/chats/messages', [
 		});
 
 		if (!mid) {
-			socket.emit('modules.chats.send', {
-				roomId: roomId,
+			api.post(`/chats/${roomId}`, {
 				message: msg,
-			}, function (err) {
-				if (err) {
-					inputEl.val(msg);
-					messages.updateRemainingLength(inputEl.parent());
-					if (err.message === '[[error:email-not-confirmed-chat]]') {
-						return messagesModule.showEmailConfirmWarning(err.message);
-					}
-
-					return alerts.alert({
-						alert_id: 'chat_spam_error',
-						title: '[[global:alert.error]]',
-						message: err.message,
-						type: 'danger',
-						timeout: 10000,
-					});
+			}).catch((err) => {
+				inputEl.val(msg);
+				messages.updateRemainingLength(inputEl.parent());
+				if (err.message === '[[error:email-not-confirmed-chat]]') {
+					return messagesModule.showEmailConfirmWarning(err.message);
 				}
+
+				return alerts.alert({
+					alert_id: 'chat_spam_error',
+					title: '[[global:alert.error]]',
+					message: err.message,
+					type: 'danger',
+					timeout: 10000,
+				});
 			});
 		} else {
 			socket.emit('modules.chats.edit', {

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -101,3 +101,15 @@ chatsAPI.invite = async (caller, data) => {
 	delete data.uids;
 	return chatsAPI.users(caller, data);
 };
+
+chatsAPI.kick = async (caller, data) => {
+	const uidsExist = await user.exists(data.uids);
+	if (!uidsExist.every(Boolean)) {
+		throw new Error('[[error:no-user]]');
+	}
+
+	await messaging.removeUsersFromRoom(caller.uid, data.uids, data.roomId);
+
+	delete data.uids;
+	return chatsAPI.users(caller, data);
+};

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -29,7 +29,7 @@ chatsAPI.create = async function (caller, data) {
 	}
 
 	if (!data.uids || !Array.isArray(data.uids)) {
-		throw new Error(`[[error:array-expected, uids, ${typeof data.uids}]]`);
+		throw new Error(`[[error:wrong-parameter-type, uids, ${typeof data.uids}, Array]]`);
 	}
 
 	await Promise.all(data.uids.map(async uid => messaging.canMessageUser(caller.uid, uid)));

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const meta = require('../meta');
+const privileges = require('../privileges');
+const messaging = require('../messaging');
+
+
+const websockets = require('../socket.io');
+const socketHelpers = require('../socket.io/helpers');
+
+const chatsAPI = module.exports;
+
+function rateLimitExceeded(caller) {
+	const session = caller.request ? caller.request.session : caller.session;	// socket vs req
+	const now = Date.now();
+	session.lastChatMessageTime = session.lastChatMessageTime || 0;
+	if (now - session.lastChatMessageTime < meta.config.chatMessageDelay) {
+		return true;
+	}
+	session.lastChatMessageTime = now;
+	return false;
+}
+
+chatsAPI.create = async function (caller, data) {
+	if (rateLimitExceeded(caller)) {
+		throw new Error('[[error:too-many-messages]]');
+	}
+
+	if (!data.uids || !Array.isArray(data.uids)) {
+		throw new Error(`[[error:array-expected, uids, ${typeof data.uids}]]`);
+	}
+
+	await Promise.all(data.uids.map(async uid => messaging.canMessageUser(caller.uid, uid)));
+	const roomId = await messaging.newRoom(caller.uid, data.uids);
+
+	return await messaging.getRoomData(roomId);
+};

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -72,3 +72,14 @@ chatsAPI.rename = async (caller, data) => {
 		roomId: data.roomId,
 	});
 };
+
+chatsAPI.users = async (caller, data) => {
+	const [isOwner, users] = await Promise.all([
+		messaging.isRoomOwner(caller.uid, data.roomId),
+		messaging.getUsersInRoom(data.roomId, 0, -1),
+	]);
+	users.forEach((user) => {
+		user.canKick = (parseInt(user.uid, 10) !== parseInt(caller.uid, 10)) && isOwner;
+	});
+	return { users };
+};

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -108,7 +108,12 @@ chatsAPI.kick = async (caller, data) => {
 		throw new Error('[[error:no-user]]');
 	}
 
-	await messaging.removeUsersFromRoom(caller.uid, data.uids, data.roomId);
+	// Additional checks if kicking vs leaving
+	if (data.uids.length === 1 && parseInt(data.uids[0], 10) === caller.uid) {
+		await messaging.leaveRoom([caller.uid], data.roomId);
+	} else {
+		await messaging.removeUsersFromRoom(caller.uid, data.uids, data.roomId);
+	}
 
 	delete data.uids;
 	return chatsAPI.users(caller, data);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -5,6 +5,7 @@ module.exports = {
 	groups: require('./groups'),
 	topics: require('./topics'),
 	posts: require('./posts'),
+	chats: require('./chats'),
 	categories: require('./categories'),
 	flags: require('./flags'),
 };

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -70,7 +70,22 @@ Chats.invite = async (req, res) => {
 };
 
 Chats.kick = async (req, res) => {
-	// ...
+	const users = await api.chats.kick(req, {
+		...req.body,
+		roomId: req.params.roomId,
+	});
+
+	helpers.formatApiResponse(200, res, users);
+};
+
+Chats.kickUser = async (req, res) => {
+	req.body.uids = [req.params.uid];
+	const users = await api.chats.kick(req, {
+		...req.body,
+		roomId: req.params.roomId,
+	});
+
+	helpers.formatApiResponse(200, res, users);
 };
 
 Chats.messages = {};

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -66,6 +66,11 @@ Chats.kick = async (req, res) => {
 };
 
 Chats.messages = {};
+Chats.messages.get = async (req, res) => {
+	const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
+	helpers.formatApiResponse(200, res, messages.pop());
+};
+
 Chats.messages.edit = async (req, res) => {
 	await messaging.canEdit(req.params.mid, req.uid);
 	await messaging.editMessage(req.uid, req.params.mid, req.params.roomId, req.body.message);

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -36,7 +36,12 @@ Chats.get = async (req, res) => {
 };
 
 Chats.post = async (req, res) => {
-	// ...
+	const messageObj = await api.chats.post(req, {
+		...req.body,
+		roomId: req.params.roomId,
+	});
+
+	helpers.formatApiResponse(200, res, messageObj);
 };
 
 Chats.users = async (req, res) => {

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -61,7 +61,12 @@ Chats.users = async (req, res) => {
 };
 
 Chats.invite = async (req, res) => {
-	// ...
+	const users = await api.chats.invite(req, {
+		...req.body,
+		roomId: req.params.roomId,
+	});
+
+	helpers.formatApiResponse(200, res, users);
 };
 
 Chats.kick = async (req, res) => {

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -1,0 +1,49 @@
+/* eslint-disable */
+'use strict';
+
+const api = require('../../api');
+
+const helpers = require('../helpers');
+
+const Chats = module.exports;
+
+Chats.list = async (req, res) => {
+	// ...
+};
+
+Chats.create = async (req, res) => {
+	// ...
+};
+
+Chats.exists = async (req, res) => {
+	helpers.formatApiResponse(200, res);
+};
+
+Chats.get = async (req, res) => {
+	// ...
+};
+
+Chats.post = async (req, res) => {
+	// ...
+};
+
+Chats.users = async (req, res) => {
+	// ...
+};
+
+Chats.invite = async (req, res) => {
+	// ...
+};
+
+Chats.kick = async (req, res) => {
+	// ...
+};
+
+Chats.message = {};
+Chats.messages.edit = async (req, res) => {
+	// ...
+};
+
+Chats.messages.delete = async (req, res) => {
+	// ...
+};

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -54,7 +54,10 @@ Chats.rename = async (req, res) => {
 };
 
 Chats.users = async (req, res) => {
-	// ...
+	const users = await api.chats.users(req, {
+		...req.params,
+	});
+	helpers.formatApiResponse(200, res, users);
 };
 
 Chats.invite = async (req, res) => {

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -44,6 +44,15 @@ Chats.post = async (req, res) => {
 	helpers.formatApiResponse(200, res, messageObj);
 };
 
+Chats.rename = async (req, res) => {
+	const roomObj = await api.chats.rename(req, {
+		...req.body,
+		roomId: req.params.roomId,
+	});
+
+	helpers.formatApiResponse(200, res, roomObj);
+};
+
 Chats.users = async (req, res) => {
 	// ...
 };

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -80,5 +80,15 @@ Chats.messages.edit = async (req, res) => {
 };
 
 Chats.messages.delete = async (req, res) => {
-	// ...
+	await messaging.canDelete(req.params.mid, req.uid);
+	await messaging.deleteMessage(req.params.mid, req.uid);
+
+	helpers.formatApiResponse(200, res);
+};
+
+Chats.messages.restore = async (req, res) => {
+	await messaging.canDelete(req.params.mid, req.uid);
+	await messaging.restoreMessage(req.params.mid, req.uid);
+
+	helpers.formatApiResponse(200, res);
 };

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -67,7 +67,11 @@ Chats.kick = async (req, res) => {
 
 Chats.messages = {};
 Chats.messages.edit = async (req, res) => {
-	// ...
+	await messaging.canEdit(req.params.mid, req.uid);
+	await messaging.editMessage(req.uid, req.params.mid, req.params.roomId, req.body.message);
+
+	const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
+	helpers.formatApiResponse(200, res, messages.pop());
 };
 
 Chats.messages.delete = async (req, res) => {

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -1,14 +1,20 @@
-/* eslint-disable */
 'use strict';
 
 const api = require('../../api');
+const messaging = require('../../messaging');
 
 const helpers = require('../helpers');
 
 const Chats = module.exports;
 
 Chats.list = async (req, res) => {
-	// ...
+	const page = (isFinite(req.query.page) && parseInt(req.query.page, 10)) || 1;
+	const perPage = (isFinite(req.query.perPage) && parseInt(req.query.perPage, 10)) || 20;
+	const start = Math.max(0, page - 1) * perPage;
+	const stop = start + perPage;
+	const { rooms } = await messaging.getRecentChats(req.uid, req.uid, start, stop);
+
+	helpers.formatApiResponse(200, res, { rooms });
 };
 
 Chats.create = async (req, res) => {
@@ -39,7 +45,7 @@ Chats.kick = async (req, res) => {
 	// ...
 };
 
-Chats.message = {};
+Chats.messages = {};
 Chats.messages.edit = async (req, res) => {
 	// ...
 };

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -18,7 +18,8 @@ Chats.list = async (req, res) => {
 };
 
 Chats.create = async (req, res) => {
-	// ...
+	const roomObj = await api.chats.create(req, req.body);
+	helpers.formatApiResponse(200, res, roomObj);
 };
 
 Chats.exists = async (req, res) => {

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -27,7 +27,12 @@ Chats.exists = async (req, res) => {
 };
 
 Chats.get = async (req, res) => {
-	// ...
+	const roomObj = await messaging.loadRoom(req.uid, {
+		uid: req.query.uid || req.uid,
+		roomId: req.params.roomId,
+	});
+
+	helpers.formatApiResponse(200, res, roomObj);
 };
 
 Chats.post = async (req, res) => {

--- a/src/controllers/write/index.js
+++ b/src/controllers/write/index.js
@@ -7,6 +7,7 @@ Write.groups = require('./groups');
 Write.categories = require('./categories');
 Write.topics = require('./topics');
 Write.posts = require('./posts');
+Write.chats = require('./chats');
 Write.flags = require('./flags');
 Write.admin = require('./admin');
 Write.files = require('./files');

--- a/src/messaging/edit.js
+++ b/src/messaging/edit.js
@@ -47,6 +47,11 @@ module.exports = function (Messaging) {
 			durationConfig = 'chatDeleteDuration';
 		}
 
+		const exists = await Messaging.messageExists(messageId);
+		if (!exists) {
+			throw new Error('[[error:invalid-mid]]');
+		}
+
 		const isAdminOrGlobalMod = await user.isAdminOrGlobalMod(uid);
 
 		if (meta.config.disableChat) {

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -20,6 +20,7 @@ require('./rooms')(Messaging);
 require('./unread')(Messaging);
 require('./notifications')(Messaging);
 
+Messaging.messageExists = async mid => db.exists(`message:${mid}`);
 
 Messaging.getMessages = async (params) => {
 	const isNew = params.isNew || false;

--- a/src/messaging/rooms.js
+++ b/src/messaging/rooms.js
@@ -109,9 +109,6 @@ module.exports = function (Messaging) {
 		if (!payload.isOwner) {
 			throw new Error('[[error:cant-remove-users-from-chat-room]]');
 		}
-		if (payload.userCount === 2) {
-			throw new Error('[[error:cant-remove-last-user]]');
-		}
 
 		await Messaging.leaveRoom(payload.uids, payload.roomId);
 	};

--- a/src/messaging/rooms.js
+++ b/src/messaging/rooms.js
@@ -191,7 +191,7 @@ module.exports = function (Messaging) {
 
 	Messaging.renameRoom = async function (uid, roomId, newName) {
 		if (!newName) {
-			throw new Error('[[error:invalid-name]]');
+			throw new Error('[[error:invalid-data]]');
 		}
 		newName = newName.trim();
 		if (newName.length > 75) {

--- a/src/middleware/assert.js
+++ b/src/middleware/assert.js
@@ -14,6 +14,7 @@ const user = require('../user');
 const groups = require('../groups');
 const topics = require('../topics');
 const posts = require('../posts');
+const messaging = require('../messaging');
 const slugify = require('../slugify');
 
 const helpers = require('./helpers');
@@ -101,6 +102,23 @@ Assert.folderName = helpers.try(async (req, res, next) => {
 	}
 
 	res.locals.folderPath = folderPath;
+
+	next();
+});
+
+Assert.room = helpers.try(async (req, res, next) => {
+	const [exists, inRoom] = await Promise.all([
+		await messaging.roomExists(req.params.roomId),
+		await messaging.isUserInRoom(req.uid, req.params.roomId),
+	]);
+
+	if (!exists) {
+		return controllerHelpers.formatApiResponse(404, res, new Error('[[error:chat-room-does-not-exist]]'));
+	}
+
+	if (!inRoom) {
+		return controllerHelpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
+	}
 
 	next();
 });

--- a/src/middleware/assert.js
+++ b/src/middleware/assert.js
@@ -107,6 +107,10 @@ Assert.folderName = helpers.try(async (req, res, next) => {
 });
 
 Assert.room = helpers.try(async (req, res, next) => {
+	if (!isFinite(req.params.roomId)) {
+		return controllerHelpers.formatApiResponse(400, res, new Error('[[error:invalid-data]]'));
+	}
+
 	const [exists, inRoom] = await Promise.all([
 		await messaging.roomExists(req.params.roomId),
 		await messaging.isUserInRoom(req.uid, req.params.roomId),

--- a/src/middleware/assert.js
+++ b/src/middleware/assert.js
@@ -126,3 +126,11 @@ Assert.room = helpers.try(async (req, res, next) => {
 
 	next();
 });
+
+Assert.message = helpers.try(async (req, res, next) => {
+	if (!isFinite(req.params.mid) || !(await messaging.messageExists(req.params.mid))) {
+		return controllerHelpers.formatApiResponse(400, res, new Error('[[error:invalid-mid]]'));
+	}
+
+	next();
+});

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -255,5 +255,5 @@ middleware.checkRequired = function (fields, req, res, next) {
 		return next();
 	}
 
-	controllers.helpers.formatApiResponse(400, res, new Error(`Required parameters were missing from this API call: ${missing.join(', ')}`));
+	controllers.helpers.formatApiResponse(400, res, new Error(`[[error:required-parameters-missing, ${missing.join(' ')}]]`));
 };

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -133,6 +133,14 @@ module.exports = function (middleware) {
 		controllers.helpers.notAllowed(req, res);
 	});
 
+	middleware.canChat = helpers.try(async (req, res, next) => {
+		const canChat = await privileges.global.can('chat', req.uid);
+		if (canChat) {
+			return next();
+		}
+		controllers.helpers.notAllowed(req, res);
+	});
+
 	middleware.checkAccountPermissions = helpers.try(async (req, res, next) => {
 		// This middleware ensures that only the requested user and admins can pass
 

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -15,7 +15,7 @@ module.exports = function () {
 
 	setupApiRoute(router, 'head', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.exists);
 	setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
-	// setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.post);
+	setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['message'])], controllers.write.chats.post);
 	// // no route for room deletion, reserved just in case...
 
 	// setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -23,7 +23,7 @@ module.exports = function () {
 	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
 	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
 
-	// setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.get);
+	setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.get);
 	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
 	// setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
 

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -11,19 +11,19 @@ module.exports = function () {
 	const middlewares = [middleware.ensureLoggedIn, middleware.canChat];
 
 	setupApiRoute(router, 'get', '/', [...middlewares], controllers.write.chats.list);
-	setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.create);
+	// setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.create);
 
 	setupApiRoute(router, 'head', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.exists);
-	setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
-	setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.post);
-	// no route for room deletion, reserved just in case...
+	// setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
+	// setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.post);
+	// // no route for room deletion, reserved just in case...
 
-	setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
-	setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
-	setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
+	// setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
+	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
+	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
 
-	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
-	setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
+	// setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
+	// setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
 
 	return router;
 };

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -23,8 +23,8 @@ module.exports = function () {
 	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
 	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
 
-	setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.get);
-	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
+	setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.get);
+	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.edit);
 	// setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
 
 	return router;

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -23,7 +23,8 @@ module.exports = function () {
 	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
 	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
 
-	// setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
+	// setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.get);
+	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
 	// setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
 
 	return router;

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -16,7 +16,8 @@ module.exports = function () {
 	setupApiRoute(router, 'head', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.exists);
 	setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
 	setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['message'])], controllers.write.chats.post);
-	// // no route for room deletion, reserved just in case...
+	setupApiRoute(router, 'put', '/:roomId', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['name'])], controllers.write.chats.rename);
+	// no route for room deletion, noted here just in case...
 
 	// setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
 	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const router = require('express').Router();
+const middleware = require('../../middleware');
+const controllers = require('../../controllers');
+const routeHelpers = require('../helpers');
+
+const { setupApiRoute } = routeHelpers;
+
+module.exports = function () {
+	const middlewares = [middleware.ensureLoggedIn, middleware.canChat];
+
+	setupApiRoute(router, 'get', '/', [...middlewares], controllers.write.chats.list);
+	setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.create);
+
+	setupApiRoute(router, 'head', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.exists);
+	setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
+	setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.post);
+	// no route for room deletion, reserved just in case...
+
+	setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
+	setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
+	setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
+
+	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.edit);
+	setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
+
+	return router;
+};

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -14,7 +14,7 @@ module.exports = function () {
 	setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.create);
 
 	setupApiRoute(router, 'head', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.exists);
-	// setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
+	setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);
 	// setupApiRoute(router, 'post', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.post);
 	// // no route for room deletion, reserved just in case...
 

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -21,7 +21,8 @@ module.exports = function () {
 
 	setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
 	setupApiRoute(router, 'post', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
-	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
+	setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
+	setupApiRoute(router, 'delete', '/:roomId/users/:uid', [...middlewares, middleware.assert.room, middleware.assert.user], controllers.write.chats.kickUser);
 
 	setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.get);
 	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.edit);

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -19,7 +19,7 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:roomId', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['name'])], controllers.write.chats.rename);
 	// no route for room deletion, noted here just in case...
 
-	// setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
+	setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
 	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
 	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
 

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -20,7 +20,7 @@ module.exports = function () {
 	// no route for room deletion, noted here just in case...
 
 	setupApiRoute(router, 'get', '/:roomId/users', [...middlewares, middleware.assert.room], controllers.write.chats.users);
-	// setupApiRoute(router, 'put', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
+	setupApiRoute(router, 'post', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.invite);
 	// setupApiRoute(router, 'delete', '/:roomId/users', [...middlewares, middleware.assert.room, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.kick);
 
 	setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.get);

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -25,7 +25,8 @@ module.exports = function () {
 
 	setupApiRoute(router, 'get', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.get);
 	setupApiRoute(router, 'put', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.edit);
-	// setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room], controllers.write.chats.messages.delete);
+	setupApiRoute(router, 'post', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.restore);
+	setupApiRoute(router, 'delete', '/:roomId/:mid', [...middlewares, middleware.assert.room, middleware.assert.message], controllers.write.chats.messages.delete);
 
 	return router;
 };

--- a/src/routes/write/chats.js
+++ b/src/routes/write/chats.js
@@ -11,7 +11,7 @@ module.exports = function () {
 	const middlewares = [middleware.ensureLoggedIn, middleware.canChat];
 
 	setupApiRoute(router, 'get', '/', [...middlewares], controllers.write.chats.list);
-	// setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.create);
+	setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['uids'])], controllers.write.chats.create);
 
 	setupApiRoute(router, 'head', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.exists);
 	// setupApiRoute(router, 'get', '/:roomId', [...middlewares, middleware.assert.room], controllers.write.chats.get);

--- a/src/routes/write/index.js
+++ b/src/routes/write/index.js
@@ -37,6 +37,7 @@ Write.reload = async (params) => {
 	router.use('/api/v3/categories', require('./categories')());
 	router.use('/api/v3/topics', require('./topics')());
 	router.use('/api/v3/posts', require('./posts')());
+	router.use('/api/v3/chats', require('./chats')());
 	router.use('/api/v3/flags', require('./flags')());
 	router.use('/api/v3/admin', require('./admin')());
 	router.use('/api/v3/files', require('./files')());

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -203,15 +203,15 @@ SocketModules.chats.markAllRead = async function (socket) {
 };
 
 SocketModules.chats.renameRoom = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'PUT /api/v3/chats/:roomId');
+
 	if (!data || !data.roomId || !data.newName) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	await Messaging.renameRoom(socket.uid, data.roomId, data.newName);
-	const uids = await Messaging.getUidsInRoom(data.roomId, 0, -1);
-	const eventData = { roomId: data.roomId, newName: validator.escape(String(data.newName)) };
-	uids.forEach((uid) => {
-		server.in(`uid_${uid}`).emit('event:chats.roomRename', eventData);
-	});
+
+	data.name = data.newName;
+	delete data.newName;
+	await api.chats.rename(socket, data);
 };
 
 SocketModules.chats.getRecentChats = async function (socket, data) {

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -100,6 +100,8 @@ function rateLimitExceeded(socket) {
 }
 
 SocketModules.chats.loadRoom = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'GET /api/v3/chats/:roomId');
+
 	if (!data || !data.roomId) {
 		throw new Error('[[error:invalid-data]]');
 	}

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -156,6 +156,8 @@ SocketModules.chats.edit = async function (socket, data) {
 };
 
 SocketModules.chats.delete = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'DELETE /api/v3/chats/:roomId/:mid');
+
 	if (!data || !data.roomId || !data.messageId) {
 		throw new Error('[[error:invalid-data]]');
 	}
@@ -164,6 +166,8 @@ SocketModules.chats.delete = async function (socket, data) {
 };
 
 SocketModules.chats.restore = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'POST /api/v3/chats/:roomId/:mid');
+
 	if (!data || !data.roomId || !data.messageId) {
 		throw new Error('[[error:invalid-data]]');
 	}

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -131,6 +131,8 @@ SocketModules.chats.removeUserFromRoom = async function (socket, data) {
 };
 
 SocketModules.chats.leave = async function (socket, roomid) {
+	sockets.warnDeprecated(socket, 'DELETE /api/v3/chats/:roomId/users OR DELETE /api/v3/chats/:roomId/users/:uid');
+
 	if (!socket.uid || !roomid) {
 		throw new Error('[[error:invalid-data]]');
 	}

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -117,15 +117,17 @@ SocketModules.chats.addUserToRoom = async function (socket, data) {
 };
 
 SocketModules.chats.removeUserFromRoom = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'DELETE /api/v3/chats/:roomId/users OR DELETE /api/v3/chats/:roomId/users/:uid');
+
 	if (!data || !data.roomId) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const exists = await user.exists(data.uid);
-	if (!exists) {
-		throw new Error('[[error:no-user]]');
-	}
 
-	await Messaging.removeUsersFromRoom(socket.uid, [data.uid], data.roomId);
+	// Revised API can accept multiple uids now
+	data.uids = [data.uid];
+	delete data.uid;
+
+	await api.chats.kick(socket, data);
 };
 
 SocketModules.chats.leave = async function (socket, roomid) {

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -84,21 +84,17 @@ SocketModules.chats.loadRoom = async function (socket, data) {
 };
 
 SocketModules.chats.getUsersInRoom = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'GET /api/v3/chats/:roomId/user');
+
 	if (!data || !data.roomId) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const [isUserInRoom, isOwner, userData] = await Promise.all([
-		Messaging.isUserInRoom(socket.uid, data.roomId),
-		Messaging.isRoomOwner(socket.uid, data.roomId),
-		Messaging.getUsersInRoom(data.roomId, 0, -1),
-	]);
+	const isUserInRoom = await Messaging.isUserInRoom(socket.uid, data.roomId);
 	if (!isUserInRoom) {
 		throw new Error('[[error:no-privileges]]');
 	}
-	userData.forEach((user) => {
-		user.canKick = (parseInt(user.uid, 10) !== parseInt(socket.uid, 10)) && isOwner;
-	});
-	return userData;
+
+	return api.chats.users(socket, data);
 };
 
 SocketModules.chats.addUserToRoom = async function (socket, data) {

--- a/src/socket.io/modules.js
+++ b/src/socket.io/modules.js
@@ -146,6 +146,8 @@ SocketModules.chats.leave = async function (socket, roomid) {
 };
 
 SocketModules.chats.edit = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'PUT /api/v3/chats/:roomId/:mid');
+
 	if (!data || !data.roomId || !data.message) {
 		throw new Error('[[error:invalid-data]]');
 	}

--- a/test/api.js
+++ b/test/api.js
@@ -390,6 +390,7 @@ describe('API', async () => {
 
 					try {
 						if (type === 'json') {
+							console.log(`calling ${url}`);
 							response = await request(url, {
 								method: method,
 								jar: !unauthenticatedRoutes.includes(path) ? jar : undefined,
@@ -418,7 +419,12 @@ describe('API', async () => {
 
 				it('response status code should match one of the schema defined responses', () => {
 					// HACK: allow HTTP 418 I am a teapot, for now   👇
-					assert(context[method].responses.hasOwnProperty('418') || Object.keys(context[method].responses).includes(String(response.statusCode)), `${method.toUpperCase()} ${path} sent back unexpected HTTP status code: ${response.statusCode}`);
+					try {
+						assert(context[method].responses.hasOwnProperty('418') || Object.keys(context[method].responses).includes(String(response.statusCode)), `${method.toUpperCase()} ${path} sent back unexpected HTTP status code: ${response.statusCode}`);
+					} catch (e) {
+						console.log(response.body);
+						throw e;
+					}
 				});
 
 				// Recursively iterate through schema properties, comparing type

--- a/test/api.js
+++ b/test/api.js
@@ -135,6 +135,7 @@ describe('API', async () => {
 		});
 		meta.config.allowTopicsThumbnail = 1;
 		meta.config.termsOfUse = 'I, for one, welcome our new test-driven overlords';
+		meta.config.chatMessageDelay = 0;
 
 		// Create a category
 		const testCategory = await categories.create({ name: 'test' });

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -657,7 +657,11 @@ describe('Messaging Library', () => {
 		});
 
 		it('should edit message', async () => {
-			const { statusCode, body } = await callv3API('put', `/chats/${roomId}/${mid}`, { message: 'message edited' }, 'foo');
+			let { statusCode, body } = await callv3API('put', `/chats/${roomId}/${mid}`, { message: 'message edited' }, 'foo');
+			assert.strictEqual(statusCode, 200);
+			assert.strictEqual(body.response.content, 'message edited');
+
+			({ statusCode, body } = await callv3API('get', `/chats/${roomId}/${mid}`, {}, 'foo'));
 			assert.strictEqual(statusCode, 200);
 			assert.strictEqual(body.response.content, 'message edited');
 		});

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -521,24 +521,17 @@ describe('Messaging Library', () => {
 			});
 		});
 
-		it('should fail to rename room with invalid data', (done) => {
-			socketModules.chats.renameRoom({ uid: mocks.users.foo.uid }, null, (err) => {
-				assert.equal(err.message, '[[error:invalid-data]]');
-				socketModules.chats.renameRoom({ uid: mocks.users.foo.uid }, { roomId: null }, (err) => {
-					assert.equal(err.message, '[[error:invalid-data]]');
-					socketModules.chats.renameRoom({ uid: mocks.users.foo.uid }, { roomId: roomId, newName: null }, (err) => {
-						assert.equal(err.message, '[[error:invalid-data]]');
-						done();
-					});
-				});
-			});
+		it('should fail to rename room with invalid data', async () => {
+			let { body } = await callv3API('put', `/chats/${roomId}`, { name: null }, 'foo');
+			assert.strictEqual(body.status.message, await translator.translate('[[error:invalid-data]]'));
+
+			({ body } = await callv3API('put', `/chats/${roomId}`, {}, 'foo'));
+			assert.strictEqual(body.status.message, await translator.translate('[[error:required-parameters-missing, name]]'));
 		});
 
-		it('should rename room', (done) => {
-			socketModules.chats.renameRoom({ uid: mocks.users.foo.uid }, { roomId: roomId, newName: 'new room name' }, (err) => {
-				assert.ifError(err);
-				done();
-			});
+		it('should rename room', async () => {
+			const { statusCode } = await callv3API('put', `/chats/${roomId}`, { name: 'new room name' }, 'foo');
+			assert.strictEqual(statusCode, 200);
 		});
 
 		it('should send a room-rename system message when a room is renamed', (done) => {

--- a/test/user.js
+++ b/test/user.js
@@ -17,6 +17,7 @@ const Categories = require('../src/categories');
 const Posts = require('../src/posts');
 const Password = require('../src/password');
 const groups = require('../src/groups');
+const messaging = require('../src/messaging');
 const helpers = require('./helpers');
 const meta = require('../src/meta');
 const socketUser = require('../src/socket.io/user');
@@ -544,9 +545,13 @@ describe('User', () => {
 			const socketModules = require('../src/socket.io/modules');
 			const uid1 = await User.create({ username: 'chatuserdelete1' });
 			const uid2 = await User.create({ username: 'chatuserdelete2' });
-			const roomId = await socketModules.chats.newRoom({ uid: uid1 }, { touid: uid2 });
-			await socketModules.chats.send({ uid: uid1 }, { roomId: roomId, message: 'hello' });
-			await socketModules.chats.leave({ uid: uid2 }, roomId);
+			const roomId = await messaging.newRoom(uid1, [uid2]);
+			await messaging.addMessage({
+				uid: uid1,
+				content: 'hello',
+				roomId,
+			});
+			await messaging.leaveRoom([uid2], roomId);
 			await User.delete(1, uid1);
 			assert.strictEqual(await User.exists(uid1), false);
 		});


### PR DESCRIPTION
# :rotating_light: Breaking Changes

* `.getUsersInRoom()`/`GET /api/v3/chats/:roomId/users` now returns an **object** with `users` array, instead of just an array of users
* `POST /api/v3/chats/:roomId/users` accepts `uids`, not `usernames`, although the deprecated socket call will still support the receipt of a single `username` data property.
* You are now allowed to kick someone from a room even if it is only you and them remaining (prior to this, if the room contained two users, the owner could not kick the other user out)