### PR TITLE
Skip i18n tests on pull requests

### DIFF
--- a/test/i18n.js
+++ b/test/i18n.js
@@ -13,7 +13,11 @@ const db = require('./mocks/databasemock');
 describe('i18n', () => {
 	let folders;
 
-	before(async () => {
+	before(async function () {
+		if (process.env.GITHUB_EVENT_NAME === 'pull_request') {
+			this.skip();
+		}
+
 		folders = await fs.promises.readdir(path.resolve(__dirname, '../public/language'));
 		folders = folders.filter(f => f !== 'README.md');
 	});


### PR DESCRIPTION
We get pull requests that contain changes to the internationalization keys. This will almost certainly cause the tests to fail since the fallbacks are not present. Otherwise the pull request is ok, but doesn't have the checkmarks.

This adjustment to the i18n tests file will skip them if the passed-in event is pull_request.

* test: skip i18n tests if the github event is a pull request
* test: add deliberately failing i18n test
