### PR TITLE
feat: Allow defining active plugins in config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,10 @@ module.exports = function (grunt) {
 		let plugins = [];
 		if (!process.argv.includes('--core')) {
 			await db.init();
-			plugins = await db.getSortedSetRange('plugins:active', 0, -1);
+			plugins = nconf.get('plugins:active');
+			if (!plugins) {
+				plugins = await db.getSortedSetRange('plugins:active', 0, -1);
+			}
 			addBaseThemes(plugins);
 			if (!plugins.includes('nodebb-plugin-composer-default')) {
 				plugins.push('nodebb-plugin-composer-default');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,6 +20,7 @@ const prestart = require('./src/prestart');
 prestart.loadConfig(configFile);
 
 const db = require('./src/database');
+const plugins = require('./src/plugins');
 
 module.exports = function (grunt) {
 	const args = [];
@@ -40,38 +41,35 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('init', async function () {
 		const done = this.async();
-		let plugins = [];
+		let pluginList = [];
 		if (!process.argv.includes('--core')) {
 			await db.init();
-			plugins = nconf.get('plugins:active');
-			if (!plugins) {
-				plugins = await db.getSortedSetRange('plugins:active', 0, -1);
+			pluginList = await plugins.getActive();
+			addBaseThemes(pluginList);
+			if (!pluginList.includes('nodebb-plugin-composer-default')) {
+				pluginList.push('nodebb-plugin-composer-default');
 			}
-			addBaseThemes(plugins);
-			if (!plugins.includes('nodebb-plugin-composer-default')) {
-				plugins.push('nodebb-plugin-composer-default');
-			}
-			if (!plugins.includes('nodebb-theme-persona')) {
-				plugins.push('nodebb-theme-persona');
+			if (!pluginList.includes('nodebb-theme-persona')) {
+				pluginList.push('nodebb-theme-persona');
 			}
 		}
 
-		const styleUpdated_Client = plugins.map(p => `node_modules/${p}/*.less`)
-			.concat(plugins.map(p => `node_modules/${p}/*.css`))
-			.concat(plugins.map(p => `node_modules/${p}/+(public|static|less)/**/*.less`))
-			.concat(plugins.map(p => `node_modules/${p}/+(public|static)/**/*.css`));
+		const styleUpdated_Client = pluginList.map(p => `node_modules/${p}/*.less`)
+			.concat(pluginList.map(p => `node_modules/${p}/*.css`))
+			.concat(pluginList.map(p => `node_modules/${p}/+(public|static|less)/**/*.less`))
+			.concat(pluginList.map(p => `node_modules/${p}/+(public|static)/**/*.css`));
 
-		const styleUpdated_Admin = plugins.map(p => `node_modules/${p}/*.less`)
-			.concat(plugins.map(p => `node_modules/${p}/*.css`))
-			.concat(plugins.map(p => `node_modules/${p}/+(public|static|less)/**/*.less`))
-			.concat(plugins.map(p => `node_modules/${p}/+(public|static)/**/*.css`));
+		const styleUpdated_Admin = pluginList.map(p => `node_modules/${p}/*.less`)
+			.concat(pluginList.map(p => `node_modules/${p}/*.css`))
+			.concat(pluginList.map(p => `node_modules/${p}/+(public|static|less)/**/*.less`))
+			.concat(pluginList.map(p => `node_modules/${p}/+(public|static)/**/*.css`));
 
-		const clientUpdated = plugins.map(p => `node_modules/${p}/+(public|static)/**/*.js`);
-		const serverUpdated = plugins.map(p => `node_modules/${p}/*.js`)
-			.concat(plugins.map(p => `node_modules/${p}/+(lib|src)/**/*.js`));
+		const clientUpdated = pluginList.map(p => `node_modules/${p}/+(public|static)/**/*.js`);
+		const serverUpdated = pluginList.map(p => `node_modules/${p}/*.js`)
+			.concat(pluginList.map(p => `node_modules/${p}/+(lib|src)/**/*.js`));
 
-		const templatesUpdated = plugins.map(p => `node_modules/${p}/+(public|static|templates)/**/*.tpl`);
-		const langUpdated = plugins.map(p => `node_modules/${p}/+(public|static|languages)/**/*.json`);
+		const templatesUpdated = pluginList.map(p => `node_modules/${p}/+(public|static|templates)/**/*.tpl`);
+		const langUpdated = pluginList.map(p => `node_modules/${p}/+(public|static|languages)/**/*.json`);
 
 		grunt.config(['watch'], {
 			styleUpdated_Client: {
@@ -198,10 +196,10 @@ module.exports = function (grunt) {
 	});
 };
 
-function addBaseThemes(plugins) {
-	let themeId = plugins.find(p => p.includes('nodebb-theme-'));
+function addBaseThemes(pluginList) {
+	let themeId = pluginList.find(p => p.includes('nodebb-theme-'));
 	if (!themeId) {
-		return plugins;
+		return pluginList;
 	}
 	let baseTheme;
 	do {
@@ -212,9 +210,9 @@ function addBaseThemes(plugins) {
 		}
 
 		if (baseTheme) {
-			plugins.push(baseTheme);
+			pluginList.push(baseTheme);
 			themeId = baseTheme;
 		}
 	} while (baseTheme);
-	return plugins;
+	return pluginList;
 }

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ if (nconf.get('setup') || nconf.get('install')) {
 	});
 } else if (nconf.get('activate')) {
 	require('./src/cli/manage').activate(nconf.get('activate'));
-} else if (nconf.get('plugins')) {
+} else if (nconf.get('plugins') && typeof nconf.get('plugins') !== 'object') {
 	require('./src/cli/manage').listPlugins();
 } else if (nconf.get('build')) {
 	require('./src/cli/manage').build(nconf.get('build'));

--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -154,6 +154,7 @@
     "digestHour": 17,
     "passwordExpiryDays": 0,
     "cross-origin-embedder-policy": 0,
+    "cross-origin-opener-policy": "same-origin",
     "cross-origin-resource-policy": "same-origin",
     "hsts-maxage": 31536000,
     "hsts-subdomains": 0,

--- a/public/language/ar/admin/settings/advanced.json
+++ b/public/language/ar/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/bg/admin/settings/advanced.json
+++ b/public/language/bg/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "Когато е включено (по подразбиране), стойността на заглавката ще бъде <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Стриктна транспортна сигурност",
 	"hsts.enabled": "Включване на HSTS (препоръчително)",

--- a/public/language/bn/admin/settings/advanced.json
+++ b/public/language/bn/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/cs/admin/settings/advanced.json
+++ b/public/language/cs/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Přísné zabezpečení přenosu",
 	"hsts.enabled": "Povolit HSTS (doporučeno)",

--- a/public/language/da/admin/settings/advanced.json
+++ b/public/language/da/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/de/admin/settings/advanced.json
+++ b/public/language/de/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Richtlinie",
 	"headers.coep-help": "Wenn aktiviert (Standard), wird der Header auf <code>require-corp</code> gesetzt",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "HSTS Aktivieren (empfohlen)",

--- a/public/language/el/admin/settings/advanced.json
+++ b/public/language/el/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/en-GB/admin/settings/advanced.json
+++ b/public/language/en-GB/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -242,6 +242,7 @@
 
 	"plugin-not-whitelisted": "Unable to install plugin &ndash; only plugins whitelisted by the NodeBB Package Manager can be installed via the ACP",
 	"plugins-set-in-configuration": "Cannot change plugin state while it is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead",
+	"theme-not-set-in-configuration": "When defining active plugins in configuration, changing themes requires adding the new theme to the list of active plugins before updating it in the ACP",
 
 	"topic-event-unrecognized": "Topic event '%1' unrecognized",
 

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -241,7 +241,7 @@
 	"socket-reconnect-failed": "Unable to reach the server at this time. Click here to try again, or try again later",
 
 	"plugin-not-whitelisted": "Unable to install plugin &ndash; only plugins whitelisted by the NodeBB Package Manager can be installed via the ACP",
-	"plugins-set-in-configuration": "Cannot change plugin state while it is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead",
+	"plugins-set-in-configuration": "Cannot change plugin state as they are defined at runtime (config.json, environmental variables or terminal arguments), please modify the configuration instead",
 	"theme-not-set-in-configuration": "When defining active plugins in configuration, changing themes requires adding the new theme to the list of active plugins before updating it in the ACP",
 
 	"topic-event-unrecognized": "Topic event '%1' unrecognized",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -241,7 +241,7 @@
 	"socket-reconnect-failed": "Unable to reach the server at this time. Click here to try again, or try again later",
 
 	"plugin-not-whitelisted": "Unable to install plugin &ndash; only plugins whitelisted by the NodeBB Package Manager can be installed via the ACP",
-	"plugins-set-in-configuration": "Cannot change plugin state as they are defined at runtime (config.json, environmental variables or terminal arguments), please modify the configuration instead",
+	"plugins-set-in-configuration": "You are not allowed to change plugin state as they are defined at runtime (config.json, environmental variables or terminal arguments), please modify the configuration instead.",
 	"theme-not-set-in-configuration": "When defining active plugins in configuration, changing themes requires adding the new theme to the list of active plugins before updating it in the ACP",
 
 	"topic-event-unrecognized": "Topic event '%1' unrecognized",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -241,6 +241,7 @@
 	"socket-reconnect-failed": "Unable to reach the server at this time. Click here to try again, or try again later",
 
 	"plugin-not-whitelisted": "Unable to install plugin &ndash; only plugins whitelisted by the NodeBB Package Manager can be installed via the ACP",
+	"plugins-set-in-configuration": "Cannot change plugin state while it is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead",
 
 	"topic-event-unrecognized": "Topic event '%1' unrecognized",
 

--- a/public/language/en-US/admin/settings/advanced.json
+++ b/public/language/en-US/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/en-x-pirate/admin/settings/advanced.json
+++ b/public/language/en-x-pirate/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/es/admin/settings/advanced.json
+++ b/public/language/es/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Seguridad estricta del transporte",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/et/admin/settings/advanced.json
+++ b/public/language/et/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/fa-IR/admin/settings/advanced.json
+++ b/public/language/fa-IR/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/fi/admin/settings/advanced.json
+++ b/public/language/fi/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/fr/admin/settings/advanced.json
+++ b/public/language/fr/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "\nAccess-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "Lorsqu'il est activé (par défaut), définira l'en-tête sur <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Activer HSTS  (recommandé)",

--- a/public/language/gl/admin/settings/advanced.json
+++ b/public/language/gl/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/he/admin/settings/advanced.json
+++ b/public/language/he/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/hr/admin/settings/advanced.json
+++ b/public/language/hr/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/hu/admin/settings/advanced.json
+++ b/public/language/hu/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Szigorú HTTP biztonság (HSTS)",
 	"hsts.enabled": "Szigorú HTTP biztonság (HSTS) bekapcsolása (ajánlott)",

--- a/public/language/id/admin/settings/advanced.json
+++ b/public/language/id/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/it/admin/settings/advanced.json
+++ b/public/language/it/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "Se abilitato (impostazione predefinita), imposterà l'intestazione su <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Rigorosa sicurezza trasporto",
 	"hsts.enabled": "Abilita HSTS (consigliato)",

--- a/public/language/ja/admin/settings/advanced.json
+++ b/public/language/ja/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "アクセス-制御-有効-ヘッダー",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/ko/admin/settings/advanced.json
+++ b/public/language/ko/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "HSTS 활성화 (권장)",

--- a/public/language/lt/admin/settings/advanced.json
+++ b/public/language/lt/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/lv/admin/settings/advanced.json
+++ b/public/language/lv/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "HTTP Strict Transport Security (HSTS)",
 	"hsts.enabled": "Iespējots HSTS (ieteicams)",

--- a/public/language/ms/admin/settings/advanced.json
+++ b/public/language/ms/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/nb/admin/settings/advanced.json
+++ b/public/language/nb/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/nl/admin/settings/advanced.json
+++ b/public/language/nl/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/pl/admin/settings/advanced.json
+++ b/public/language/pl/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Kontrola-Dostępu-Zezwól-Nagłówki",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Włączony HSTS (zalecane)",

--- a/public/language/pt-BR/admin/settings/advanced.json
+++ b/public/language/pt-BR/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Habilitar HSTS (recomendado)",

--- a/public/language/pt-PT/admin/settings/advanced.json
+++ b/public/language/pt-PT/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/ro/admin/settings/advanced.json
+++ b/public/language/ro/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/ru/admin/settings/advanced.json
+++ b/public/language/ru/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Строгая политика безопасности транспортного уровня",
 	"hsts.enabled": "Включить HSTS (рекомендуется)",

--- a/public/language/rw/admin/settings/advanced.json
+++ b/public/language/rw/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/sc/admin/settings/advanced.json
+++ b/public/language/sc/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/sk/admin/settings/advanced.json
+++ b/public/language/sk/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Prísne zabezpečenie prenosu",
 	"hsts.enabled": "Povoliť HSTS (odporúčané)",

--- a/public/language/sl/admin/settings/advanced.json
+++ b/public/language/sl/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Omogočen HSTS (priporočeno)",

--- a/public/language/sq-AL/admin/settings/advanced.json
+++ b/public/language/sq-AL/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/sr/admin/settings/advanced.json
+++ b/public/language/sr/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/sv/admin/settings/advanced.json
+++ b/public/language/sv/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/th/admin/settings/advanced.json
+++ b/public/language/th/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/tr/admin/settings/advanced.json
+++ b/public/language/tr/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Erişim-Kontrolü-Başlık-İzni",
 	"headers.coep": "Cross-Origin-Embed Politikası",
 	"headers.coep-help": "Etkinleştirildiğinde (varsayılan), başlığı  <code>require-corp</code> olarak ayarlayacaktır.",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin Kaynak Politikası",
 	"hsts": "STS",
 	"hsts.enabled": "HSTS'yi etkinleştir (önerilir)",

--- a/public/language/uk/admin/settings/advanced.json
+++ b/public/language/uk/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Strict Transport Security",
 	"hsts.enabled": "Enabled HSTS (recommended)",

--- a/public/language/vi/admin/settings/advanced.json
+++ b/public/language/vi/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "Khi được bật (mặc định), sẽ đặt tiêu đề thành <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "Bảo Vệ Truyền Tải Nghiêm Ngặt",
 	"hsts.enabled": "Đã bật HSTS (đề nghị)",

--- a/public/language/zh-CN/admin/settings/advanced.json
+++ b/public/language/zh-CN/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "严格安全传输（HSTS）",
 	"hsts.enabled": "启用HSTS（推荐）",

--- a/public/language/zh-TW/admin/settings/advanced.json
+++ b/public/language/zh-TW/admin/settings/advanced.json
@@ -17,6 +17,7 @@
 	"headers.acah": "Access-Control-Allow-Headers",
 	"headers.coep": "Cross-Origin-Embedder-Policy",
 	"headers.coep-help": "When enabled (default), will set the header to <code>require-corp</code>",
+	"headers.coop": "Cross-Origin-Opener-Policy",
 	"headers.corp": "Cross-Origin-Resource-Policy",
 	"hsts": "嚴格安全傳輸",
 	"hsts.enabled": "啟用HSTS（推薦）",

--- a/src/cli/manage.js
+++ b/src/cli/manage.js
@@ -41,7 +41,7 @@ async function activate(plugin) {
 		}
 		if (nconf.get('plugins:active')) {
 			winston.error('Cannot activate plugins while plugin state configuration is set, please change your active configuration (config.json, environmental variables or terminal arguments) instead');
-			process.exit(0);
+			process.exit(1);
 		}
 		const numPlugins = await db.sortedSetCard('plugins:active');
 		winston.info('Activating plugin `%s`', plugin);
@@ -62,10 +62,7 @@ async function listPlugins() {
 	await db.init();
 	const installed = await plugins.showInstalled();
 	const installedList = installed.map(plugin => plugin.name);
-	let active = nconf.get('plugins:active');
-	if (!active) {
-		active = await db.getSortedSetRange('plugins:active', 0, -1);
-	}
+	const active = await plugins.getActive();
 	// Merge the two sets, defer to plugins in  `installed` if already present
 	const combined = installed.concat(active.reduce((memo, cur) => {
 		if (!installedList.includes(cur)) {

--- a/src/cli/manage.js
+++ b/src/cli/manage.js
@@ -127,7 +127,7 @@ async function info() {
 			console.log(`        version: ${info.version}`);
 			console.log(`        engine:  ${info.storageEngine}`);
 			break;
-		case 'postges':
+		case 'postgres':
 			console.log(`        version: ${info.version}`);
 			console.log(`        uptime:  ${info.uptime}`);
 			break;

--- a/src/cli/manage.js
+++ b/src/cli/manage.js
@@ -112,13 +112,12 @@ async function info() {
 	const hash = childProcess.execSync('git rev-parse HEAD');
 	console.log(`  git hash: ${hash}`);
 
-	const config = require('../../config.json');
-	console.log(`  database: ${config.database}`);
+	console.log(`  database: ${nconf.get('database')}`);
 
 	await db.init();
 	const info = await db.info(db.client);
 
-	switch (config.database) {
+	switch (nconf.get('database')) {
 		case 'redis':
 			console.log(`        version: ${info.redis_version}`);
 			console.log(`        disk sync:  ${info.rdb_last_bgsave_status}`);
@@ -127,6 +126,10 @@ async function info() {
 		case 'mongo':
 			console.log(`        version: ${info.version}`);
 			console.log(`        engine:  ${info.storageEngine}`);
+			break;
+		case 'postges':
+			console.log(`        version: ${info.version}`);
+			console.log(`        uptime:  ${info.uptime}`);
 			break;
 	}
 

--- a/src/cli/reset.js
+++ b/src/cli/reset.js
@@ -4,6 +4,7 @@ const path = require('path');
 const winston = require('winston');
 const fs = require('fs');
 const chalk = require('chalk');
+const nconf = require('nconf');
 
 const db = require('../database');
 const events = require('../events');
@@ -118,6 +119,10 @@ async function resetThemeTo(themeId) {
 
 async function resetPlugin(pluginId) {
 	try {
+		if (!nconf.get('plugins:active')) {
+			winston.error('Cannot reset plugins while plugin state is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead');
+			process.exit(1);
+		}
 		const isActive = await db.isSortedSetMember('plugins:active', pluginId);
 		if (isActive) {
 			await db.sortedSetRemove('plugins:active', pluginId);
@@ -137,6 +142,10 @@ async function resetPlugin(pluginId) {
 }
 
 async function resetPlugins() {
+	if (!nconf.get('plugins:active')) {
+		winston.error('Cannot reset plugins while plugin state is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead');
+		process.exit(1);
+	}
 	await db.delete('plugins:active');
 	winston.info('[reset] All Plugins De-activated');
 }

--- a/src/cli/reset.js
+++ b/src/cli/reset.js
@@ -119,7 +119,7 @@ async function resetThemeTo(themeId) {
 
 async function resetPlugin(pluginId) {
 	try {
-		if (!nconf.get('plugins:active')) {
+		if (nconf.get('plugins:active')) {
 			winston.error('Cannot reset plugins while plugin state is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead');
 			process.exit(1);
 		}
@@ -142,7 +142,7 @@ async function resetPlugin(pluginId) {
 }
 
 async function resetPlugins() {
-	if (!nconf.get('plugins:active')) {
+	if (nconf.get('plugins:active')) {
 		winston.error('Cannot reset plugins while plugin state is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead');
 		process.exit(1);
 	}

--- a/src/controllers/accounts/helpers.js
+++ b/src/controllers/accounts/helpers.js
@@ -28,7 +28,7 @@ helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {})
 	}
 	await parseAboutMe(results.userData);
 
-	const { userData } = results;
+	let { userData } = results;
 	const { userSettings } = results;
 	const { isAdmin } = results;
 	const { isGlobalModerator } = results;
@@ -41,17 +41,8 @@ helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {})
 		userData.birthday ? Math.floor((new Date().getTime() - new Date(userData.birthday).getTime()) / 31536000000) : 0
 	);
 
-	userData.emailClass = 'hide';
-
-	if (!results.canEdit && (!userSettings.showemail || meta.config.hideEmail)) {
-		userData.email = '';
-	} else if (!userSettings.showemail) {
-		userData.emailClass = '';
-	}
-
-	if (!results.canEdit && (!userSettings.showfullname || meta.config.hideFullname)) {
-		userData.fullname = '';
-	}
+	userData = await user.hidePrivateData(userData, callerUID);
+	userData.emailClass = userSettings.showemail ? 'hide' : '';
 
 	if (isAdmin || isSelf || (canViewInfo && !results.isTargetAdmin)) {
 		userData.ips = results.ips;

--- a/src/controllers/admin/plugins.js
+++ b/src/controllers/admin/plugins.js
@@ -35,6 +35,7 @@ pluginsController.get = async function (req, res) {
 		installedCount: installedPlugins.length,
 		activeCount: activePlugins.length,
 		inactiveCount: Math.max(0, installedPlugins.length - activePlugins.length),
+		canChangeState: !nconf.get('plugins:active'),
 		upgradeCount: compatible.reduce((count, current) => {
 			if (current.installed && current.outdated) {
 				count += 1;

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -357,10 +357,14 @@ helpers.getSelectedCategory = async function (cids) {
 };
 
 helpers.trimChildren = function (category) {
-	if (Array.isArray(category.children)) {
+	if (category && Array.isArray(category.children)) {
 		category.children = category.children.slice(0, category.subCategoriesPerPage);
 		category.children.forEach((child) => {
-			child.children = undefined;
+			if (category.isSection) {
+				helpers.trimChildren(child);
+			} else {
+				child.children = undefined;
+			}
 		});
 	}
 };

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -3,7 +3,6 @@
 const path = require('path');
 
 const user = require('../user');
-const meta = require('../meta');
 const privileges = require('../privileges');
 const accountHelpers = require('./accounts/helpers');
 
@@ -68,17 +67,13 @@ userController.getUserDataByUID = async function (callerUid, uid) {
 	if (!canView) {
 		throw new Error('[[error:no-privileges]]');
 	}
-	const [userData, settings] = await Promise.all([
-		user.getUserData(uid),
-		user.getSettings(uid),
-	]);
 
+	let userData = await user.getUserData(uid);
 	if (!userData) {
 		throw new Error('[[error:no-user]]');
 	}
 
-	userData.email = settings.showemail && !meta.config.hideEmail ? userData.email : undefined;
-	userData.fullname = settings.showfullname && !meta.config.hideFullname ? userData.fullname : undefined;
+	userData = await user.hidePrivateData(userData, callerUid);
 
 	return userData;
 };

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -8,8 +8,6 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const chalk = require('chalk');
 
-const plugins = require('../plugins');
-
 const cacheBuster = require('./cacheBuster');
 const { aliases } = require('./aliases');
 
@@ -201,7 +199,9 @@ exports.webpack = async function (options) {
 	const webpack = require('webpack');
 	const fs = require('fs');
 	const util = require('util');
-	const activePlugins = await plugins.getActive();
+	const plugins = require('../plugins/data');
+
+	const activePlugins = await plugins.getActiveIds();
 	if (!activePlugins.includes('nodebb-plugin-composer-default')) {
 		activePlugins.push('nodebb-plugin-composer-default');
 	}

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -8,6 +8,8 @@ const path = require('path');
 const mkdirp = require('mkdirp');
 const chalk = require('chalk');
 
+const plugins = require('../plugins');
+
 const cacheBuster = require('./cacheBuster');
 const { aliases } = require('./aliases');
 
@@ -200,10 +202,7 @@ exports.webpack = async function (options) {
 	const fs = require('fs');
 	const util = require('util');
 	const db = require('../database');
-	let activePlugins = nconf.get('plugins:active');
-	if (!activePlugins) {
-		activePlugins = await db.getSortedSetRange('plugins:active', 0, -1);
-	}
+	const activePlugins = plugins.data.getActiveIds();
 	if (!activePlugins.includes('nodebb-plugin-composer-default')) {
 		activePlugins.push('nodebb-plugin-composer-default');
 	}

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -201,7 +201,7 @@ exports.webpack = async function (options) {
 	const webpack = require('webpack');
 	const fs = require('fs');
 	const util = require('util');
-	const activePlugins = plugins.data.getActiveIds();
+	const activePlugins = await plugins.getActive();
 	if (!activePlugins.includes('nodebb-plugin-composer-default')) {
 		activePlugins.push('nodebb-plugin-composer-default');
 	}

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -200,8 +200,10 @@ exports.webpack = async function (options) {
 	const fs = require('fs');
 	const util = require('util');
 	const db = require('../database');
-
-	const activePlugins = await db.getSortedSetRange('plugins:active', 0, -1);
+	let activePlugins = nconf.get('plugins:active');
+	if (!activePlugins) {
+		activePlugins = await db.getSortedSetRange('plugins:active', 0, -1);
+	}
 	if (!activePlugins.includes('nodebb-plugin-composer-default')) {
 		activePlugins.push('nodebb-plugin-composer-default');
 	}

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -201,7 +201,7 @@ exports.webpack = async function (options) {
 	const util = require('util');
 	const plugins = require('../plugins/data');
 
-	const activePlugins = await plugins.getActiveIds();
+	const activePlugins = await plugins.getActive();
 	if (!activePlugins.includes('nodebb-plugin-composer-default')) {
 		activePlugins.push('nodebb-plugin-composer-default');
 	}

--- a/src/meta/build.js
+++ b/src/meta/build.js
@@ -201,7 +201,6 @@ exports.webpack = async function (options) {
 	const webpack = require('webpack');
 	const fs = require('fs');
 	const util = require('util');
-	const db = require('../database');
 	const activePlugins = plugins.data.getActiveIds();
 	if (!activePlugins.includes('nodebb-plugin-composer-default')) {
 		activePlugins.push('nodebb-plugin-composer-default');

--- a/src/meta/templates.js
+++ b/src/meta/templates.js
@@ -15,7 +15,6 @@ const Benchpress = require('benchpressjs');
 
 const plugins = require('../plugins');
 const file = require('../file');
-const db = require('../database');
 const { themeNamePattern, paths } = require('../constants');
 
 const viewsPath = nconf.get('views_dir');

--- a/src/meta/templates.js
+++ b/src/meta/templates.js
@@ -121,7 +121,7 @@ async function compile() {
 
 	let files = nconf.get('plugins:active');
 	if (!files) {
-		await db.getSortedSetRange('plugins:active', 0, -1);
+		files = await db.getSortedSetRange('plugins:active', 0, -1);
 	}
 	files = await getTemplateDirs(files);
 	files = await getTemplateFiles(files);

--- a/src/meta/templates.js
+++ b/src/meta/templates.js
@@ -119,10 +119,7 @@ async function compile() {
 	await _rimraf(viewsPath);
 	await mkdirp(viewsPath);
 
-	let files = nconf.get('plugins:active');
-	if (!files) {
-		files = await db.getSortedSetRange('plugins:active', 0, -1);
-	}
+	let files = plugins.getActive();
 	files = await getTemplateDirs(files);
 	files = await getTemplateFiles(files);
 

--- a/src/meta/templates.js
+++ b/src/meta/templates.js
@@ -119,7 +119,10 @@ async function compile() {
 	await _rimraf(viewsPath);
 	await mkdirp(viewsPath);
 
-	let files = await db.getSortedSetRange('plugins:active', 0, -1);
+	let files = nconf.get('plugins:active');
+	if (!files) {
+		await db.getSortedSetRange('plugins:active', 0, -1);
+	}
 	files = await getTemplateDirs(files);
 	files = await getTemplateFiles(files);
 

--- a/src/meta/templates.js
+++ b/src/meta/templates.js
@@ -118,7 +118,7 @@ async function compile() {
 	await _rimraf(viewsPath);
 	await mkdirp(viewsPath);
 
-	let files = plugins.getActive();
+	let files = await plugins.getActive();
 	files = await getTemplateDirs(files);
 	files = await getTemplateFiles(files);
 

--- a/src/meta/themes.js
+++ b/src/meta/themes.js
@@ -97,13 +97,15 @@ Themes.set = async (data) => {
 
 				let config = await fs.promises.readFile(pathToThemeJson, 'utf8');
 				config = JSON.parse(config);
-				if (nconf.get('plugins:active')) {
-					// this is only a warning because otherwise it becomes impossible to actually change themes
-					winston.warn('Changing themes also requires adjusting the configuration (config.json, environmental variables or terminal arguments), please change it instead');
-				} else {
+				const activePluginsConfig = nconf.get('plugins:active');
+				if (!activePluginsConfig) {
 					await db.sortedSetRemove('plugins:active', current);
 					const numPlugins = await db.sortedSetCard('plugins:active');
 					await db.sortedSetAdd('plugins:active', numPlugins, data.id);
+				} else if (!activePluginsConfig.includes(data.id)) {
+					// This prevents changing theme when configuration doesn't include it, but allows it otherwise
+					winston.error('When defining active plugins in configuration, changing themes requires adding the new theme to the list of active plugins before updating it in the ACP');
+					throw new Error('[[error:theme-not-set-in-configuration]]');
 				}
 
 				// Re-set the themes path (for when NodeBB is reloaded)

--- a/src/meta/themes.js
+++ b/src/meta/themes.js
@@ -97,10 +97,15 @@ Themes.set = async (data) => {
 
 				let config = await fs.promises.readFile(pathToThemeJson, 'utf8');
 				config = JSON.parse(config);
+				if (nconf.get('plugins:active')) {
+					// this is only a warning because otherwise it becomes impossible to actually change themes
+					winston.warn('Changing themes also requires adjusting the configuration (config.json, environmental variables or terminal arguments), please change it instead');
+				} else {
+					await db.sortedSetRemove('plugins:active', current);
+					const numPlugins = await db.sortedSetCard('plugins:active');
+					await db.sortedSetAdd('plugins:active', numPlugins, data.id);
+				}
 
-				await db.sortedSetRemove('plugins:active', current);
-				const numPlugins = await db.sortedSetCard('plugins:active');
-				await db.sortedSetAdd('plugins:active', numPlugins, data.id);
 				// Re-set the themes path (for when NodeBB is reloaded)
 				Themes.setPath(config);
 

--- a/src/plugins/data.js
+++ b/src/plugins/data.js
@@ -14,11 +14,17 @@ const Data = module.exports;
 
 const basePath = path.join(__dirname, '../../');
 
-Data.getPluginPaths = async function () {
-	let plugins = nconf.get('plugins:active');
-	if (!plugins) {
-		plugins = await db.getSortedSetRange('plugins:active', 0, -1);
+// to get this functionality use `plugins.getActive()` from `src/plugins/install.js` instead
+// this method duplicates that one, because requiring that file here would have side effects
+async function getActiveIds() {
+	if (nconf.get('plugins:active')) {
+		return nconf.get('plugins:active');
 	}
+	return await db.getSortedSetRange('plugins:active', 0, -1);
+}
+
+Data.getPluginPaths = async function () {
+	const plugins = await getActiveIds();
 	const pluginPaths = plugins.filter(plugin => plugin && typeof plugin === 'string')
 		.map(plugin => path.join(paths.nodeModules, plugin));
 	const exists = await Promise.all(pluginPaths.map(file.exists));

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -56,6 +56,10 @@ module.exports = function (Plugins) {
 	}
 
 	Plugins.toggleActive = async function (id) {
+		if (nconf.get('plugins:active')) {
+			winston.error('Cannot activate plugins while plugin state is set in the configuration (config.json, environmental variables or terminal arguments), please modify the configuration instead');
+			throw new Error('[[error:plugins-set-in-configuration]]');
+		}
 		const isActive = await Plugins.isActive(id);
 		if (isActive) {
 			await db.sortedSetRemove('plugins:active', id);
@@ -144,10 +148,16 @@ module.exports = function (Plugins) {
 	};
 
 	Plugins.isActive = async function (id) {
+		if (nconf.get('plugins:active')) {
+			return nconf.get('plugins:active').includes(id);
+		}
 		return await db.isSortedSetMember('plugins:active', id);
 	};
 
 	Plugins.getActive = async function () {
+		if (nconf.get('plugins:active')) {
+			return nconf.get('plugins:active');
+		}
 		return await db.getSortedSetRange('plugins:active', 0, -1);
 	};
 

--- a/src/socket.io/admin/plugins.js
+++ b/src/socket.io/admin/plugins.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const nconf = require('nconf');
+
 const plugins = require('../../plugins');
 const events = require('../../events');
 const db = require('../../database');
@@ -35,6 +37,9 @@ Plugins.getActive = async function () {
 };
 
 Plugins.orderActivePlugins = async function (socket, data) {
+	if (nconf.get('plugins:active')) {
+		throw new Error('[[error:plugins-set-in-configuration]]');
+	}
 	data = data.filter(plugin => plugin && plugin.name);
 	await Promise.all(data.map(plugin => db.sortedSetAdd('plugins:active', plugin.order || 0, plugin.name)));
 };

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -7,6 +7,7 @@ const semver = require('semver');
 const readline = require('readline');
 const winston = require('winston');
 const chalk = require('chalk');
+const nconf = require('nconf');
 
 const db = require('./database');
 const file = require('./file');
@@ -61,7 +62,10 @@ Upgrade.getAll = async function () {
 
 Upgrade.appendPluginScripts = async function (files) {
 	// Find all active plugins
-	const plugins = await db.getSortedSetRange('plugins:active', 0, -1);
+	let plugins = nconf.get('plugins:active');
+	if (!plugins) {
+		plugins = await db.getSortedSetRange('plugins:active', 0, -1);
+	}
 	plugins.forEach((plugin) => {
 		const configPath = path.join(paths.nodeModules, plugin, 'plugin.json');
 		try {

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -7,8 +7,8 @@ const semver = require('semver');
 const readline = require('readline');
 const winston = require('winston');
 const chalk = require('chalk');
-const nconf = require('nconf');
 
+const plugins = require('./plugins');
 const db = require('./database');
 const file = require('./file');
 const { paths } = require('./constants');
@@ -62,12 +62,9 @@ Upgrade.getAll = async function () {
 
 Upgrade.appendPluginScripts = async function (files) {
 	// Find all active plugins
-	let plugins = nconf.get('plugins:active');
-	if (!plugins) {
-		plugins = await db.getSortedSetRange('plugins:active', 0, -1);
-	}
-	plugins.forEach((plugin) => {
-		const configPath = path.join(paths.nodeModules, plugin, 'plugin.json');
+	const activePlugins = plugins.data.getActive();
+	activePlugins.forEach((plugin) => {
+		const configPath = path.join(plugin.path, 'plugin.json');
 		try {
 			const pluginConfig = require(configPath);
 			if (pluginConfig.hasOwnProperty('upgrades') && Array.isArray(pluginConfig.upgrades)) {

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -11,7 +11,7 @@ const chalk = require('chalk');
 const plugins = require('./plugins');
 const db = require('./database');
 const file = require('./file');
-
+const { paths } = require('./constants');
 /*
  * Need to write an upgrade script for NodeBB? Cool.
  *
@@ -61,9 +61,9 @@ Upgrade.getAll = async function () {
 
 Upgrade.appendPluginScripts = async function (files) {
 	// Find all active plugins
-	const activePlugins = await plugins.data.getActive();
+	const activePlugins = await plugins.getActive();
 	activePlugins.forEach((plugin) => {
-		const configPath = path.join(plugin.path, 'plugin.json');
+		const configPath = path.join(paths.nodeModules, plugin, 'plugin.json');
 		try {
 			const pluginConfig = require(configPath);
 			if (pluginConfig.hasOwnProperty('upgrades') && Array.isArray(pluginConfig.upgrades)) {

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -11,7 +11,6 @@ const chalk = require('chalk');
 const plugins = require('./plugins');
 const db = require('./database');
 const file = require('./file');
-const { paths } = require('./constants');
 
 /*
  * Need to write an upgrade script for NodeBB? Cool.

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -61,7 +61,7 @@ Upgrade.getAll = async function () {
 
 Upgrade.appendPluginScripts = async function (files) {
 	// Find all active plugins
-	const activePlugins = plugins.data.getActive();
+	const activePlugins = await plugins.data.getActive();
 	activePlugins.forEach((plugin) => {
 		const configPath = path.join(plugin.path, 'plugin.json');
 		try {

--- a/src/views/admin/extend/plugins.tpl
+++ b/src/views/admin/extend/plugins.tpl
@@ -1,3 +1,6 @@
+{{{ if !canChangeState }}}
+<div class="alert alert-warning">[[error:plugins-set-in-configuration]]</div>
+{{{ end }}}
 <ul class="nav nav-pills">
 	<li>
 		<a href="#trending" data-toggle="tab">

--- a/src/views/admin/partials/installed_plugin_item.tpl
+++ b/src/views/admin/partials/installed_plugin_item.tpl
@@ -5,7 +5,7 @@
 								<!-- IF ../isTheme -->
 								<a href="{config.relative_path}/admin/appearance/themes" class="btn btn-info">[[admin/extend/plugins:plugin-item.themes]]</a>
 								<!-- ELSE -->
-								<button  data-action="toggleActive" class="btn <!-- IF ../active --> btn-warning<!-- ELSE --> btn-success<!-- ENDIF ../active --> <!-- IF !canChangeState -->disabled<!-- ENDIF -->">
+								<button data-action="toggleActive" class="btn <!-- IF ../active --> btn-warning<!-- ELSE --> btn-success<!-- ENDIF ../active --> <!-- IF !canChangeState -->disabled<!-- ENDIF -->">
 								<i class="fa fa-power-off"></i> <!-- IF ../active -->[[admin/extend/plugins:plugin-item.deactivate]]<!-- ELSE -->[[admin/extend/plugins:plugin-item.activate]]<!-- ENDIF ../active --></button>
 								<!-- ENDIF ../isTheme -->
 

--- a/src/views/admin/partials/installed_plugin_item.tpl
+++ b/src/views/admin/partials/installed_plugin_item.tpl
@@ -5,7 +5,7 @@
 								<!-- IF ../isTheme -->
 								<a href="{config.relative_path}/admin/appearance/themes" class="btn btn-info">[[admin/extend/plugins:plugin-item.themes]]</a>
 								<!-- ELSE -->
-								<button data-action="toggleActive" class="btn <!-- IF ../active --> btn-warning<!-- ELSE --> btn-success<!-- ENDIF ../active -->">
+								<button  data-action="toggleActive" class="btn <!-- IF ../active --> btn-warning<!-- ELSE --> btn-success<!-- ENDIF ../active --> <!-- IF !canChangeState -->disabled<!-- ENDIF -->">
 								<i class="fa fa-power-off"></i> <!-- IF ../active -->[[admin/extend/plugins:plugin-item.deactivate]]<!-- ELSE -->[[admin/extend/plugins:plugin-item.activate]]<!-- ENDIF ../active --></button>
 								<!-- ENDIF ../isTheme -->
 

--- a/src/views/admin/settings/advanced.tpl
+++ b/src/views/admin/settings/advanced.tpl
@@ -74,6 +74,15 @@
 			</div>
 			<p class="help-block">[[admin/settings/advanced:headers.coep-help]]</p>
 			<div class="form-group">
+				<label for="cross-origin-resource-policy">[[admin/settings/advanced:headers.coop]]</label>
+				<select class="form-control" id="cross-origin-opener-policy" data-field="cross-origin-opener-policy">
+					<option value="same-origin">same-origin</option>
+					<option value="same-origin-allow-popups">same-origin-allow-popups</option>
+					<option value="unsafe-none">unsafe-none</option>
+				</select>
+			</div>
+
+			<div class="form-group">
 				<label for="cross-origin-resource-policy">[[admin/settings/advanced:headers.corp]]</label>
 				<select class="form-control" id="cross-origin-resource-policy" data-field="cross-origin-resource-policy">
 					<option value="same-site">same-site</option>

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -196,7 +196,7 @@ function setupHelmet(app) {
 	if (meta.config['cross-origin-embedder-policy']) {
 		app.use(helmet.crossOriginEmbedderPolicy());
 	}
-	app.use(helmet.crossOriginOpenerPolicy());
+	app.use(helmet.crossOriginOpenerPolicy({ policy: meta.config['cross-origin-opener-policy'] }));
 	app.use(helmet.crossOriginResourcePolicy({ policy: meta.config['cross-origin-resource-policy'] }));
 	app.use(helmet.dnsPrefetchControl());
 	app.use(helmet.expectCt());

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -10,315 +10,315 @@ const db = require('./mocks/databasemock');
 const plugins = require('../src/plugins');
 
 describe('Plugins', () => {
-	it('should load plugin data', (done) => {
-		const pluginId = 'nodebb-plugin-markdown';
-		plugins.loadPlugin(path.join(nconf.get('base_dir'), `node_modules/${pluginId}`), (err) => {
-			assert.ifError(err);
-			assert(plugins.libraries[pluginId]);
-			assert(plugins.loadedHooks['static:app.load']);
+	// it('should load plugin data', (done) => {
+	// 	const pluginId = 'nodebb-plugin-markdown';
+	// 	plugins.loadPlugin(path.join(nconf.get('base_dir'), `node_modules/${pluginId}`), (err) => {
+	// 		assert.ifError(err);
+	// 		assert(plugins.libraries[pluginId]);
+	// 		assert(plugins.loadedHooks['static:app.load']);
 
-			done();
-		});
-	});
+	// 		done();
+	// 	});
+	// });
 
-	it('should return true if hook has listeners', (done) => {
-		assert(plugins.hooks.hasListeners('filter:parse.post'));
-		done();
-	});
+	// it('should return true if hook has listeners', (done) => {
+	// 	assert(plugins.hooks.hasListeners('filter:parse.post'));
+	// 	done();
+	// });
 
-	it('should register and fire a filter hook', (done) => {
-		function filterMethod1(data, callback) {
-			data.foo += 1;
-			callback(null, data);
-		}
-		function filterMethod2(data, callback) {
-			data.foo += 5;
-			callback(null, data);
-		}
+	// it('should register and fire a filter hook', (done) => {
+	// 	function filterMethod1(data, callback) {
+	// 		data.foo += 1;
+	// 		callback(null, data);
+	// 	}
+	// 	function filterMethod2(data, callback) {
+	// 		data.foo += 5;
+	// 		callback(null, data);
+	// 	}
 
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod1 });
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod2 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod1 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod2 });
 
-		plugins.hooks.fire('filter:test.hook', { foo: 1 }, (err, data) => {
-			assert.ifError(err);
-			assert.equal(data.foo, 7);
-			done();
-		});
-	});
+	// 	plugins.hooks.fire('filter:test.hook', { foo: 1 }, (err, data) => {
+	// 		assert.ifError(err);
+	// 		assert.equal(data.foo, 7);
+	// 		done();
+	// 	});
+	// });
 
-	it('should register and fire a filter hook having 3 methods', async () => {
-		function method1(data, callback) {
-			data.foo += 1;
-			callback(null, data);
-		}
-		async function method2(data) {
-			return new Promise((resolve) => {
-				data.foo += 5;
-				resolve(data);
-			});
-		}
-		function method3(data) {
-			data.foo += 1;
-			return data;
-		}
+	// it('should register and fire a filter hook having 3 methods', async () => {
+	// 	function method1(data, callback) {
+	// 		data.foo += 1;
+	// 		callback(null, data);
+	// 	}
+	// 	async function method2(data) {
+	// 		return new Promise((resolve) => {
+	// 			data.foo += 5;
+	// 			resolve(data);
+	// 		});
+	// 	}
+	// 	function method3(data) {
+	// 		data.foo += 1;
+	// 		return data;
+	// 	}
 
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method1 });
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method2 });
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method3 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method1 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method2 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method3 });
 
-		const data = await plugins.hooks.fire('filter:test.hook2', { foo: 1 });
-		assert.strictEqual(data.foo, 8);
-	});
+	// 	const data = await plugins.hooks.fire('filter:test.hook2', { foo: 1 });
+	// 	assert.strictEqual(data.foo, 8);
+	// });
 
-	it('should not error with invalid hooks', async () => {
-		function method1(data, callback) {
-			data.foo += 1;
-			return data;
-		}
-		function method2(data, callback) {
-			data.foo += 2;
-			// this is invalid
-			callback(null, data);
-			return data;
-		}
+	// it('should not error with invalid hooks', async () => {
+	// 	function method1(data, callback) {
+	// 		data.foo += 1;
+	// 		return data;
+	// 	}
+	// 	function method2(data, callback) {
+	// 		data.foo += 2;
+	// 		// this is invalid
+	// 		callback(null, data);
+	// 		return data;
+	// 	}
 
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method1 });
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method2 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method1 });
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method2 });
 
-		const data = await plugins.hooks.fire('filter:test.hook3', { foo: 1 });
-		assert.strictEqual(data.foo, 4);
-	});
+	// 	const data = await plugins.hooks.fire('filter:test.hook3', { foo: 1 });
+	// 	assert.strictEqual(data.foo, 4);
+	// });
 
-	it('should register and fire a filter hook that returns a promise that gets rejected', (done) => {
-		async function method(data) {
-			return new Promise((resolve, reject) => {
-				data.foo += 5;
-				reject(new Error('nope'));
-			});
-		}
-		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook4', method: method });
-		plugins.hooks.fire('filter:test.hook4', { foo: 1 }, (err) => {
-			assert(err);
-			done();
-		});
-	});
+	// it('should register and fire a filter hook that returns a promise that gets rejected', (done) => {
+	// 	async function method(data) {
+	// 		return new Promise((resolve, reject) => {
+	// 			data.foo += 5;
+	// 			reject(new Error('nope'));
+	// 		});
+	// 	}
+	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook4', method: method });
+	// 	plugins.hooks.fire('filter:test.hook4', { foo: 1 }, (err) => {
+	// 		assert(err);
+	// 		done();
+	// 	});
+	// });
 
-	it('should register and fire an action hook', (done) => {
-		function actionMethod(data) {
-			assert.equal(data.bar, 'test');
-			done();
-		}
+	// it('should register and fire an action hook', (done) => {
+	// 	function actionMethod(data) {
+	// 		assert.equal(data.bar, 'test');
+	// 		done();
+	// 	}
 
-		plugins.hooks.register('test-plugin', { hook: 'action:test.hook', method: actionMethod });
-		plugins.hooks.fire('action:test.hook', { bar: 'test' });
-	});
+	// 	plugins.hooks.register('test-plugin', { hook: 'action:test.hook', method: actionMethod });
+	// 	plugins.hooks.fire('action:test.hook', { bar: 'test' });
+	// });
 
-	it('should register and fire a static hook', (done) => {
-		function actionMethod(data, callback) {
-			assert.equal(data.bar, 'test');
-			callback();
-		}
+	// it('should register and fire a static hook', (done) => {
+	// 	function actionMethod(data, callback) {
+	// 		assert.equal(data.bar, 'test');
+	// 		callback();
+	// 	}
 
-		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: actionMethod });
-		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-			assert.ifError(err);
-			done();
-		});
-	});
+	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: actionMethod });
+	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+	// 		assert.ifError(err);
+	// 		done();
+	// 	});
+	// });
 
-	it('should register and fire a static hook returning a promise', (done) => {
-		async function method(data) {
-			assert.equal(data.bar, 'test');
-			return new Promise((resolve) => {
-				resolve();
-			});
-		}
-		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
-		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-			assert.ifError(err);
-			done();
-		});
-	});
+	// it('should register and fire a static hook returning a promise', (done) => {
+	// 	async function method(data) {
+	// 		assert.equal(data.bar, 'test');
+	// 		return new Promise((resolve) => {
+	// 			resolve();
+	// 		});
+	// 	}
+	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
+	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+	// 		assert.ifError(err);
+	// 		done();
+	// 	});
+	// });
 
-	it('should register and fire a static hook returning a promise that gets rejected with a error', (done) => {
-		async function method(data) {
-			assert.equal(data.bar, 'test');
-			return new Promise((resolve, reject) => {
-				reject(new Error('just because'));
-			});
-		}
-		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
-		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-			assert.strictEqual(err.message, 'just because');
-			plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
-			done();
-		});
-	});
+	// it('should register and fire a static hook returning a promise that gets rejected with a error', (done) => {
+	// 	async function method(data) {
+	// 		assert.equal(data.bar, 'test');
+	// 		return new Promise((resolve, reject) => {
+	// 			reject(new Error('just because'));
+	// 		});
+	// 	}
+	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
+	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+	// 		assert.strictEqual(err.message, 'just because');
+	// 		plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
+	// 		done();
+	// 	});
+	// });
 
-	it('should register and timeout a static hook returning a promise but takes too long', (done) => {
-		async function method(data) {
-			assert.equal(data.bar, 'test');
-			return new Promise((resolve) => {
-				setTimeout(resolve, 6000);
-			});
-		}
-		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
-		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-			assert.ifError(err);
-			plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
-			done();
-		});
-	});
+	// it('should register and timeout a static hook returning a promise but takes too long', (done) => {
+	// 	async function method(data) {
+	// 		assert.equal(data.bar, 'test');
+	// 		return new Promise((resolve) => {
+	// 			setTimeout(resolve, 6000);
+	// 		});
+	// 	}
+	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
+	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+	// 		assert.ifError(err);
+	// 		plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
+	// 		done();
+	// 	});
+	// });
 
-	it('should get plugin data from nbbpm', (done) => {
-		plugins.get('nodebb-plugin-markdown', (err, data) => {
-			assert.ifError(err);
-			const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
-			assert.equal(data.name, 'nodebb-plugin-markdown');
-			assert.equal(data.id, 'nodebb-plugin-markdown');
-			keys.forEach((key) => {
-				assert(data.hasOwnProperty(key));
-			});
-			done();
-		});
-	});
+	// it('should get plugin data from nbbpm', (done) => {
+	// 	plugins.get('nodebb-plugin-markdown', (err, data) => {
+	// 		assert.ifError(err);
+	// 		const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
+	// 		assert.equal(data.name, 'nodebb-plugin-markdown');
+	// 		assert.equal(data.id, 'nodebb-plugin-markdown');
+	// 		keys.forEach((key) => {
+	// 			assert(data.hasOwnProperty(key));
+	// 		});
+	// 		done();
+	// 	});
+	// });
 
-	it('should get a list of plugins', (done) => {
-		plugins.list((err, data) => {
-			assert.ifError(err);
-			const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
-			assert(Array.isArray(data));
-			keys.forEach((key) => {
-				assert(data[0].hasOwnProperty(key));
-			});
-			done();
-		});
-	});
+	// it('should get a list of plugins', (done) => {
+	// 	plugins.list((err, data) => {
+	// 		assert.ifError(err);
+	// 		const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
+	// 		assert(Array.isArray(data));
+	// 		keys.forEach((key) => {
+	// 			assert(data[0].hasOwnProperty(key));
+	// 		});
+	// 		done();
+	// 	});
+	// });
 
-	it('should show installed plugins', (done) => {
-		const { nodeModulesPath } = plugins;
-		plugins.nodeModulesPath = path.join(__dirname, './mocks/plugin_modules');
+	// it('should show installed plugins', (done) => {
+	// 	const { nodeModulesPath } = plugins;
+	// 	plugins.nodeModulesPath = path.join(__dirname, './mocks/plugin_modules');
 
-		plugins.showInstalled((err, pluginsData) => {
-			assert.ifError(err);
-			const paths = pluginsData.map(plugin => path.relative(plugins.nodeModulesPath, plugin.path).replace(/\\/g, '/'));
-			assert(paths.indexOf('nodebb-plugin-xyz') > -1);
-			assert(paths.indexOf('@nodebb/nodebb-plugin-abc') > -1);
+	// 	plugins.showInstalled((err, pluginsData) => {
+	// 		assert.ifError(err);
+	// 		const paths = pluginsData.map(plugin => path.relative(plugins.nodeModulesPath, plugin.path).replace(/\\/g, '/'));
+	// 		assert(paths.indexOf('nodebb-plugin-xyz') > -1);
+	// 		assert(paths.indexOf('@nodebb/nodebb-plugin-abc') > -1);
 
-			plugins.nodeModulesPath = nodeModulesPath;
-			done();
-		});
-	});
+	// 		plugins.nodeModulesPath = nodeModulesPath;
+	// 		done();
+	// 	});
+	// });
 
-	it('should submit usage info', (done) => {
-		plugins.submitUsageData((err) => {
-			assert.ifError(err);
-			done();
-		});
-	});
+	// it('should submit usage info', (done) => {
+	// 	plugins.submitUsageData((err) => {
+	// 		assert.ifError(err);
+	// 		done();
+	// 	});
+	// });
 
-	describe('install/activate/uninstall', () => {
-		let latest;
-		const pluginName = 'nodebb-plugin-imgur';
-		const oldValue = process.env.NODE_ENV;
-		before((done) => {
-			process.env.NODE_ENV = 'development';
-			done();
-		});
-		after((done) => {
-			process.env.NODE_ENV = oldValue;
-			done();
-		});
+	// describe('install/activate/uninstall', () => {
+	// 	let latest;
+	// 	const pluginName = 'nodebb-plugin-imgur';
+	// 	const oldValue = process.env.NODE_ENV;
+	// 	before((done) => {
+	// 		process.env.NODE_ENV = 'development';
+	// 		done();
+	// 	});
+	// 	after((done) => {
+	// 		process.env.NODE_ENV = oldValue;
+	// 		done();
+	// 	});
 
-		it('should install a plugin', function (done) {
-			this.timeout(0);
-			plugins.toggleInstall(pluginName, '1.0.16', (err, pluginData) => {
-				assert.ifError(err);
-				latest = pluginData.latest;
+	// 	it('should install a plugin', function (done) {
+	// 		this.timeout(0);
+	// 		plugins.toggleInstall(pluginName, '1.0.16', (err, pluginData) => {
+	// 			assert.ifError(err);
+	// 			latest = pluginData.latest;
 
-				assert.equal(pluginData.name, pluginName);
-				assert.equal(pluginData.id, pluginName);
-				assert.equal(pluginData.url, 'https://github.com/barisusakli/nodebb-plugin-imgur#readme');
-				assert.equal(pluginData.description, 'A Plugin that uploads images to imgur');
-				assert.equal(pluginData.active, false);
-				assert.equal(pluginData.installed, true);
+	// 			assert.equal(pluginData.name, pluginName);
+	// 			assert.equal(pluginData.id, pluginName);
+	// 			assert.equal(pluginData.url, 'https://github.com/barisusakli/nodebb-plugin-imgur#readme');
+	// 			assert.equal(pluginData.description, 'A Plugin that uploads images to imgur');
+	// 			assert.equal(pluginData.active, false);
+	// 			assert.equal(pluginData.installed, true);
 
-				const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
-				assert(packageFile.dependencies[pluginName]);
+	// 			const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+	// 			assert(packageFile.dependencies[pluginName]);
 
-				done();
-			});
-		});
+	// 			done();
+	// 		});
+	// 	});
 
-		it('should activate plugin', (done) => {
-			plugins.toggleActive(pluginName, (err) => {
-				assert.ifError(err);
-				plugins.isActive(pluginName, (err, isActive) => {
-					assert.ifError(err);
-					assert(isActive);
-					done();
-				});
-			});
-		});
+	// 	it('should activate plugin', (done) => {
+	// 		plugins.toggleActive(pluginName, (err) => {
+	// 			assert.ifError(err);
+	// 			plugins.isActive(pluginName, (err, isActive) => {
+	// 				assert.ifError(err);
+	// 				assert(isActive);
+	// 				done();
+	// 			});
+	// 		});
+	// 	});
 
-		it('should upgrade plugin', function (done) {
-			this.timeout(0);
-			plugins.upgrade(pluginName, 'latest', (err, isActive) => {
-				assert.ifError(err);
-				assert(isActive);
-				plugins.loadPluginInfo(path.join(nconf.get('base_dir'), 'node_modules', pluginName), (err, pluginInfo) => {
-					assert.ifError(err);
-					assert.equal(pluginInfo.version, latest);
-					done();
-				});
-			});
-		});
+	// 	it('should upgrade plugin', function (done) {
+	// 		this.timeout(0);
+	// 		plugins.upgrade(pluginName, 'latest', (err, isActive) => {
+	// 			assert.ifError(err);
+	// 			assert(isActive);
+	// 			plugins.loadPluginInfo(path.join(nconf.get('base_dir'), 'node_modules', pluginName), (err, pluginInfo) => {
+	// 				assert.ifError(err);
+	// 				assert.equal(pluginInfo.version, latest);
+	// 				done();
+	// 			});
+	// 		});
+	// 	});
 
-		it('should uninstall a plugin', function (done) {
-			this.timeout(0);
-			plugins.toggleInstall(pluginName, 'latest', (err, pluginData) => {
-				assert.ifError(err);
-				assert.equal(pluginData.installed, false);
-				assert.equal(pluginData.active, false);
+	// 	it('should uninstall a plugin', function (done) {
+	// 		this.timeout(0);
+	// 		plugins.toggleInstall(pluginName, 'latest', (err, pluginData) => {
+	// 			assert.ifError(err);
+	// 			assert.equal(pluginData.installed, false);
+	// 			assert.equal(pluginData.active, false);
 
-				const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
-				assert(!packageFile.dependencies[pluginName]);
+	// 			const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+	// 			assert(!packageFile.dependencies[pluginName]);
 
-				done();
-			});
-		});
-	});
+	// 			done();
+	// 		});
+	// 	});
+	// });
 
-	describe('static assets', () => {
-		it('should 404 if resource does not exist', (done) => {
-			request.get(`${nconf.get('url')}/plugins/doesnotexist/should404.tpl`, (err, res, body) => {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 404);
-				assert(body);
-				done();
-			});
-		});
+	// describe('static assets', () => {
+	// 	it('should 404 if resource does not exist', (done) => {
+	// 		request.get(`${nconf.get('url')}/plugins/doesnotexist/should404.tpl`, (err, res, body) => {
+	// 			assert.ifError(err);
+	// 			assert.equal(res.statusCode, 404);
+	// 			assert(body);
+	// 			done();
+	// 		});
+	// 	});
 
-		it('should 404 if resource does not exist', (done) => {
-			const url = `${nconf.get('url')}/plugins/nodebb-plugin-dbsearch/dbsearch/templates/admin/plugins/should404.tpl`;
-			request.get(url, (err, res, body) => {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 404);
-				assert(body);
-				done();
-			});
-		});
+	// 	it('should 404 if resource does not exist', (done) => {
+	// 		const url = `${nconf.get('url')}/plugins/nodebb-plugin-dbsearch/dbsearch/templates/admin/plugins/should404.tpl`;
+	// 		request.get(url, (err, res, body) => {
+	// 			assert.ifError(err);
+	// 			assert.equal(res.statusCode, 404);
+	// 			assert(body);
+	// 			done();
+	// 		});
+	// 	});
 
-		it('should get resource', (done) => {
-			const url = `${nconf.get('url')}/assets/templates/admin/plugins/dbsearch.tpl`;
-			request.get(url, (err, res, body) => {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 200);
-				assert(body);
-				done();
-			});
-		});
-	});
+	// 	it('should get resource', (done) => {
+	// 		const url = `${nconf.get('url')}/assets/templates/admin/plugins/dbsearch.tpl`;
+	// 		request.get(url, (err, res, body) => {
+	// 			assert.ifError(err);
+	// 			assert.equal(res.statusCode, 200);
+	// 			assert(body);
+	// 			done();
+	// 		});
+	// 	});
+	// });
 
 	describe('plugin state set in configuration', () => {
 		const activePlugins = [
@@ -371,7 +371,8 @@ describe('Plugins', () => {
 				assert.ifError(err);
 				assert(Array.isArray(data));
 				data.forEach((pluginData) => {
-					assert(activePlugins.includes(pluginData.id));
+					console.log(pluginData);
+					assert(activePlugins.includes(pluginData));
 				});
 				done();
 			});

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -331,7 +331,7 @@ describe('Plugins', () => {
 			done();
 		});
 		afterEach((done) => {
-			nconf.remove('plugins:active', activePlugins);
+			nconf.set('plugins:active', undefined);
 			done();
 		});
 

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -327,10 +327,12 @@ describe('Plugins', () => {
 		];
 		const inactivePlugin = 'nodebb-plugin-emoji';
 		beforeEach((done) => {
-			nconf.set('plugins:active', activePlugins, () => done());
+			nconf.set('plugins:active', activePlugins);
+			done();
 		});
 		afterEach((done) => {
-			nconf.reset('plugins:active', activePlugins, () => done());
+			nconf.reset('plugins:active', activePlugins);
+			done();
 		});
 
 		it('should return active plugin state from configuration', (done) => {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -359,14 +359,14 @@ describe('Plugins', () => {
 				keys.forEach((key) => {
 					assert(data[0].hasOwnProperty(key));
 				});
-				data.forEach((plugin) => {
-					assert(activePlugins.includes(plugin.id));
+				data.forEach((pluginData) => {
+					assert.equal(pluginData.active, activePlugins.includes(pluginData.id));
 				});
 				done();
 			});
 		});
 
-		it('should not deactivate a plugin if active plugins are set in configuration', async (done) => {
+		it('should not deactivate a plugin if active plugins are set in configuration', (done) => {
 			assert.rejects(plugins.toggleActive(activePlugins[0]), Error).then(() => {
 				plugins.isActive(activePlugins[0], (err, isActive) => {
 					assert.ifError(err);
@@ -376,7 +376,7 @@ describe('Plugins', () => {
 			});
 		});
 
-		it('should not activate a plugin if active plugins are set in configuration', async (done) => {
+		it('should not activate a plugin if active plugins are set in configuration', (done) => {
 			assert.rejects(plugins.toggleActive(inactivePlugin), Error).then(() => {
 				plugins.isActive(inactivePlugin, (err, isActive) => {
 					assert.ifError(err);

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -10,315 +10,315 @@ const db = require('./mocks/databasemock');
 const plugins = require('../src/plugins');
 
 describe('Plugins', () => {
-	// it('should load plugin data', (done) => {
-	// 	const pluginId = 'nodebb-plugin-markdown';
-	// 	plugins.loadPlugin(path.join(nconf.get('base_dir'), `node_modules/${pluginId}`), (err) => {
-	// 		assert.ifError(err);
-	// 		assert(plugins.libraries[pluginId]);
-	// 		assert(plugins.loadedHooks['static:app.load']);
+	it('should load plugin data', (done) => {
+		const pluginId = 'nodebb-plugin-markdown';
+		plugins.loadPlugin(path.join(nconf.get('base_dir'), `node_modules/${pluginId}`), (err) => {
+			assert.ifError(err);
+			assert(plugins.libraries[pluginId]);
+			assert(plugins.loadedHooks['static:app.load']);
 
-	// 		done();
-	// 	});
-	// });
+			done();
+		});
+	});
 
-	// it('should return true if hook has listeners', (done) => {
-	// 	assert(plugins.hooks.hasListeners('filter:parse.post'));
-	// 	done();
-	// });
+	it('should return true if hook has listeners', (done) => {
+		assert(plugins.hooks.hasListeners('filter:parse.post'));
+		done();
+	});
 
-	// it('should register and fire a filter hook', (done) => {
-	// 	function filterMethod1(data, callback) {
-	// 		data.foo += 1;
-	// 		callback(null, data);
-	// 	}
-	// 	function filterMethod2(data, callback) {
-	// 		data.foo += 5;
-	// 		callback(null, data);
-	// 	}
+	it('should register and fire a filter hook', (done) => {
+		function filterMethod1(data, callback) {
+			data.foo += 1;
+			callback(null, data);
+		}
+		function filterMethod2(data, callback) {
+			data.foo += 5;
+			callback(null, data);
+		}
 
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod1 });
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod2 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod1 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook', method: filterMethod2 });
 
-	// 	plugins.hooks.fire('filter:test.hook', { foo: 1 }, (err, data) => {
-	// 		assert.ifError(err);
-	// 		assert.equal(data.foo, 7);
-	// 		done();
-	// 	});
-	// });
+		plugins.hooks.fire('filter:test.hook', { foo: 1 }, (err, data) => {
+			assert.ifError(err);
+			assert.equal(data.foo, 7);
+			done();
+		});
+	});
 
-	// it('should register and fire a filter hook having 3 methods', async () => {
-	// 	function method1(data, callback) {
-	// 		data.foo += 1;
-	// 		callback(null, data);
-	// 	}
-	// 	async function method2(data) {
-	// 		return new Promise((resolve) => {
-	// 			data.foo += 5;
-	// 			resolve(data);
-	// 		});
-	// 	}
-	// 	function method3(data) {
-	// 		data.foo += 1;
-	// 		return data;
-	// 	}
+	it('should register and fire a filter hook having 3 methods', async () => {
+		function method1(data, callback) {
+			data.foo += 1;
+			callback(null, data);
+		}
+		async function method2(data) {
+			return new Promise((resolve) => {
+				data.foo += 5;
+				resolve(data);
+			});
+		}
+		function method3(data) {
+			data.foo += 1;
+			return data;
+		}
 
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method1 });
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method2 });
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method3 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method1 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method2 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook2', method: method3 });
 
-	// 	const data = await plugins.hooks.fire('filter:test.hook2', { foo: 1 });
-	// 	assert.strictEqual(data.foo, 8);
-	// });
+		const data = await plugins.hooks.fire('filter:test.hook2', { foo: 1 });
+		assert.strictEqual(data.foo, 8);
+	});
 
-	// it('should not error with invalid hooks', async () => {
-	// 	function method1(data, callback) {
-	// 		data.foo += 1;
-	// 		return data;
-	// 	}
-	// 	function method2(data, callback) {
-	// 		data.foo += 2;
-	// 		// this is invalid
-	// 		callback(null, data);
-	// 		return data;
-	// 	}
+	it('should not error with invalid hooks', async () => {
+		function method1(data, callback) {
+			data.foo += 1;
+			return data;
+		}
+		function method2(data, callback) {
+			data.foo += 2;
+			// this is invalid
+			callback(null, data);
+			return data;
+		}
 
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method1 });
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method2 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method1 });
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook3', method: method2 });
 
-	// 	const data = await plugins.hooks.fire('filter:test.hook3', { foo: 1 });
-	// 	assert.strictEqual(data.foo, 4);
-	// });
+		const data = await plugins.hooks.fire('filter:test.hook3', { foo: 1 });
+		assert.strictEqual(data.foo, 4);
+	});
 
-	// it('should register and fire a filter hook that returns a promise that gets rejected', (done) => {
-	// 	async function method(data) {
-	// 		return new Promise((resolve, reject) => {
-	// 			data.foo += 5;
-	// 			reject(new Error('nope'));
-	// 		});
-	// 	}
-	// 	plugins.hooks.register('test-plugin', { hook: 'filter:test.hook4', method: method });
-	// 	plugins.hooks.fire('filter:test.hook4', { foo: 1 }, (err) => {
-	// 		assert(err);
-	// 		done();
-	// 	});
-	// });
+	it('should register and fire a filter hook that returns a promise that gets rejected', (done) => {
+		async function method(data) {
+			return new Promise((resolve, reject) => {
+				data.foo += 5;
+				reject(new Error('nope'));
+			});
+		}
+		plugins.hooks.register('test-plugin', { hook: 'filter:test.hook4', method: method });
+		plugins.hooks.fire('filter:test.hook4', { foo: 1 }, (err) => {
+			assert(err);
+			done();
+		});
+	});
 
-	// it('should register and fire an action hook', (done) => {
-	// 	function actionMethod(data) {
-	// 		assert.equal(data.bar, 'test');
-	// 		done();
-	// 	}
+	it('should register and fire an action hook', (done) => {
+		function actionMethod(data) {
+			assert.equal(data.bar, 'test');
+			done();
+		}
 
-	// 	plugins.hooks.register('test-plugin', { hook: 'action:test.hook', method: actionMethod });
-	// 	plugins.hooks.fire('action:test.hook', { bar: 'test' });
-	// });
+		plugins.hooks.register('test-plugin', { hook: 'action:test.hook', method: actionMethod });
+		plugins.hooks.fire('action:test.hook', { bar: 'test' });
+	});
 
-	// it('should register and fire a static hook', (done) => {
-	// 	function actionMethod(data, callback) {
-	// 		assert.equal(data.bar, 'test');
-	// 		callback();
-	// 	}
+	it('should register and fire a static hook', (done) => {
+		function actionMethod(data, callback) {
+			assert.equal(data.bar, 'test');
+			callback();
+		}
 
-	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: actionMethod });
-	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-	// 		assert.ifError(err);
-	// 		done();
-	// 	});
-	// });
+		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: actionMethod });
+		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+			assert.ifError(err);
+			done();
+		});
+	});
 
-	// it('should register and fire a static hook returning a promise', (done) => {
-	// 	async function method(data) {
-	// 		assert.equal(data.bar, 'test');
-	// 		return new Promise((resolve) => {
-	// 			resolve();
-	// 		});
-	// 	}
-	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
-	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-	// 		assert.ifError(err);
-	// 		done();
-	// 	});
-	// });
+	it('should register and fire a static hook returning a promise', (done) => {
+		async function method(data) {
+			assert.equal(data.bar, 'test');
+			return new Promise((resolve) => {
+				resolve();
+			});
+		}
+		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
+		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+			assert.ifError(err);
+			done();
+		});
+	});
 
-	// it('should register and fire a static hook returning a promise that gets rejected with a error', (done) => {
-	// 	async function method(data) {
-	// 		assert.equal(data.bar, 'test');
-	// 		return new Promise((resolve, reject) => {
-	// 			reject(new Error('just because'));
-	// 		});
-	// 	}
-	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
-	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-	// 		assert.strictEqual(err.message, 'just because');
-	// 		plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
-	// 		done();
-	// 	});
-	// });
+	it('should register and fire a static hook returning a promise that gets rejected with a error', (done) => {
+		async function method(data) {
+			assert.equal(data.bar, 'test');
+			return new Promise((resolve, reject) => {
+				reject(new Error('just because'));
+			});
+		}
+		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
+		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+			assert.strictEqual(err.message, 'just because');
+			plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
+			done();
+		});
+	});
 
-	// it('should register and timeout a static hook returning a promise but takes too long', (done) => {
-	// 	async function method(data) {
-	// 		assert.equal(data.bar, 'test');
-	// 		return new Promise((resolve) => {
-	// 			setTimeout(resolve, 6000);
-	// 		});
-	// 	}
-	// 	plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
-	// 	plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
-	// 		assert.ifError(err);
-	// 		plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
-	// 		done();
-	// 	});
-	// });
+	it('should register and timeout a static hook returning a promise but takes too long', (done) => {
+		async function method(data) {
+			assert.equal(data.bar, 'test');
+			return new Promise((resolve) => {
+				setTimeout(resolve, 6000);
+			});
+		}
+		plugins.hooks.register('test-plugin', { hook: 'static:test.hook', method: method });
+		plugins.hooks.fire('static:test.hook', { bar: 'test' }, (err) => {
+			assert.ifError(err);
+			plugins.hooks.unregister('test-plugin', 'static:test.hook', method);
+			done();
+		});
+	});
 
-	// it('should get plugin data from nbbpm', (done) => {
-	// 	plugins.get('nodebb-plugin-markdown', (err, data) => {
-	// 		assert.ifError(err);
-	// 		const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
-	// 		assert.equal(data.name, 'nodebb-plugin-markdown');
-	// 		assert.equal(data.id, 'nodebb-plugin-markdown');
-	// 		keys.forEach((key) => {
-	// 			assert(data.hasOwnProperty(key));
-	// 		});
-	// 		done();
-	// 	});
-	// });
+	it('should get plugin data from nbbpm', (done) => {
+		plugins.get('nodebb-plugin-markdown', (err, data) => {
+			assert.ifError(err);
+			const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
+			assert.equal(data.name, 'nodebb-plugin-markdown');
+			assert.equal(data.id, 'nodebb-plugin-markdown');
+			keys.forEach((key) => {
+				assert(data.hasOwnProperty(key));
+			});
+			done();
+		});
+	});
 
-	// it('should get a list of plugins', (done) => {
-	// 	plugins.list((err, data) => {
-	// 		assert.ifError(err);
-	// 		const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
-	// 		assert(Array.isArray(data));
-	// 		keys.forEach((key) => {
-	// 			assert(data[0].hasOwnProperty(key));
-	// 		});
-	// 		done();
-	// 	});
-	// });
+	it('should get a list of plugins', (done) => {
+		plugins.list((err, data) => {
+			assert.ifError(err);
+			const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
+			assert(Array.isArray(data));
+			keys.forEach((key) => {
+				assert(data[0].hasOwnProperty(key));
+			});
+			done();
+		});
+	});
 
-	// it('should show installed plugins', (done) => {
-	// 	const { nodeModulesPath } = plugins;
-	// 	plugins.nodeModulesPath = path.join(__dirname, './mocks/plugin_modules');
+	it('should show installed plugins', (done) => {
+		const { nodeModulesPath } = plugins;
+		plugins.nodeModulesPath = path.join(__dirname, './mocks/plugin_modules');
 
-	// 	plugins.showInstalled((err, pluginsData) => {
-	// 		assert.ifError(err);
-	// 		const paths = pluginsData.map(plugin => path.relative(plugins.nodeModulesPath, plugin.path).replace(/\\/g, '/'));
-	// 		assert(paths.indexOf('nodebb-plugin-xyz') > -1);
-	// 		assert(paths.indexOf('@nodebb/nodebb-plugin-abc') > -1);
+		plugins.showInstalled((err, pluginsData) => {
+			assert.ifError(err);
+			const paths = pluginsData.map(plugin => path.relative(plugins.nodeModulesPath, plugin.path).replace(/\\/g, '/'));
+			assert(paths.indexOf('nodebb-plugin-xyz') > -1);
+			assert(paths.indexOf('@nodebb/nodebb-plugin-abc') > -1);
 
-	// 		plugins.nodeModulesPath = nodeModulesPath;
-	// 		done();
-	// 	});
-	// });
+			plugins.nodeModulesPath = nodeModulesPath;
+			done();
+		});
+	});
 
-	// it('should submit usage info', (done) => {
-	// 	plugins.submitUsageData((err) => {
-	// 		assert.ifError(err);
-	// 		done();
-	// 	});
-	// });
+	it('should submit usage info', (done) => {
+		plugins.submitUsageData((err) => {
+			assert.ifError(err);
+			done();
+		});
+	});
 
-	// describe('install/activate/uninstall', () => {
-	// 	let latest;
-	// 	const pluginName = 'nodebb-plugin-imgur';
-	// 	const oldValue = process.env.NODE_ENV;
-	// 	before((done) => {
-	// 		process.env.NODE_ENV = 'development';
-	// 		done();
-	// 	});
-	// 	after((done) => {
-	// 		process.env.NODE_ENV = oldValue;
-	// 		done();
-	// 	});
+	describe('install/activate/uninstall', () => {
+		let latest;
+		const pluginName = 'nodebb-plugin-imgur';
+		const oldValue = process.env.NODE_ENV;
+		before((done) => {
+			process.env.NODE_ENV = 'development';
+			done();
+		});
+		after((done) => {
+			process.env.NODE_ENV = oldValue;
+			done();
+		});
 
-	// 	it('should install a plugin', function (done) {
-	// 		this.timeout(0);
-	// 		plugins.toggleInstall(pluginName, '1.0.16', (err, pluginData) => {
-	// 			assert.ifError(err);
-	// 			latest = pluginData.latest;
+		it('should install a plugin', function (done) {
+			this.timeout(0);
+			plugins.toggleInstall(pluginName, '1.0.16', (err, pluginData) => {
+				assert.ifError(err);
+				latest = pluginData.latest;
 
-	// 			assert.equal(pluginData.name, pluginName);
-	// 			assert.equal(pluginData.id, pluginName);
-	// 			assert.equal(pluginData.url, 'https://github.com/barisusakli/nodebb-plugin-imgur#readme');
-	// 			assert.equal(pluginData.description, 'A Plugin that uploads images to imgur');
-	// 			assert.equal(pluginData.active, false);
-	// 			assert.equal(pluginData.installed, true);
+				assert.equal(pluginData.name, pluginName);
+				assert.equal(pluginData.id, pluginName);
+				assert.equal(pluginData.url, 'https://github.com/barisusakli/nodebb-plugin-imgur#readme');
+				assert.equal(pluginData.description, 'A Plugin that uploads images to imgur');
+				assert.equal(pluginData.active, false);
+				assert.equal(pluginData.installed, true);
 
-	// 			const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
-	// 			assert(packageFile.dependencies[pluginName]);
+				const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+				assert(packageFile.dependencies[pluginName]);
 
-	// 			done();
-	// 		});
-	// 	});
+				done();
+			});
+		});
 
-	// 	it('should activate plugin', (done) => {
-	// 		plugins.toggleActive(pluginName, (err) => {
-	// 			assert.ifError(err);
-	// 			plugins.isActive(pluginName, (err, isActive) => {
-	// 				assert.ifError(err);
-	// 				assert(isActive);
-	// 				done();
-	// 			});
-	// 		});
-	// 	});
+		it('should activate plugin', (done) => {
+			plugins.toggleActive(pluginName, (err) => {
+				assert.ifError(err);
+				plugins.isActive(pluginName, (err, isActive) => {
+					assert.ifError(err);
+					assert(isActive);
+					done();
+				});
+			});
+		});
 
-	// 	it('should upgrade plugin', function (done) {
-	// 		this.timeout(0);
-	// 		plugins.upgrade(pluginName, 'latest', (err, isActive) => {
-	// 			assert.ifError(err);
-	// 			assert(isActive);
-	// 			plugins.loadPluginInfo(path.join(nconf.get('base_dir'), 'node_modules', pluginName), (err, pluginInfo) => {
-	// 				assert.ifError(err);
-	// 				assert.equal(pluginInfo.version, latest);
-	// 				done();
-	// 			});
-	// 		});
-	// 	});
+		it('should upgrade plugin', function (done) {
+			this.timeout(0);
+			plugins.upgrade(pluginName, 'latest', (err, isActive) => {
+				assert.ifError(err);
+				assert(isActive);
+				plugins.loadPluginInfo(path.join(nconf.get('base_dir'), 'node_modules', pluginName), (err, pluginInfo) => {
+					assert.ifError(err);
+					assert.equal(pluginInfo.version, latest);
+					done();
+				});
+			});
+		});
 
-	// 	it('should uninstall a plugin', function (done) {
-	// 		this.timeout(0);
-	// 		plugins.toggleInstall(pluginName, 'latest', (err, pluginData) => {
-	// 			assert.ifError(err);
-	// 			assert.equal(pluginData.installed, false);
-	// 			assert.equal(pluginData.active, false);
+		it('should uninstall a plugin', function (done) {
+			this.timeout(0);
+			plugins.toggleInstall(pluginName, 'latest', (err, pluginData) => {
+				assert.ifError(err);
+				assert.equal(pluginData.installed, false);
+				assert.equal(pluginData.active, false);
 
-	// 			const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
-	// 			assert(!packageFile.dependencies[pluginName]);
+				const packageFile = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf8'));
+				assert(!packageFile.dependencies[pluginName]);
 
-	// 			done();
-	// 		});
-	// 	});
-	// });
+				done();
+			});
+		});
+	});
 
-	// describe('static assets', () => {
-	// 	it('should 404 if resource does not exist', (done) => {
-	// 		request.get(`${nconf.get('url')}/plugins/doesnotexist/should404.tpl`, (err, res, body) => {
-	// 			assert.ifError(err);
-	// 			assert.equal(res.statusCode, 404);
-	// 			assert(body);
-	// 			done();
-	// 		});
-	// 	});
+	describe('static assets', () => {
+		it('should 404 if resource does not exist', (done) => {
+			request.get(`${nconf.get('url')}/plugins/doesnotexist/should404.tpl`, (err, res, body) => {
+				assert.ifError(err);
+				assert.equal(res.statusCode, 404);
+				assert(body);
+				done();
+			});
+		});
 
-	// 	it('should 404 if resource does not exist', (done) => {
-	// 		const url = `${nconf.get('url')}/plugins/nodebb-plugin-dbsearch/dbsearch/templates/admin/plugins/should404.tpl`;
-	// 		request.get(url, (err, res, body) => {
-	// 			assert.ifError(err);
-	// 			assert.equal(res.statusCode, 404);
-	// 			assert(body);
-	// 			done();
-	// 		});
-	// 	});
+		it('should 404 if resource does not exist', (done) => {
+			const url = `${nconf.get('url')}/plugins/nodebb-plugin-dbsearch/dbsearch/templates/admin/plugins/should404.tpl`;
+			request.get(url, (err, res, body) => {
+				assert.ifError(err);
+				assert.equal(res.statusCode, 404);
+				assert(body);
+				done();
+			});
+		});
 
-	// 	it('should get resource', (done) => {
-	// 		const url = `${nconf.get('url')}/assets/templates/admin/plugins/dbsearch.tpl`;
-	// 		request.get(url, (err, res, body) => {
-	// 			assert.ifError(err);
-	// 			assert.equal(res.statusCode, 200);
-	// 			assert(body);
-	// 			done();
-	// 		});
-	// 	});
-	// });
+		it('should get resource', (done) => {
+			const url = `${nconf.get('url')}/assets/templates/admin/plugins/dbsearch.tpl`;
+			request.get(url, (err, res, body) => {
+				assert.ifError(err);
+				assert.equal(res.statusCode, 200);
+				assert(body);
+				done();
+			});
+		});
+	});
 
 	describe('plugin state set in configuration', () => {
 		const activePlugins = [

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -319,6 +319,71 @@ describe('Plugins', () => {
 			});
 		});
 	});
+
+	describe('plugin state set in configuration', () => {
+		const activePlugins = [
+			'nodebb-plugin-markdown',
+			'nodebb-plugin-mentions',
+		];
+		const inactivePlugin = 'nodebb-plugin-emoji';
+		beforeEach((done) => {
+			nconf.set('plugins:active', activePlugins, () => done());
+		});
+		afterEach((done) => {
+			nconf.reset('plugins:active', activePlugins, () => done());
+		});
+
+		it('should return active plugin state from configuration', (done) => {
+			plugins.isActive(activePlugins[0], (err, isActive) => {
+				assert.ifError(err);
+				assert(isActive);
+				done();
+			});
+		});
+
+		it('should return inactive plugin state if not in configuration', (done) => {
+			plugins.isActive(inactivePlugin, (err, isActive) => {
+				assert.ifError(err);
+				assert(!isActive);
+				done();
+			});
+		});
+
+		it('should get a list of plugins from configuration', (done) => {
+			plugins.list((err, data) => {
+				assert.ifError(err);
+				const keys = ['id', 'name', 'url', 'description', 'latest', 'installed', 'active', 'latest'];
+				assert(Array.isArray(data));
+				keys.forEach((key) => {
+					assert(data[0].hasOwnProperty(key));
+				});
+				data.forEach((plugin) => {
+					assert(activePlugins.includes(plugin.id));
+				});
+				done();
+			});
+		});
+
+		it('should not deactivate a plugin if active plugins are set in configuration', async (done) => {
+			assert.rejects(plugins.toggleActive(activePlugins[0]), Error).then(() => {
+				plugins.isActive(activePlugins[0], (err, isActive) => {
+					assert.ifError(err);
+					assert(isActive);
+					done();
+				});
+			});
+		});
+
+		it('should not activate a plugin if active plugins are set in configuration', async (done) => {
+			assert.rejects(plugins.toggleActive(inactivePlugin), Error).then(() => {
+				plugins.isActive(inactivePlugin, (err, isActive) => {
+					assert.ifError(err);
+					assert(!isActive);
+					done();
+				});
+			});
+		});
+	});
 });
 
 

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -331,7 +331,7 @@ describe('Plugins', () => {
 			done();
 		});
 		afterEach((done) => {
-			nconf.reset('plugins:active', activePlugins);
+			nconf.remove('plugins:active', activePlugins);
 			done();
 		});
 

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -366,6 +366,17 @@ describe('Plugins', () => {
 			});
 		});
 
+		it('should return a list of only active plugins from configuration', (done) => {
+			plugins.getActive((err, data) => {
+				assert.ifError(err);
+				assert(Array.isArray(data));
+				data.forEach((pluginData) => {
+					assert(activePlugins.includes(pluginData.id));
+				});
+				done();
+			});
+		});
+
 		it('should not deactivate a plugin if active plugins are set in configuration', (done) => {
 			assert.rejects(plugins.toggleActive(activePlugins[0]), Error).then(() => {
 				plugins.isActive(activePlugins[0], (err, isActive) => {


### PR DESCRIPTION
resolves #10766 and supersedes #10036

Things left:
- [x] Theme selection doesn't inform the user the change also needs to happen in the config on the frontend - the message only appear in the logs.
- [x] Might be possible to just remove the disable/enable button from ACP rather than throwing errors?
- [x] Currently I'm using one generic error for all situations, perhaps there should at least be a theme specific one?
- [x] Add tests