### PR TITLE
fix: type error when item param is null

### DIFF
--- a/src/navigation/admin.js
+++ b/src/navigation/admin.js
@@ -65,7 +65,7 @@ admin.get = async function () {
 	}
 	const ids = await db.getSortedSetRange('navigation:enabled', 0, -1);
 	const data = await db.getObjects(ids.map(id => `navigation:enabled:${id}`));
-	cache = data.map((item) => {
+	cache = data.filter(x => x).map((item) => {
 		if (item.hasOwnProperty('groups')) {
 			try {
 				item.groups = JSON.parse(item.groups);


### PR DESCRIPTION
While migrating data (stored in redis) from an old (`v0.7.2`) nodebb to the latest version (`2.5.7`) I ran into the following issue when starting nodebb:

```
→ [2018/11/10] Navigation item visibility groups...Error occurred
2022-11-03T19:26:32.749Z [10347] - warn: NodeBB Setup Aborted.
 TypeError: Cannot read properties of null (reading 'hasOwnProperty')
    at /home/nodebb/nodebb/src/navigation/admin.js:69:12
    at Array.map (<anonymous>)
    at admin.get (/home/nodebb/nodebb/src/navigation/admin.js:68:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.method (/home/nodebb/nodebb/src/upgrades/1.11.0/navigation_visibility_groups.js:9:16)
    at async Upgrade.process (/home/nodebb/nodebb/src/upgrade.js:161:4)
    at async Upgrade.run (/home/nodebb/nodebb/src/upgrade.js:110:2)
    at async checkUpgrade (/home/nodebb/nodebb/src/install.js:559:4)
    at async install.setup (/home/nodebb/nodebb/src/install.js:583:3)
    at async Object.setup (/home/nodebb/nodebb/src/cli/setup.js:23:15)
```

As a workaround I propose the changes below. Please be aware that I'm not (yet?) at all familiar with nodebb's codebase and hence cannot judge whether a this is a valid solution or a different approach provides more merit.

I'm happy to provide more information on the migrated data, the commands I ran etc. if this would be helpful to the reviewers.