### PR TITLE
User Exports via v3 API

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -86,6 +86,8 @@ paths:
     $ref: 'write/users/uid/emails/email.yaml'
   /users/{uid}/emails/{email}/confirm:
     $ref: 'write/users/uid/emails/email/confirm.yaml'
+  /users/{uid}/exports/{type}:
+    $ref: 'write/users/uid/exports/type.yaml'
   /groups/:
     $ref: 'write/groups.yaml'
   /groups/{slug}:

--- a/public/openapi/write/users/uid/exports/type.yaml
+++ b/public/openapi/write/users/uid/exports/type.yaml
@@ -1,0 +1,85 @@
+head:
+  tags:
+    - users
+  summary: Check if a user's export exists
+  parameters:
+    - in: path
+      name: uid
+      schema:
+        type: integer
+      required: true
+      description: uid of the user to make the query for
+      example: 1
+    - in: path
+      name: type
+      schema:
+        type: string
+      required: true
+      description: The type of export to query
+      example: posts
+  responses:
+    '204':
+      description: Exported file found.
+    '404':
+      description: Exported file not found — this could be because an export has never been generated for this user.
+get:
+  tags:
+    - users
+  summary: Download a user's exported data
+  parameters:
+    - in: path
+      name: uid
+      schema:
+        type: integer
+      required: true
+      description: uid of the user to make the query for
+      example: 1
+    - in: path
+      name: type
+      schema:
+        type: string
+      required: true
+      description: The type of export to download
+      example: posts
+  responses:
+    '200':
+      description: A download containing the requested exported data
+    '404':
+      description: Exported file not found — this could be because an export has never been generated for this user.
+post:
+  tags:
+    - users
+  summary: Generate a user export
+  description: |
+    This operation generates a user export file for later download.
+    It will return immediately with the `202 Accepted` response code, meaning the request was accepted for processing.
+    The expected behaviour is for the client to then poll the corresponding `HEAD` method until it returns a `204 No Content`
+    (or if awaiting a new export, for the `Last-Modified` or `ETag` header to change)
+    at which point the `GET` method can be called for download.
+  parameters:
+    - in: path
+      name: uid
+      schema:
+        type: integer
+      required: true
+      description: uid of the user to make the query for
+      example: 1
+    - in: path
+      name: type
+      schema:
+        type: string
+      required: true
+      description: The type of export to download
+      example: posts
+  responses:
+    '202':
+      description: Successfully started generating the requested user export
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object

--- a/public/src/client/account/consent.js
+++ b/public/src/client/account/consent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('forum/account/consent', ['forum/account/header', 'alerts'], function (header, alerts) {
+define('forum/account/consent', ['forum/account/header', 'alerts', 'api'], function (header, alerts, api) {
 	const Consent = {};
 
 	Consent.init = function () {
@@ -17,18 +17,15 @@ define('forum/account/consent', ['forum/account/header', 'alerts'], function (he
 			});
 		});
 
-		handleExport($('[data-action="export-profile"]'), 'user.exportProfile', '[[user:consent.export-profile-success]]');
-		handleExport($('[data-action="export-posts"]'), 'user.exportPosts', '[[user:consent.export-posts-success]]');
-		handleExport($('[data-action="export-uploads"]'), 'user.exportUploads', '[[user:consent.export-uploads-success]]');
+		handleExport($('[data-action="export-profile"]'), 'profile', '[[user:consent.export-profile-success]]');
+		handleExport($('[data-action="export-posts"]'), 'posts', '[[user:consent.export-posts-success]]');
+		handleExport($('[data-action="export-uploads"]'), 'uploads', '[[user:consent.export-uploads-success]]');
 
-		function handleExport(el, method, success) {
+		function handleExport(el, type, success) {
 			el.on('click', function () {
-				socket.emit(method, { uid: ajaxify.data.uid }, function (err) {
-					if (err) {
-						return alerts.error(err);
-					}
+				api.post(`/users/${ajaxify.data.uid}/exports/${type}`).then(() => {
 					alerts.success(success);
-				});
+				}).catch(alerts.error);
 			});
 		}
 	};

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -434,11 +434,22 @@ helpers.formatApiResponse = async (statusCode, res, payload) => {
 			res.set('cache-control', 'private');
 		}
 
+		let code = 'ok';
+		let message = 'OK';
+		switch (statusCode) {
+			case 202:
+				code = 'accepted';
+				message = 'Accepted';
+				break;
+
+			case 204:
+				code = 'no-content';
+				message = 'No Content';
+				break;
+		}
+
 		res.status(statusCode).json({
-			status: {
-				code: 'ok',
-				message: 'OK',
-			},
+			status: { code, message },
 			response: payload || {},
 		});
 	} else if (payload instanceof Error) {

--- a/src/controllers/user.js
+++ b/src/controllers/user.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const winston = require('winston');
 
 const user = require('../user');
 const privileges = require('../privileges');
@@ -90,7 +91,10 @@ userController.exportProfile = async function (req, res, next) {
 	sendExport(`${res.locals.uid}_profile.json`, 'application/json', res, next);
 };
 
+// DEPRECATED; Remove in NodeBB v3.0.0
 function sendExport(filename, type, res, next) {
+	winston.warn(`[users/export] Access via page API is deprecated, use GET /api/v3/users/:uid/exports/:type instead.`);
+
 	res.sendFile(filename, {
 		root: path.join(__dirname, '../../build/export'),
 		headers: {

--- a/src/routes/write/users.js
+++ b/src/routes/write/users.js
@@ -51,6 +51,10 @@ function authenticatedRoutes() {
 	setupApiRoute(router, 'get', '/:uid/emails/:email', [...middlewares, middleware.assert.user], controllers.write.users.getEmail);
 	setupApiRoute(router, 'post', '/:uid/emails/:email/confirm', [...middlewares, middleware.assert.user], controllers.write.users.confirmEmail);
 
+	setupApiRoute(router, 'head', '/:uid/exports/:type', [...middlewares, middleware.assert.user, middleware.checkAccountPermissions], controllers.write.users.checkExportByType);
+	setupApiRoute(router, 'get', '/:uid/exports/:type', [...middlewares, middleware.assert.user, middleware.checkAccountPermissions], controllers.write.users.getExportByType);
+	setupApiRoute(router, 'post', '/:uid/exports/:type', [...middlewares, middleware.assert.user, middleware.checkAccountPermissions], controllers.write.users.generateExportsByType);
+
 	// Shorthand route to access user routes by userslug
 	router.all('/+bySlug/:userslug*?', [], controllers.write.users.redirectBySlug);
 }

--- a/src/socket.io/user/profile.js
+++ b/src/socket.io/user/profile.js
@@ -1,13 +1,11 @@
 'use strict';
 
-const winston = require('winston');
-
 const user = require('../../user');
-const events = require('../../events');
-const notifications = require('../../notifications');
 const privileges = require('../../privileges');
-const db = require('../../database');
 const plugins = require('../../plugins');
+
+const sockets = require('..');
+const api = require('../../api');
 
 module.exports = function (SocketUser) {
 	SocketUser.updateCover = async function (socket, data) {
@@ -64,6 +62,8 @@ module.exports = function (SocketUser) {
 	};
 
 	async function doExport(socket, data, type) {
+		sockets.warnDeprecated(socket, 'POST /api/v3/users/:uid/exports/:type');
+
 		if (!socket.uid) {
 			throw new Error('[[error:invalid-uid]]');
 		}
@@ -74,36 +74,6 @@ module.exports = function (SocketUser) {
 
 		await user.isAdminOrSelf(socket.uid, data.uid);
 
-		const count = await db.incrObjectField('locks', `export:${data.uid}${type}`);
-		if (count > 1) {
-			throw new Error('[[error:already-exporting]]');
-		}
-
-		const child = require('child_process').fork(`./src/user/jobs/export-${type}.js`, [], {
-			env: process.env,
-		});
-		child.send({ uid: data.uid });
-		child.on('error', async (err) => {
-			winston.error(err.stack);
-			await db.deleteObjectField('locks', `export:${data.uid}${type}`);
-		});
-		child.on('exit', async () => {
-			await db.deleteObjectField('locks', `export:${data.uid}${type}`);
-			const userData = await user.getUserFields(data.uid, ['username', 'userslug']);
-			const { displayname } = userData;
-			const n = await notifications.create({
-				bodyShort: `[[notifications:${type}-exported, ${displayname}]]`,
-				path: `/api/user/${userData.userslug}/export/${type}`,
-				nid: `${type}:export:${data.uid}`,
-				from: data.uid,
-			});
-			await notifications.push(n, [socket.uid]);
-			await events.log({
-				type: `export:${type}`,
-				uid: socket.uid,
-				targetUid: data.uid,
-				ip: socket.ip,
-			});
-		});
+		api.users.generateExport(socket, { type, ...data });
 	}
 };


### PR DESCRIPTION
- feat: allow v3 api to handle 202 and 204 response codes as well.
- refactor: move export generation logic to v3 controller, GET/HEAD routes for exports
- fix: use api v3 for user export routes on client-side
