### PR TITLE
feat: detect alternative package managers based on lockfile

### DIFF
--- a/src/cli/upgrade-plugins.js
+++ b/src/cli/upgrade-plugins.js
@@ -6,16 +6,13 @@ const cproc = require('child_process');
 const semver = require('semver');
 const fs = require('fs');
 const path = require('path');
-const nconf = require('nconf');
 const chalk = require('chalk');
 
 const { paths, pluginNamePattern } = require('../constants');
+const pkgInstall = require('./package-install');
 
-const packageManager = nconf.get('package_manager');
-
-const supportedPackageManagerList = require('./package-install').supportedPackageManager; // load config from src/cli/package-install.js
-
-let packageManagerExecutable = supportedPackageManagerList.indexOf(packageManager) >= 0 ? packageManager : 'npm';
+const packageManager = pkgInstall.getPackageManager();
+let packageManagerExecutable = packageManager;
 const packageManagerInstallArgs = packageManager === 'yarn' ? ['add'] : ['install', '--save'];
 
 if (process.platform === 'win32') {

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -13,10 +13,9 @@ const db = require('../database');
 const meta = require('../meta');
 const pubsub = require('../pubsub');
 const { paths } = require('../constants');
+const pkgInstall = require('../cli/package-install');
 
-const supportedPackageManagerList = require('../cli/package-install').supportedPackageManager;
-// load config from src/cli/package-install.js
-const packageManager = supportedPackageManagerList.indexOf(nconf.get('package_manager')) >= 0 ? nconf.get('package_manager') : 'npm';
+const packageManager = pkgInstall.getPackageManager();
 let packageManagerExecutable = packageManager;
 const packageManagerCommands = {
 	yarn: {


### PR DESCRIPTION
If a package manager is not explicitly set in config.json or passed-in via argv/env, NodeBB will now check for the presence of alternative package managers' lockfiles and adjust the package manager to-be-used accordingly. If the standard npm lockfile exists, npm will always be used.
