### PR TITLE
feat: send hook name in caller object in plugin hooks

### DIFF
--- a/src/plugins/hooks.js
+++ b/src/plugins/hooks.js
@@ -99,7 +99,7 @@ Hooks.fire = async function (hook, params) {
 	let deleteCaller = false;
 	if (params && typeof params === 'object' && !params.hasOwnProperty('caller')) {
 		const als = require('../als');
-		params.caller = als.getStore();
+		params.caller = { ...als.getStore(), hook };
 		deleteCaller = true;
 	}
 	const result = await hookTypeToMethod[hookType](hook, hookList, params);


### PR DESCRIPTION
This change sends the hook name in with the regular hook payload. It is useful in cases where a single hook listener can be used for multiple hooks.

One example being the following four hooks:

1. `filter:privileges.global.list`
1. `filter:privileges.global.list_human`
1. `filter:privileges.global.groups.list`
1. `filter:privileges.global.groups.list_human`

If a plugin is adding a single privilege, the label usually remains the same, and the privilege itself is only different from the group privilege because it is prefixed with `group:`

The one main argument _against_ merging this in is only that it encourages function overloading.

Even with the rationale above, the better solution is a refactor of the privilege hooks so only one hook is called on NodeBB start.
