### PR TITLE
fix: change how zxcvbn is required so that its removal from the minified entry point file is not breaking

### DIFF
--- a/public/src/client/account/edit/password.js
+++ b/public/src/client/account/edit/password.js
@@ -1,13 +1,14 @@
 'use strict';
 
 define('forum/account/edit/password', [
-	'forum/account/header', 'translator', 'zxcvbn', 'api', 'alerts',
-], function (header, translator, zxcvbn, api, alerts) {
+	'forum/account/header', 'translator', 'api', 'alerts',
+], function (header, translator, api, alerts) {
 	const AccountEditPassword = {};
 
 	AccountEditPassword.init = function () {
 		header.init();
 
+		utils.requireZxcvbn();
 		handlePasswordChange();
 	};
 
@@ -24,7 +25,7 @@ define('forum/account/edit/password', [
 			passwordvalid = false;
 
 			try {
-				utils.assertPasswordValidity(password.val(), zxcvbn);
+				utils.assertPasswordValidity(password.val());
 
 				if (password.val() === ajaxify.data.username) {
 					throw new Error('[[user:password_same_as_username]]');

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -2,8 +2,8 @@
 
 
 define('forum/register', [
-	'translator', 'slugify', 'api', 'bootbox', 'forum/login', 'jquery-form', 'zxcvbn',
-], function (translator, slugify, api, bootbox, Login, zxcvbn) {
+	'translator', 'slugify', 'api', 'bootbox', 'forum/login', 'jquery-form',
+], function (translator, slugify, api, bootbox, Login) {
 	const Register = {};
 	let validationError = false;
 	const successIcon = '';
@@ -14,6 +14,7 @@ define('forum/register', [
 		const password_confirm = $('#password-confirm');
 		const register = $('#register');
 
+		utils.requireZxcvbn();
 		handleLanguageOverride();
 
 		$('#content #noscript').val('false');
@@ -143,7 +144,7 @@ define('forum/register', [
 		const password_confirm_notify = $('#password-confirm-notify');
 
 		try {
-			utils.assertPasswordValidity(password, zxcvbn);
+			utils.assertPasswordValidity(password);
 
 			if (password === $('#username').val()) {
 				throw new Error('[[user:password_same_as_username]]');

--- a/public/src/client/reset_code.js
+++ b/public/src/client/reset_code.js
@@ -1,10 +1,12 @@
 'use strict';
 
 
-define('forum/reset_code', ['alerts', 'zxcvbn'], function (alerts, zxcvbn) {
+define('forum/reset_code', ['alerts'], function (alerts) {
 	const ResetCode = {};
 
 	ResetCode.init = function () {
+		utils.requireZxcvbn();
+
 		const reset_code = ajaxify.data.code;
 
 		const resetEl = $('#reset');
@@ -13,7 +15,7 @@ define('forum/reset_code', ['alerts', 'zxcvbn'], function (alerts, zxcvbn) {
 
 		resetEl.on('click', function () {
 			try {
-				utils.assertPasswordValidity(password.val(), zxcvbn);
+				utils.assertPasswordValidity(password.val());
 
 				if (password.val() !== repeat.val()) {
 					throw new Error('[[reset_password:passwords_do_not_match]]');

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -6,6 +6,13 @@ const $ = require('jquery');
 
 const utils = { ...require('./utils.common') };
 
+utils.requireZxcvbn = async () => new Promise((resolve) => {
+	require(['zxcvbn'], (zxcvbn) => {
+		app.zxcvbn = zxcvbn;
+		resolve(zxcvbn);
+	});
+});
+
 utils.getLanguage = function () {
 	let lang = 'en-GB';
 	if (typeof window === 'object' && window.config && window.utils) {
@@ -56,7 +63,7 @@ utils.isMobile = function () {
 	});
 };
 
-utils.assertPasswordValidity = (password, zxcvbn) => {
+utils.assertPasswordValidity = (password) => {
 	// More checks on top of basic utils.isPasswordValid()
 	if (!utils.isPasswordValid(password)) {
 		throw new Error('[[user:change_password_error]]');
@@ -66,7 +73,7 @@ utils.assertPasswordValidity = (password, zxcvbn) => {
 		throw new Error('[[error:password-too-long]]');
 	}
 
-	const passwordStrength = zxcvbn(password);
+	const passwordStrength = app.zxcvbn(password);
 	if (passwordStrength.score < ajaxify.data.minimumPasswordStrength) {
 		throw new Error('[[user:weak_password]]');
 	}


### PR DESCRIPTION
This is an attempt to fix the breaking nature of b7addffc9e13e71145394b72291db93a7f076d82

It works because every invocation of utils.assertPasswordValidity is tied to a user action, so zxcvbn is not needed _immediately_ on page load.
At the init step of each page that needs to call `utils.assertPasswordValidity()`, we require zxcvbn asynchronously.

A follow-up commit to this PR will be made to put all of this inside of `utils.assertPasswordValidity()`.
