### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/public/src/admin/dashboard.js
+++ b/public/src/admin/dashboard.js
@@ -356,9 +356,9 @@ define('admin/dashboard', [
 						},
 					}).on('shown.bs.modal', function () {
 						const date = new Date();
-						const today = date.toISOString().substr(0, 10);
+						const today = date.toISOString().slice(0, 10);
 						date.setDate(date.getDate() - 1);
-						const yesterday = date.toISOString().substr(0, 10);
+						const yesterday = date.toISOString().slice(0, 10);
 
 						modal.find('#startRange').val(targetEl.attr('data-startRange') || yesterday);
 						modal.find('#endRange').val(targetEl.attr('data-endRange') || today);

--- a/public/src/admin/modules/dashboard-line-graph.js
+++ b/public/src/admin/modules/dashboard-line-graph.js
@@ -112,9 +112,9 @@ define('admin/modules/dashboard-line-graph', ['Chart', 'translator', 'benchpress
 					},
 				}).on('shown.bs.modal', function () {
 					const date = new Date();
-					const today = date.toISOString().substr(0, 10);
+					const today = date.toISOString().slice(0, 10);
 					date.setDate(date.getDate() - 1);
-					const yesterday = date.toISOString().substr(0, 10);
+					const yesterday = date.toISOString().slice(0, 10);
 
 					modal.find('#startRange').val(targetEl.attr('data-startRange') || yesterday);
 					modal.find('#endRange').val(targetEl.attr('data-endRange') || today);

--- a/public/src/client/groups/details.js
+++ b/public/src/client/groups/details.js
@@ -215,7 +215,7 @@ define('forum/groups/details', [
 			api.put(`/groups/${ajaxify.data.group.slug}`, settings).then(() => {
 				if (settings.name) {
 					let pathname = window.location.pathname;
-					pathname = pathname.substr(1, pathname.lastIndexOf('/'));
+					pathname = pathname.slice(1, pathname.lastIndexOf('/') + 1);
 					ajaxify.go(pathname + slugify(settings.name));
 				} else {
 					ajaxify.refresh();

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -335,7 +335,7 @@
 			// see https://github.com/NodeBB/NodeBB/issues/4378
 			tag = tag.replace(/\u202E/gi, '');
 			tag = tag.replace(/[,/#!$^*;:{}=_`<>'"~()?|]/g, '');
-			tag = tag.substr(0, maxLength || 15).trim();
+			tag = tag.slice(0, maxLength || 15).trim();
 			const matches = tag.match(/^[.-]*(.+?)[.-]*$/);
 			if (matches && matches.length > 1) {
 				tag = matches[1];
@@ -652,7 +652,7 @@
 				);
 
 				if (key) {
-					if (key.substr(-2, 2) === '[]') {
+					if (key.slice(-2) === '[]') {
 						key = key.slice(0, -2);
 					}
 					if (!hash[key]) {

--- a/src/api/helpers.js
+++ b/src/api/helpers.js
@@ -40,7 +40,7 @@ exports.buildReqObject = (req, payload) => {
 		protocol: encrypted ? 'https' : 'http',
 		secure: encrypted,
 		url: referer,
-		path: referer.substr(referer.indexOf(host) + host.length),
+		path: referer.slice(referer.indexOf(host) + host.length),
 		headers: headers,
 	};
 };

--- a/src/categories/create.js
+++ b/src/categories/create.js
@@ -88,7 +88,7 @@ module.exports = function (Categories) {
 		await db.sortedSetAddBulk([
 			['categories:cid', category.order, category.cid],
 			[`cid:${parentCid}:children`, category.order, category.cid],
-			['categories:name', 0, `${data.name.substr(0, 200).toLowerCase()}:${category.cid}`],
+			['categories:name', 0, `${data.name.slice(0, 200).toLowerCase()}:${category.cid}`],
 		]);
 
 		await privileges.categories.give(result.defaultPrivileges, category.cid, 'registered-users');

--- a/src/categories/delete.js
+++ b/src/categories/delete.js
@@ -29,7 +29,7 @@ module.exports = function (Categories) {
 	async function purgeCategory(cid, categoryData) {
 		const bulkRemove = [['categories:cid', cid]];
 		if (categoryData && categoryData.name) {
-			bulkRemove.push(['categories:name', `${categoryData.name.substr(0, 200).toLowerCase()}:${cid}`]);
+			bulkRemove.push(['categories:name', `${categoryData.name.slice(0, 200).toLowerCase()}:${cid}`]);
 		}
 		await db.sortedSetRemoveBulk(bulkRemove);
 

--- a/src/categories/update.js
+++ b/src/categories/update.js
@@ -138,8 +138,8 @@ module.exports = function (Categories) {
 
 	async function updateName(cid, newName) {
 		const oldName = await Categories.getCategoryField(cid, 'name');
-		await db.sortedSetRemove('categories:name', `${oldName.substr(0, 200).toLowerCase()}:${cid}`);
-		await db.sortedSetAdd('categories:name', 0, `${newName.substr(0, 200).toLowerCase()}:${cid}`);
+		await db.sortedSetRemove('categories:name', `${oldName.slice(0, 200).toLowerCase()}:${cid}`);
+		await db.sortedSetAdd('categories:name', 0, `${newName.slice(0, 200).toLowerCase()}:${cid}`);
 		await db.setObjectField(`category:${cid}`, 'name', newName);
 	}
 };

--- a/src/controllers/admin/info.js
+++ b/src/controllers/admin/info.js
@@ -140,5 +140,5 @@ async function getGitInfo() {
 		getAsync('git rev-parse HEAD'),
 		getAsync('git rev-parse --abbrev-ref HEAD'),
 	]);
-	return { hash: hash, hashShort: hash.substr(0, 6), branch: branch };
+	return { hash: hash, hashShort: hash.slice(0, 6), branch: branch };
 }

--- a/src/controllers/search.js
+++ b/src/controllers/search.js
@@ -102,7 +102,7 @@ const searches = {};
 async function recordSearch(data) {
 	const { query, searchIn } = data;
 	if (query) {
-		const cleanedQuery = String(query).trim().toLowerCase().substr(0, 255);
+		const cleanedQuery = String(query).trim().toLowerCase().slice(0, 255);
 		if (['titles', 'titlesposts', 'posts'].includes(searchIn) && cleanedQuery.length > 2) {
 			searches[data.uid] = searches[data.uid] || { timeoutId: 0, queries: [] };
 			searches[data.uid].queries.push(cleanedQuery);

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -202,7 +202,7 @@ async function addTags(topicData, req, res) {
 	}
 
 	if (description.length > 255) {
-		description = `${description.substr(0, 255)}...`;
+		description = `${description.slice(0, 255)}...`;
 	}
 	description = description.replace(/\n/g, ' ');
 

--- a/src/controllers/uploads.js
+++ b/src/controllers/uploads.js
@@ -182,7 +182,7 @@ async function saveFileToLocal(uid, folder, uploadedFile) {
 	const name = uploadedFile.name || 'upload';
 	const extension = path.extname(name) || '';
 
-	const filename = `${Date.now()}-${validator.escape(name.substr(0, name.length - extension.length)).substr(0, 255)}${extension}`;
+	const filename = `${Date.now()}-${validator.escape(name.slice(0, -extension.length)).slice(0, 255)}${extension}`;
 
 	const upload = await file.saveFileToLocal(filename, folder, uploadedFile.path);
 	const storedFile = {

--- a/src/database/postgres/sorted.js
+++ b/src/database/postgres/sorted.js
@@ -577,11 +577,11 @@ DELETE FROM "legacy_zset" z
 
 		if (min !== '-') {
 			if (min.match(/^\(/)) {
-				q.values.push(min.substr(1));
+				q.values.push(min.slice(1));
 				q.suffix += 'GT';
 				q.where += ` AND z."value" > $${q.values.length}::TEXT COLLATE "C"`;
 			} else if (min.match(/^\[/)) {
-				q.values.push(min.substr(1));
+				q.values.push(min.slice(1));
 				q.suffix += 'GE';
 				q.where += ` AND z."value" >= $${q.values.length}::TEXT COLLATE "C"`;
 			} else {
@@ -593,11 +593,11 @@ DELETE FROM "legacy_zset" z
 
 		if (max !== '+') {
 			if (max.match(/^\(/)) {
-				q.values.push(max.substr(1));
+				q.values.push(max.slice(1));
 				q.suffix += 'LT';
 				q.where += ` AND z."value" < $${q.values.length}::TEXT COLLATE "C"`;
 			} else if (max.match(/^\[/)) {
-				q.values.push(max.substr(1));
+				q.values.push(max.slice(1));
 				q.suffix += 'LE';
 				q.where += ` AND z."value" <= $${q.values.length}::TEXT COLLATE "C"`;
 			} else {

--- a/src/emailer.js
+++ b/src/emailer.js
@@ -101,7 +101,7 @@ Emailer.getTemplates = async (config) => {
 	emails = emails.filter(email => !email.endsWith('.js'));
 
 	const templates = await Promise.all(emails.map(async (email) => {
-		const path = email.replace(emailsPath, '').substr(1).replace('.tpl', '');
+		const path = email.replace(emailsPath, '').slice(1).replace('.tpl', '');
 		const original = await fs.promises.readFile(email, 'utf8');
 
 		return {

--- a/src/upgrades/1.15.0/consolidate_flags.js
+++ b/src/upgrades/1.15.0/consolidate_flags.js
@@ -32,7 +32,7 @@ module.exports = {
 				}
 
 				methods.push(
-					db.sortedSetAdd.bind(db, `flag:${flagObj.flagId}:reports`, flagObj.datetime, String(flagObj.description).substr(0, 250)),
+					db.sortedSetAdd.bind(db, `flag:${flagObj.flagId}:reports`, flagObj.datetime, String(flagObj.description).slice(0, 250)),
 					db.sortedSetAdd.bind(db, `flag:${flagObj.flagId}:reporters`, flagObj.datetime, flagObj.uid)
 				);
 

--- a/src/upgrades/1.15.0/fullname_search_set.js
+++ b/src/upgrades/1.15.0/fullname_search_set.js
@@ -16,7 +16,7 @@ module.exports = {
 			const userData = await user.getUsersFields(uids, ['uid', 'fullname']);
 			const bulkAdd = userData
 				.filter(u => u.uid && u.fullname)
-				.map(u => ['fullname:sorted', 0, `${String(u.fullname).substr(0, 255).toLowerCase()}:${u.uid}`]);
+				.map(u => ['fullname:sorted', 0, `${String(u.fullname).slice(0, 255).toLowerCase()}:${u.uid}`]);
 			await db.sortedSetAddBulk(bulkAdd);
 		}, {
 			batch: 500,

--- a/src/upgrades/1.17.0/category_name_zset.js
+++ b/src/upgrades/1.17.0/category_name_zset.js
@@ -16,7 +16,7 @@ module.exports = {
 			const bulkAdd = categoryData.map(cat => [
 				'categories:name',
 				0,
-				`${String(cat.name).substr(0, 200).toLowerCase()}:${cat.cid}`,
+				`${String(cat.name).slice(0, 200).toLowerCase()}:${cat.cid}`,
 			]);
 			await db.sortedSetAddBulk(bulkAdd);
 			progress.incr(cids.length);

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1239,7 +1239,7 @@ describe('Controllers', () => {
 				request(`${nconf.get('url')}/me/bookmarks`, { json: true }, (err, res, body) => {
 					assert.ifError(err);
 					assert.equal(res.statusCode, 200);
-					assert(body.includes('Login to your account'), body.substr(0, 500));
+					assert(body.includes('Login to your account'), body.slice(0, 500));
 					done();
 				});
 			});

--- a/test/database/sorted.js
+++ b/test/database/sorted.js
@@ -1491,7 +1491,7 @@ describe('Sorted Set methods', () => {
 			await db.sortedSetAdd('sortedSetLexSearch', [0, 0, 0], ['baris:usakli:1', 'baris usakli:2', 'baris soner:3']);
 			const query = 'baris:';
 			const min = query;
-			const max = query.substr(0, query.length - 1) + String.fromCharCode(query.charCodeAt(query.length - 1) + 1);
+			const max = query.slice(0, -1) + String.fromCharCode(query.charCodeAt(query.length - 1) + 1);
 			const result = await db.getSortedSetRangeByLex('sortedSetLexSearch', min, max, 0, -1);
 			assert.deepStrictEqual(result, ['baris:usakli:1']);
 		});


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.