### PR TITLE
refactor: privileges system to use a Map in the backend instead of separate objects for keys and labels

### DIFF
--- a/public/openapi/read/admin/manage/privileges/cid.yaml
+++ b/public/openapi/read/admin/manage/privileges/cid.yaml
@@ -27,17 +27,13 @@ get:
                           users:
                             type: array
                             items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
+                              type: string
+                              description: Language key of the privilege name's user-friendly name
                           groups:
                             type: array
                             items:
-                              type: object
-                              properties:
-                                name:
-                                  type: string
+                              type: string
+                              description: Language key of the privilege name's user-friendly name
                       keys:
                         type: object
                         properties:

--- a/public/openapi/write/categories/cid/privileges.yaml
+++ b/public/openapi/write/categories/cid/privileges.yaml
@@ -30,19 +30,13 @@ get:
                       users:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Language key of the privilege name's user-friendly name
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
                       groups:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Language key of the privilege name's user-friendly name
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
                   users:
                     type: array
                     items:

--- a/public/openapi/write/categories/cid/privileges/privilege.yaml
+++ b/public/openapi/write/categories/cid/privileges/privilege.yaml
@@ -47,19 +47,13 @@ put:
                       users:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Language key of the privilege name's user-friendly name
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
                       groups:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Language key of the privilege name's user-friendly name
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
                   users:
                     type: array
                     items:
@@ -164,19 +158,13 @@ delete:
                       users:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Language key of the privilege name's user-friendly name
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
                       groups:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              description: Language key of the privilege name's user-friendly name
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
                   users:
                     type: array
                     items:

--- a/src/privileges/admin.js
+++ b/src/privileges/admin.js
@@ -11,40 +11,36 @@ const utils = require('../utils');
 
 const privsAdmin = module.exports;
 
-privsAdmin.privilegeLabels = [
-	{ name: '[[admin/manage/privileges:admin-dashboard]]' },
-	{ name: '[[admin/manage/privileges:admin-categories]]' },
-	{ name: '[[admin/manage/privileges:admin-privileges]]' },
-	{ name: '[[admin/manage/privileges:admin-admins-mods]]' },
-	{ name: '[[admin/manage/privileges:admin-users]]' },
-	{ name: '[[admin/manage/privileges:admin-groups]]' },
-	{ name: '[[admin/manage/privileges:admin-tags]]' },
-	{ name: '[[admin/manage/privileges:admin-settings]]' },
-];
+/**
+ * Looking to add a new admin privilege via plugin/theme? Attach a hook to
+ * `static:privileges.admin.init` and call .set() on the privilege map passed
+ * in to your listener.
+ */
+const _privilegeMap = new Map([
+	['admin:dashboard', { label: '[[admin/manage/privileges:admin-dashboard]]' }],
+	['admin:categories', { label: '[[admin/manage/privileges:admin-categories]]' }],
+	['admin:privileges', { label: '[[admin/manage/privileges:admin-privileges]]' }],
+	['admin:admins-mods', { label: '[[admin/manage/privileges:admin-admins-mods]]' }],
+	['admin:users', { label: '[[admin/manage/privileges:admin-users]]' }],
+	['admin:groups', { label: '[[admin/manage/privileges:admin-groups]]' }],
+	['admin:tags', { label: '[[admin/manage/privileges:admin-tags]]' }],
+	['admin:settings', { label: '[[admin/manage/privileges:admin-settings]]' }],
+]);
 
-privsAdmin.userPrivilegeList = [
-	'admin:dashboard',
-	'admin:categories',
-	'admin:privileges',
-	'admin:admins-mods',
-	'admin:users',
-	'admin:groups',
-	'admin:tags',
-	'admin:settings',
-];
-
-privsAdmin.groupPrivilegeList = privsAdmin.userPrivilegeList.map(privilege => `groups:${privilege}`);
-
-privsAdmin.privilegeList = privsAdmin.userPrivilegeList.concat(privsAdmin.groupPrivilegeList);
-
-privsAdmin.getUserPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.admin.list', privsAdmin.userPrivilegeList.slice());
-privsAdmin.getGroupPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.admin.groups.list', privsAdmin.groupPrivilegeList.slice());
+privsAdmin.getUserPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.admin.list', Array.from(_privilegeMap.keys()));
+privsAdmin.getGroupPrivilegeList = async () => await plugins.hooks.fire('filter:privileges.admin.groups.list', Array.from(_privilegeMap.keys()).map(privilege => `groups:${privilege}`));
 privsAdmin.getPrivilegeList = async () => {
 	const [user, group] = await Promise.all([
 		privsAdmin.getUserPrivilegeList(),
 		privsAdmin.getGroupPrivilegeList(),
 	]);
 	return user.concat(group);
+};
+
+privsAdmin.init = async () => {
+	await plugins.hooks.fire('static:privileges.admin.init', {
+		privileges: _privilegeMap,
+	});
 };
 
 // Mapping for a page route (via direct match or regexp) to a privilege
@@ -118,9 +114,9 @@ privsAdmin.resolve = (path) => {
 };
 
 privsAdmin.list = async function (uid) {
-	const privilegeLabels = privsAdmin.privilegeLabels.slice();
-	const userPrivilegeList = privsAdmin.userPrivilegeList.slice();
-	const groupPrivilegeList = privsAdmin.groupPrivilegeList.slice();
+	const privilegeLabels = Array.from(_privilegeMap.values()).map(data => data.label);
+	const userPrivilegeList = await privsAdmin.getUserPrivilegeList();
+	const groupPrivilegeList = await privsAdmin.getGroupPrivilegeList();
 
 	// Restrict privileges column to superadmins
 	if (!(await user.isAdministrator(uid))) {
@@ -135,10 +131,10 @@ privsAdmin.list = async function (uid) {
 		groups: plugins.hooks.fire('filter:privileges.admin.groups.list_human', privilegeLabels.slice()),
 	});
 
-	const keys = await utils.promiseParallel({
-		users: plugins.hooks.fire('filter:privileges.admin.list', userPrivilegeList.slice()),
-		groups: plugins.hooks.fire('filter:privileges.admin.groups.list', groupPrivilegeList.slice()),
-	});
+	const keys = {
+		users: userPrivilegeList,
+		groups: groupPrivilegeList,
+	};
 
 	const payload = await utils.promiseParallel({
 		labels,

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -13,8 +13,8 @@ const utils = require('../utils');
 const privsCategories = module.exports;
 
 /**
- * Looking to add a new global privilege via plugin/theme? Attach a hook to
- * `static:privileges.global.init` and call .set() on the privilege map passed
+ * Looking to add a new category privilege via plugin/theme? Attach a hook to
+ * `static:privileges.category.init` and call .set() on the privilege map passed
  * in to your listener.
  */
 const _privilegeMap = new Map([

--- a/src/privileges/index.js
+++ b/src/privileges/index.js
@@ -8,4 +8,10 @@ privileges.topics = require('./topics');
 privileges.posts = require('./posts');
 privileges.users = require('./users');
 
+privileges.init = async () => {
+	await privileges.global.init();
+	await privileges.admin.init();
+	await privileges.categories.init();
+};
+
 require('../promisify')(privileges);

--- a/src/views/admin/partials/privileges/category.tpl
+++ b/src/views/admin/partials/privileges/category.tpl
@@ -14,9 +14,9 @@
 							<tr>
 								<th colspan="2">[[admin/manage/categories:privileges.section-group]]</th>
 								<th class="text-center">[[admin/manage/privileges:select-clear-all]]</th>
-								<!-- BEGIN privileges.labels.groups -->
-								<th class="text-center">{privileges.labels.groups.name}</th>
-								<!-- END privileges.labels.groups -->
+								{{{ each privileges.labels.groups }}}
+								<th class="text-center">{@value}</th>
+								{{{ end }}}
 							</tr>
 						</thead>
 						<tbody>
@@ -97,9 +97,9 @@
 							<tr>
 								<th colspan="2">[[admin/manage/categories:privileges.section-user]]</th>
 								<th class="text-center">[[admin/manage/privileges:select-clear-all]]</th>
-								<!-- BEGIN privileges.labels.users -->
-								<th class="text-center">{privileges.labels.users.name}</th>
-								<!-- END privileges.labels.users -->
+								{{{ each privileges.labels.users }}}
+								<th class="text-center">{@value}</th>
+								{{{ end }}}
 							</tr>
 						</thead>
 						<tbody>

--- a/src/views/admin/partials/privileges/global.tpl
+++ b/src/views/admin/partials/privileges/global.tpl
@@ -18,9 +18,9 @@
 							<tr>
 								<th colspan="2">[[admin/manage/categories:privileges.section-group]]</th>
 								<th class="text-center">[[admin/manage/privileges:select-clear-all]]</th>
-								<!-- BEGIN privileges.labels.groups -->
-								<th class="text-center">{privileges.labels.groups.name}</th>
-								<!-- END privileges.labels.groups -->
+								{{{ each privileges.labels.groups }}}
+								<th class="text-center">{@value}</th>
+								{{{ end }}}
 							</tr>
 						</thead>
 						<tbody>
@@ -71,9 +71,9 @@
 							<tr>
 								<th colspan="2">[[admin/manage/categories:privileges.section-user]]</th>
 								<th class="text-center">[[admin/manage/privileges:select-clear-all]]</th>
-								<!-- BEGIN privileges.labels.users -->
-								<th class="text-center">{privileges.labels.users.name}</th>
-								<!-- END privileges.labels.users -->
+								{{{ each privileges.labels.users }}}
+								<th class="text-center">{@value}</th>
+								{{{ end }}}
 							</tr>
 						</thead>
 						<tbody>

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -31,6 +31,7 @@ const logger = require('./logger');
 const plugins = require('./plugins');
 const flags = require('./flags');
 const topicEvents = require('./topics/events');
+const privileges = require('./privileges');
 const routes = require('./routes');
 const auth = require('./routes/authentication');
 
@@ -103,6 +104,7 @@ async function initializeNodeBB() {
 		middleware: middleware,
 	});
 	await routes(app, middleware);
+	await privileges.init();
 	await meta.blacklist.load();
 	await flags.init();
 	await analytics.init();


### PR DESCRIPTION
- Existing hooks are preserved (to be deprecated at a later date, possibly)
- Newly added init hooks (`static:privileges.categories.init`) are called on NodeBB start, and provide a one-stop shop to add new privileges, instead of having to add to four different hooks
