### PR TITLE
docs: remove the redundant security policy template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,3 @@ contact_links:
   - name: Community Forum
     url: https://community.nodebb.org
     about: Github Issues are for bug reports and feature requests only, please use community forum for other support
-  - name: Security Issues
-    url: https://nodebb.org/bounty/
-    about: |
-      Found a security exploit? Please email us at security@nodebb.org instead for immediate attention. DO NOT SUBMIT VULNERABILITIES TO THE PUBLIC BUG TRACKER


### PR DESCRIPTION
Oh good, an undocumented feature... Seems like the security link is redundant then.
![obraz](https://user-images.githubusercontent.com/25460763/175570200-36ad0281-3076-47b0-ae88-34e00822fd14.png)
