### PR TITLE
fix: remove socket.io cluster adapter

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -123,7 +123,6 @@
         "sitemap": "7.1.1",
         "slideout": "1.0.1",
         "socket.io": "4.5.1",
-        "socket.io-adapter-cluster": "1.0.1",
         "socket.io-client": "4.5.1",
         "@socket.io/redis-adapter": "7.2.0",
         "sortablejs": "1.15.0",


### PR DESCRIPTION
resolves #10741 

It's just a small non-breaking change (since the package wasn't used and I think it won't be removed from existing installations on upgrade anyway), so I think it can go to `master`.