### PR TITLE
J and K as topic navigation hotkeys

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -73,19 +73,39 @@ define('forum/topic', [
 	};
 
 	function handleTopicSearch() {
-		if (config.topicSearchEnabled) {
-			require(['mousetrap', 'search'], function (mousetrap, search) {
-				mousetrap.bind(['command+f', 'ctrl+f'], function (e) {
-					e.preventDefault();
-					$('#search-fields input').val('in:topic-' + ajaxify.data.tid + ' ');
-					search.showAndFocusInput();
-				});
+		require(['mousetrap'], (mousetrap) => {
+			if (config.topicSearchEnabled) {
+				require(['search'], function (search) {
+					mousetrap.bind(['command+f', 'ctrl+f'], function (e) {
+						e.preventDefault();
+						$('#search-fields input').val('in:topic-' + ajaxify.data.tid + ' ');
+						search.showAndFocusInput();
+					});
 
-				hooks.onPage('action:ajaxify.cleanup', () => {
-					mousetrap.unbind(['command+f', 'ctrl+f']);
+					hooks.onPage('action:ajaxify.cleanup', () => {
+						mousetrap.unbind(['command+f', 'ctrl+f']);
+					});
 				});
+			}
+
+			mousetrap.bind('j', () => {
+				const index = navigator.getIndex();
+				const count = navigator.getCount();
+				if (index === count) {
+					return;
+				}
+
+				navigator.scrollToIndex(index, true, 0);
 			});
-		}
+
+			mousetrap.bind('k', () => {
+				const index = navigator.getIndex();
+				if (index === 1) {
+					return;
+				}
+				navigator.scrollToIndex(index - 2, true, 0);
+			});
+		});
 	}
 
 	Topic.toTop = function () {

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -581,9 +581,9 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 		function animateScroll() {
 			function reenableScroll() {
 				// Re-enable onScroll behaviour
-				$(window).on('scroll', navigator.delayedUpdate);
-				const scrollToRect = scrollTo.get(0).getBoundingClientRect();
-				navigator.update(scrollToRect.top);
+				setTimeout(() => { // fixes race condition from jQuery — onAnimateComplete called too quickly
+					$(window).on('scroll', navigator.delayedUpdate);
+				}, 50);
 			}
 			function onAnimateComplete() {
 				if (done) {

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -47,7 +47,6 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 		thumb = $('.scroller-thumb');
 		thumbText = thumb.find('.thumb-text');
 
-
 		$(window).off('scroll', navigator.delayedUpdate).on('scroll', navigator.delayedUpdate);
 
 		paginationBlockEl.find('.dropdown-menu').off('click').on('click', function (e) {
@@ -331,6 +330,8 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 		return parts[1] + '/' + parts[2] + '/' + parts[3] + (index ? '/' + index : '');
 	}
 
+	navigator.getCount = () => count;
+
 	navigator.setCount = function (value) {
 		value = parseInt(value, 10);
 		if (value === count) {
@@ -438,6 +439,13 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 		}
 
 		toggle(!!count);
+	};
+
+	navigator.getIndex = () => index;
+
+	navigator.setIndex = (newIndex) => {
+		index = newIndex + 1;
+		navigator.updateTextAndProgressBar();
 	};
 
 	navigator.updateTextAndProgressBar = function () {

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -446,6 +446,7 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 	navigator.setIndex = (newIndex) => {
 		index = newIndex + 1;
 		navigator.updateTextAndProgressBar();
+		setThumbToIndex(index);
 	};
 
 	navigator.updateTextAndProgressBar = function () {

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -561,11 +561,13 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 		navigator.scrollToElement(scrollTo, highlight, duration, topicIndex);
 	};
 
-	navigator.scrollToElement = function (scrollTo, highlight, duration, newIndex = null) {
+	navigator.scrollToElement = async (scrollTo, highlight, duration, newIndex = null) => {
 		if (!scrollTo.length) {
 			navigator.scrollActive = false;
 			return;
 		}
+
+		await hooks.fire('filter:navigator.scroll', { scrollTo, highlight, duration, newIndex });
 
 		const postHeight = scrollTo.outerHeight(true);
 		const navbarHeight = components.get('navbar').outerHeight(true);
@@ -584,6 +586,8 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 				// Re-enable onScroll behaviour
 				setTimeout(() => { // fixes race condition from jQuery — onAnimateComplete called too quickly
 					$(window).on('scroll', navigator.delayedUpdate);
+
+					hooks.fire('action:navigator.scrolled', { scrollTo, highlight, duration, newIndex });
 				}, 50);
 			}
 			function onAnimateComplete() {

--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -552,15 +552,15 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 
 	navigator.scrollToPostIndex = function (postIndex, highlight, duration) {
 		const scrollTo = components.get('post', 'index', postIndex);
-		navigator.scrollToElement(scrollTo, highlight, duration);
+		navigator.scrollToElement(scrollTo, highlight, duration, postIndex);
 	};
 
 	navigator.scrollToTopicIndex = function (topicIndex, highlight, duration) {
 		const scrollTo = $('[component="category/topic"][data-index="' + topicIndex + '"]');
-		navigator.scrollToElement(scrollTo, highlight, duration);
+		navigator.scrollToElement(scrollTo, highlight, duration, topicIndex);
 	};
 
-	navigator.scrollToElement = function (scrollTo, highlight, duration) {
+	navigator.scrollToElement = function (scrollTo, highlight, duration, newIndex = null) {
 		if (!scrollTo.length) {
 			navigator.scrollActive = false;
 			return;
@@ -594,8 +594,13 @@ define('navigator', ['forum/pagination', 'components', 'hooks', 'alerts'], funct
 
 				navigator.scrollActive = false;
 				highlightPost();
-				$('body').scrollTop($('body').scrollTop() - 1);
-				$('html').scrollTop($('html').scrollTop() - 1);
+
+				const scrollToRect = scrollTo.get(0).getBoundingClientRect();
+				if (!newIndex) {
+					navigator.update(scrollToRect.top);
+				} else {
+					navigator.setIndex(newIndex);
+				}
 			}
 
 			let scrollTop = 0;


### PR DESCRIPTION
- feat: a couple utility methods in navigator module to get and set count and index
- fix: race condition where `navigator.update` was called when it should not be
- fix: do not call `navigator.update()` when `scrollToElement` is explicitly passed a new index value
- feat: j and k hotkeys in topic to navigate through it quickly
