### PR TITLE
Add plugin.js support

### DIFF
--- a/src/plugins/data.js
+++ b/src/plugins/data.js
@@ -28,15 +28,25 @@ Data.getPluginPaths = async function () {
 };
 
 Data.loadPluginInfo = async function (pluginPath) {
+	const pluginJsonPath = path.join(pluginPath, 'plugin.json');
+	const pluginJsPath = path.join(pluginPath, 'plugin.js');
+
+	let [hasPluginJson, hasPluginJs] = await Promise.all([pluginJsonPath, pluginJsPath].map(file.exists));
+
 	const [packageJson, pluginJson] = await Promise.all([
 		fs.promises.readFile(path.join(pluginPath, 'package.json'), 'utf8'),
-		fs.promises.readFile(path.join(pluginPath, 'plugin.json'), 'utf8'),
+		hasPluginJson ? fs.promises.readFile(pluginJsonPath, 'utf8') : Promise.resolve(null),
 	]);
 
 	let pluginData;
 	let packageData;
 	try {
-		pluginData = JSON.parse(pluginJson);
+		if (hasPluginJson && pluginJson && typeof pluginJson === "string") {
+			pluginData = JSON.parse(pluginJson)
+		} else if (hasPluginJs) {
+			pluginData = require(pluginJsPath)
+		}
+
 		packageData = JSON.parse(packageJson);
 
 		pluginData.license = parseLicense(packageData);
@@ -51,7 +61,7 @@ Data.loadPluginInfo = async function (pluginPath) {
 	} catch (err) {
 		const pluginDir = path.basename(pluginPath);
 
-		winston.error(`[plugins/${pluginDir}] Error in plugin.json or package.json!${err.stack}`);
+		winston.error(`[plugins/${pluginDir}] Error in plugin.${hasPluginJson ? "json" : "js"} or package.json!${err.stack}`);
 		throw new Error('[[error:parse-error]]');
 	}
 	return pluginData;
@@ -208,6 +218,7 @@ Data.getModules = async function getModules(pluginData) {
 	}
 
 	const modules = {};
+
 	async function processModule(key) {
 		const modulePath = await resolveModulePath(pluginData.path, pluginModules[key]);
 		if (modulePath) {


### PR DESCRIPTION
Sometimes it would be better to use a full blown script for plugin manifest because we can use it to resolve some complicated stuff and future type stubs for code safety. This practice is basically everywhere. SWC, ESLint, Mocha, Jest all allows such use.

For my own sake, this also added a slightly good benefit of lexicographically sorting the fields thanks to ESLint. My OCD hits when I see the fields not being sorted from A to Z.

Missing
- Tests
- Examples