### PR TITLE
Roll back passport

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -104,7 +104,7 @@
         "nodebb-widget-essentials": "6.0.0",
         "nodemailer": "6.7.7",
         "nprogress": "0.2.0",
-        "passport": "0.6.0",
+        "passport": "0.5.2",
         "passport-http-bearer": "1.0.1",
         "passport-local": "1.0.0",
         "pg": "8.7.3",

--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -351,7 +351,7 @@ authenticationController.doLogin = async function (req, uid) {
 		}
 	}
 
-	await loginAsync({ uid: uid }, { keepSessionInfo: true });
+	await loginAsync({ uid: uid });
 	await authenticationController.onSuccessfulLogin(req, uid);
 };
 
@@ -459,7 +459,6 @@ authenticationController.localLogin = async function (req, username, password, n
 };
 
 const destroyAsync = util.promisify((req, callback) => req.session.destroy(callback));
-const logoutAsync = util.promisify((req, callback) => req.logout(callback));
 
 authenticationController.logout = async function (req, res, next) {
 	if (!req.loggedIn || !req.sessionID) {
@@ -471,7 +470,7 @@ authenticationController.logout = async function (req, res, next) {
 
 	try {
 		await user.auth.revokeSession(sessionID, uid);
-		await logoutAsync(req);
+		req.logout();
 
 		await destroyAsync(req);
 		res.clearCookie(nconf.get('sessionKey'), meta.configs.cookie.get());

--- a/src/middleware/header.js
+++ b/src/middleware/header.js
@@ -41,10 +41,8 @@ middleware.buildHeader = helpers.try(async (req, res, next) => {
 	]);
 
 	if (!canLoginIfBanned && req.loggedIn) {
-		req.logout(() => {
-			res.redirect('/');
-		});
-		return;
+		req.logout();
+		return res.redirect('/');
 	}
 
 	res.locals.config = config;

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -35,7 +35,7 @@ module.exports = function (middleware) {
 	async function authenticate(req, res) {
 		async function finishLogin(req, user) {
 			const loginAsync = util.promisify(req.login).bind(req);
-			await loginAsync(user, { keepSessionInfo: true });
+			await loginAsync(user);
 			await controllers.authentication.onSuccessfulLogin(req, user.uid);
 			req.uid = user.uid;
 			req.loggedIn = req.uid > 0;

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -139,7 +139,7 @@ Auth.reloadRoutes = async function (params) {
 			})(req, res, next);
 		}, Auth.middleware.validateAuth, (req, res, next) => {
 			async.waterfall([
-				async.apply(req.login.bind(req), res.locals.user, { keepSessionInfo: true }),
+				async.apply(req.login.bind(req), res.locals.user),
 				async.apply(controllers.authentication.onSuccessfulLogin, req, req.uid),
 			], (err) => {
 				if (err) {


### PR DESCRIPTION
This reverts commit 6b2a6f9006602796666e72c6a4f530b726409bf2.

This revert is needed as upgrading to passport v0.6 is considered a breaking change as all calls to `.login()`/`.logout()`/`.authenticate()` now re-roll the session by default, meaning all SSO plugins (and 2factor plugin) break.
