### PR TITLE
Fixes X-Upstream-Hostname header for os hostnames with invalid chars

### DIFF
--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -62,7 +62,7 @@ module.exports = function (middleware) {
 		}
 
 		if (process.env.NODE_ENV === 'development') {
-			headers['X-Upstream-Hostname'] = os.hostname();
+			headers['X-Upstream-Hostname'] = os.hostname().replace(/[^0-9A-Za-z-]/g, '');
 		}
 
 		for (const [key, value] of Object.entries(headers)) {


### PR DESCRIPTION
If the os's hostname has invalid characters (must be A-Za-z9-9-), this will fail during local development.