### PR TITLE
fix(ACP): cannot setting networks for sharing posts

### DIFF
--- a/src/social.js
+++ b/src/social.js
@@ -41,12 +41,12 @@ social.getActivePostSharing = async function () {
 };
 
 social.setActivePostSharingNetworks = async function (networkIDs) {
+	social.postSharing = null;
 	await db.delete('social:posts.activated');
 	if (!networkIDs.length) {
 		return;
 	}
 	await db.setAdd('social:posts.activated', networkIDs);
-	social.postSharing = null;
 };
 
 require('./promisify')(social);

--- a/src/views/admin/settings/social.tpl
+++ b/src/views/admin/settings/social.tpl
@@ -1,4 +1,4 @@
-<div class="social settings">
+<div class="social">
 	<form role="form">
 		<div class="row">
 			<div class="col-sm-2 col-xs-12 settings-header">[[admin/settings/social:post-sharing]]</div>


### PR DESCRIPTION
Fixes "ACP > SETTINGS > Social" is loading/saving from/to `config` object instead of `social:posts.activated` object.

This problem occurs because these lines in [admin.js#L48-L53](https://github.com/NodeBB/NodeBB/blob/master/public/src/admin/admin.js#L48-L53) require 'admin/settings' and call `Settings.prepare()` if there is an element that has a `settings` class on the page.
[settings.js#L66-L92](https://github.com/NodeBB/NodeBB/blob/8d109fef47fddb026a8ffa8fe950134011b2607c/public/src/admin/settings.js#L66-L92) makes the "save button" saves fields to `config` object instead of to `social:posts.activated` object as [social.js#L8-L24](https://github.com/NodeBB/NodeBB/blob/master/public/src/admin/settings/social.js#L8-L24) does.

The fix is pretty simple, remove the settings class in social.tpl file. 😄