### PR TITLE
fix: CSRF handler to go back to saving in session

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -472,8 +472,6 @@ authenticationController.logout = async function (req, res, next) {
 
 		await destroyAsync(req);
 		res.clearCookie(nconf.get('sessionKey'), meta.configs.cookie.get());
-		req.uid = 0;
-		req.headers['x-csrf-token'] = req.csrfToken();
 
 		await user.setUserField(uid, 'lastonline', Date.now() - (meta.config.onlineCutoff * 60000));
 		await db.sortedSetAdd('users:online', Date.now() - (meta.config.onlineCutoff * 60000), uid);

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -34,17 +34,11 @@ middleware.regexes = {
 	timestampedUpload: /^\d+-.+$/,
 };
 
-const csurfMiddleware = csrf({
-	cookie: nconf.get('url_parsed').protocol === 'https:' ? {
-		secure: true,
-		sameSite: 'Strict',
-		httpOnly: true,
-	} : true,
-});
+const csrfMiddleware = csrf();
 
 middleware.applyCSRF = function (req, res, next) {
 	if (req.uid >= 0) {
-		csurfMiddleware(req, res, next);
+		csrfMiddleware(req, res, next);
 	} else {
 		next();
 	}


### PR DESCRIPTION
It seems there is an issue with how our CSRF validation strategy is implemented.

- Prior to Oct 2019, CSRF was saved in session and checked via applyCSRF middleware.﻿
- In cf7e0cfd2d737c6c1ce74b13cd0a24243f1ad6f8, the handler was changed to save a separate cookie for csrf-enabled routes. The purported reason was so that guests could browse the forum without receiving an `express.sid` cookie.
- It seems that in doing so, it meant that any calls to req.csrfToken() and passing the token in requests, etc. was pointless, since the token was saved in the cookie itself and sent back to the server
- This PR changes the behaviour back to saving the CSRF token in session, but only invokes it for logged-in users, which is how it should have been implemented in the first place
