### PR TITLE
Stop colors.js vandalism

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -41,7 +41,7 @@
         "chart.js": "^2.9.4",
         "cli-graph": "^3.2.2",
         "clipboard": "^2.0.6",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "commander": "^7.1.0",
         "compare-versions": "4.1.2",
         "compression": "^1.7.4",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "packageRules": [
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": ["colors"]
     }
   ]
 }


### PR DESCRIPTION
`colors.js` was made to print endless zalgo upon import in `1.4.1` and `1.4.44-liberty-2` versions. Becaues NodeBB used a `^` semver range these versions will be installed by default, breaking the installation process and any attempt at using nodebb cli (at least, not sure if it's not used elsewhere). Thankfully it doesn't do anything worse than blocking the terminal.

This PR pins the version to 1.4.0 and exludes it from renovate bumps so it isn't updated to the broken one.

You can see the commit introducing the vandalism here: https://github.com/Marak/colors.js/commit/074a0f8ed0c31c35d13d28632bd8a049ff136fb6

edit: I expect the abusing version will be relatively soon removed by npm. I for one reported it. So before merging it will be a good idea to check if it's still necessary or if 1.4.1 was removed from https://www.npmjs.com/package/colors