### PR TITLE
types: add types for database abstration layer

### DIFF
--- a/types/hash.ts
+++ b/types/hash.ts
@@ -1,0 +1,56 @@
+export interface HashQueryable {
+  decrObjectField(
+    key: string | string[],
+    field: string,
+  ): Promise<number | number[]>
+
+  deleteObjectField(key: string, field: string): Promise<void>
+
+  deleteObjectFields(key: string, fields: string[]): Promise<void>
+
+  getObject(key: string, fields: string[]): Promise<object>
+
+  getObjectField(key: string, field: string): Promise<any>
+
+  getObjectFields(key: string, fields: string[]): Promise<Record<string, any>>
+
+  getObjectKeys(key: string): Promise<string[]>
+
+  getObjectValues(key: string): Promise<any[]>
+
+  getObjects(keys: string[], fields: string[]): Promise<any[]>
+
+  getObjectsFields(
+    keys: string[],
+    fields: string[],
+  ): Promise<Record<string, any>[]>
+
+  incrObjectField(
+    key: string | string[],
+    field: string,
+  ): Promise<number | number[]>
+
+  incrObjectFieldBy(
+    key: string | string[],
+    field: string,
+    value: number,
+  ): Promise<number | number[]>
+
+  incrObjectFieldByBulk(
+    data: [key: string, batch: Record<string, number>][],
+  ): Promise<void>
+
+  isObjectField(key: string, field: string): Promise<boolean>
+
+  isObjectFields(key: string, fields: string[]): Promise<boolean[]>
+
+  setObject(key: string | string[], data: Record<string, any>): Promise<void>
+
+  setObjectBulk(args: [key: string, data: Record<string, any>][]): Promise<void>
+
+  setObjectField(
+    key: string | string[],
+    field: string,
+    value: any,
+  ): Promise<void>
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,58 @@
+import { Store } from 'express-session'
+
+export { HashQueryable } from './hash'
+export { ListQueryable } from './list'
+export { HashSetQueryable } from './set'
+export { StringQueryable } from './string'
+export {
+  SortedSetQueryable,
+  SortedSetTheoryOperation,
+  SortedSetScanBaseParameters,
+} from './zset'
+
+export interface INodeBBDatabaseBackend {
+  checkCompatibility(callback: () => void): Promise<void>
+
+  checkCompatibilityVersion(
+    version: string,
+    callback: () => void,
+  ): Promise<void>
+
+  close(): Promise<void>
+
+  createIndices(callback: () => void): Promise<void>
+
+  createSessionStore(options: any): Promise<Store>
+
+  emptydb(): Promise<void>
+
+  flushdb(): Promise<void>
+
+  info(db: any): Promise<any>
+
+  init(): Promise<void>
+}
+
+export type RedisStyleMatchString =
+  | string
+  | `*${string}`
+  | `${string}*`
+  | `*${string}*`
+export type RedisStyleRangeString = `${'(' | '['}${number}`
+export type RedisStyleRangeStringWithLex =
+  | RedisStyleRangeString
+  | '-inf'
+  | '+inf'
+
+export enum ObjectType {
+  HASH = 'hash',
+  LIST = 'list',
+  SET = 'set',
+  STRING = 'string',
+  SORTED_SET = 'zset',
+}
+
+export type ValueAndScore = { value: string; score: number }
+export type RedisStyleAggregate = 'SUM' | 'MIN' | 'MAX'
+export type NumberTowardsMinima = number | '-inf'
+export type NumberTowardsMaxima = number | '+inf'

--- a/types/list.ts
+++ b/types/list.ts
@@ -1,0 +1,15 @@
+export interface ListQueryable {
+  listPrepend(key: string, value: string): Promise<void>
+
+  listAppend(key: string, value: string): Promise<void>
+
+  listRemoveLast(key: string): Promise<any>
+
+  listRemoveAll(key: string, value: string | string[]): Promise<void>
+
+  listTrim(key: string, start: number, stop: number): Promise<void>
+
+  getListRange(key: string, start: number, stop: number): Promise<any[]>
+
+  listLength(key: string): Promise<number>
+}

--- a/types/set.ts
+++ b/types/set.ts
@@ -1,0 +1,25 @@
+export interface HashSetQueryable {
+  getSetMembers(key: string): Promise<string[]>
+
+  getSetsMembers(keys: string[]): Promise<string[][]>
+
+  isMemberOfSets(sets: string[], value: string): Promise<boolean[]>
+
+  isSetMember(key: string, value: string): Promise<boolean>
+
+  isSetMembers(key: string, values: string[]): Promise<boolean[]>
+
+  setAdd(key: string, value: string | string[]): Promise<void>
+
+  setCount(key: string): Promise<number>
+
+  setRemove(key: string | string[], value: string | string[]): Promise<void>
+
+  setRemoveRandom(key: string): Promise<string>
+
+  setsAdd(keys: string[], value: string | string[]): Promise<void>
+
+  setsCount(keys: string[]): Promise<number[]>
+
+  setsRemove(keys: string[], value: string): Promise<void>
+}

--- a/types/string.ts
+++ b/types/string.ts
@@ -1,0 +1,35 @@
+import { ObjectType, RedisStyleMatchString } from './index'
+
+export interface StringQueryable {
+  delete(key: string): Promise<void>
+
+  deleteAll(keys: string[]): Promise<void>
+
+  exists(key: string): Promise<boolean>
+
+  exists(key: string[]): Promise<boolean[]>
+
+  expire(key: string, seconds: number): Promise<void>
+
+  expireAt(key: string, timestampInSeconds: number): Promise<void>
+
+  get(key: string): Promise<string | null>
+
+  increment(key: string): Promise<number>
+
+  pexpire(key: string, ms: number): Promise<void>
+
+  pexpireAt(key: string, timestampInMs: number): Promise<void>
+
+  pttl(key: string): Promise<number>
+
+  rename(oldkey: string, newkey: string): Promise<void>
+
+  scan(params: { match: RedisStyleMatchString }): Promise<string[]>
+
+  set(key: string, value: string): Promise<void>
+
+  ttl(key: string): Promise<number>
+
+  type(key: string): Promise<ObjectType>
+}

--- a/types/zset.ts
+++ b/types/zset.ts
@@ -1,0 +1,240 @@
+import {
+  NumberTowardsMaxima,
+  NumberTowardsMinima,
+  RedisStyleAggregate,
+  RedisStyleMatchString,
+  RedisStyleRangeString,
+  ValueAndScore,
+} from './index'
+
+export type SortedSetTheoryOperation = {
+  sets: string[]
+  start?: number
+  stop?: number
+  weights?: number[]
+  aggregate?: RedisStyleAggregate
+}
+
+export type SortedSetScanBaseParameters = {
+  key: string
+  match: RedisStyleMatchString
+  limit: number
+}
+
+export interface SortedSetQueryable {
+  getSortedSetIntersect(
+    params: SortedSetTheoryOperation & { withScores: true },
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetIntersect(
+    params: SortedSetTheoryOperation & { withScores: false },
+  ): Promise<string[]>
+
+  getSortedSetMembers(key: string): Promise<string[]>
+
+  getSortedSetRange(
+    key: string | string[],
+    start: number,
+    stop: number,
+  ): Promise<string[]>
+
+  getSortedSetRangeByLex(
+    key: string | string[],
+    min: RedisStyleRangeString,
+    max: RedisStyleRangeString,
+    start: number,
+    count: number,
+  ): Promise<string[]>
+
+  getSortedSetRangeByScore(
+    key: string | string[],
+    start: number,
+    count: number,
+    min: NumberTowardsMinima,
+    max: NumberTowardsMaxima,
+  ): Promise<string[]>
+
+  getSortedSetRangeByScoreWithScores(
+    key: string | string[],
+    start: number,
+    count: number,
+    min: NumberTowardsMinima,
+    max: NumberTowardsMaxima,
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetRangeWithScores(
+    key: string | string[],
+    start: number,
+    stop: number,
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetRevIntersect(
+    params: SortedSetTheoryOperation & { withScores: true },
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetRevIntersect(
+    params: SortedSetTheoryOperation & { withScores: false },
+  ): Promise<string[]>
+
+  getSortedSetRevRange(
+    key: string | string[],
+    start: number,
+    stop: number,
+  ): Promise<string[]>
+
+  getSortedSetRevRangeByLex(
+    key: string,
+    max: RedisStyleRangeString,
+    min: RedisStyleRangeString,
+    start: number,
+    count: number,
+  ): Promise<string[]>
+
+  getSortedSetRevRangeByScore(
+    key: string,
+    start: number,
+    count: number,
+    max: NumberTowardsMaxima,
+    min: NumberTowardsMinima,
+  ): Promise<string[]>
+
+  getSortedSetRevRangeByScoreWithScores(
+    key: string,
+    start: number,
+    count: number,
+    max: NumberTowardsMaxima,
+    min: NumberTowardsMinima,
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetRevRangeWithScores(
+    key: string,
+    start: number,
+    stop: number,
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetRevUnion(
+    params: SortedSetTheoryOperation & { withScores: false },
+  ): Promise<string[]>
+
+  getSortedSetRevUnion(
+    params: SortedSetTheoryOperation & { withScores: true },
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetScan(
+    params: SortedSetScanBaseParameters & { withScores: true },
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetScan(
+    params: SortedSetScanBaseParameters & { withScores: false },
+  ): Promise<string[]>
+
+  getSortedSetUnion(
+    params: SortedSetTheoryOperation & { withScores: true },
+  ): Promise<ValueAndScore[]>
+
+  getSortedSetUnion(
+    params: SortedSetTheoryOperation & { withScores: false },
+  ): Promise<string[]>
+
+  getSortedSetsMembers(keys: string[]): Promise<string[][]>
+
+  isMemberOfSortedSets(keys: string[], value: string): Promise<boolean[]>
+
+  isSortedSetMember(key: string, value: string): Promise<boolean>
+
+  isSortedSetMembers(key: string, values: string[]): Promise<boolean[]>
+
+  processSortedSet(
+    setKey: string,
+    processFn: (ids: number[]) => Promise<void> | void,
+    options: { withScores?: boolean; batch?: number; interval?: number },
+  ): Promise<any>
+
+  sortedSetAdd(key: string, score: number, value: string): Promise<void>
+
+  sortedSetAdd(key: string, score: number[], value: string[]): Promise<void>
+
+  sortedSetAddBulk(
+    args: [key: string, score: number[], value: string[]][],
+  ): Promise<void>
+
+  sortedSetCard(key: string): Promise<number>
+
+  sortedSetCount(
+    key: string,
+    min: NumberTowardsMinima,
+    max: NumberTowardsMaxima,
+  ): Promise<number>
+
+  sortedSetIncrBy(
+    key: string,
+    increment: number,
+    value: string,
+  ): Promise<number>
+
+  sortedSetIncrByBulk(
+    data: [key: string, increment: number, value: string][],
+  ): Promise<number[]>
+
+  sortedSetIntersectCard(keys: string[]): Promise<number>
+
+  sortedSetLexCount(
+    key: string,
+    min: RedisStyleRangeString,
+    max: RedisStyleRangeString,
+  ): Promise<number>
+
+  sortedSetRank(key: string, value: string): Promise<number>
+
+  sortedSetRanks(key: string, values: string[]): Promise<number[]>
+
+  sortedSetRemove(
+    key: string | string[],
+    value: string | string[],
+  ): Promise<void>
+
+  sortedSetRemoveBulk(data: [key: string, member: string][]): Promise<void>
+
+  sortedSetRemoveRangeByLex(
+    key: string,
+    min: RedisStyleRangeString,
+    max: RedisStyleRangeString,
+  ): Promise<void>
+
+  sortedSetRevRank(key: string, value: string): Promise<number>
+
+  sortedSetRevRanks(key: string, values: string[]): Promise<number[]>
+
+  sortedSetScore(key: string, value: string): Promise<number | null>
+
+  sortedSetScores(key: string, values: string[]): Promise<number[]>
+
+  sortedSetUnionCard(keys: string[]): Promise<number>
+
+  sortedSetsAdd(
+    keys: string[],
+    scores: number | number[],
+    value: string,
+  ): Promise<void>
+
+  sortedSetsCard(keys: string[]): Promise<number[]>
+
+  sortedSetsCardSum(keys: string[]): Promise<number>
+
+  sortedSetsRanks<T extends readonly [] | readonly string[]>(
+    keys: T,
+    values: { [K in keyof T]: string },
+  ): Promise<number[]>
+
+  sortedSetsRemove(keys: string[], value: string): Promise<void>
+
+  sortedSetsRemoveRangeByScore(
+    keys: string[],
+    min: NumberTowardsMinima,
+    max: NumberTowardsMaxima,
+  ): Promise<void>
+
+  sortedSetsRevRanks(keys: string[], values: string[]): Promise<number[]>
+
+  sortedSetsScore(keys: string[], value: string): Promise<number[]>
+}


### PR DESCRIPTION
This is a simple type deduction for the database interface, which is used for my own (closed source and premium plugin atm sorry) database integration based on TypeORM. 

But technically, anyone can use all of these interfaces to implement a full-blown database backend, but some unexpected use and arguments are still missing. Thus this is still in draft state.

Signed-off-by: steve <29133953+stevefan1999-personal@users.noreply.github.com>