### PR TITLE
fix: return at least one in sizeCalculation

### DIFF
--- a/src/posts/cache.js
+++ b/src/posts/cache.js
@@ -6,7 +6,7 @@ const meta = require('../meta');
 module.exports = cacheCreate({
 	name: 'post',
 	maxSize: meta.config.postCacheSize,
-	sizeCalculation: function (n) { return n.length; },
+	sizeCalculation: function (n) { return n.length || 1; },
 	ttl: 0,
 	enabled: global.env === 'production',
 });


### PR DESCRIPTION
if post content is empty post cache should still consider its size to be one. Required since lru-cache only accepts positive integers in as return value of sizeCalulation.

Unless I missed something, post cache is the only cache instance in NodeBB that uses `maxSize` and `sizeCalculation`, so this should be the only place this bug exists.

fixes #10831