### PR TITLE
Client-side form validity checking (via `pattern` attribute)

### DIFF
--- a/public/language/en-GB/admin/settings/email.json
+++ b/public/language/en-GB/admin/settings/email.json
@@ -40,6 +40,7 @@
 	"subscriptions.disable": "Disable email digests",
 	"subscriptions.hour": "Digest Hour",
 	"subscriptions.hour-help": "Please enter a number representing the hour to send scheduled email digests (e.g. <code>0</code> for midnight, <code>17</code> for 5:00pm). Keep in mind that this is the hour according to the server itself, and may not exactly match your system clock.<br /> The approximate server time is: <span id=\"serverTime\"></span><br /> The next daily digest is scheduled to be sent  <span id=\"nextDigestTime\"></span>",
+	"subscriptions.hour-hint": "a number between 0 and 24",
 	"notifications.remove-images": "Remove images from email notifications",
 	"require-email-address": "Require new users to specify an email address",
 	"require-email-address-warning": "By default, users can opt-out of entering an email address by leaving the field blank. Enabling this option means they have to enter an email address in order to proceed with registration. <strong>It does not ensure user will enter a real email address, nor even an address they own.</strong>",

--- a/public/src/admin/settings.js
+++ b/public/src/admin/settings.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('admin/settings', ['uploader', 'mousetrap', 'hooks', 'alerts'], function (uploader, mousetrap, hooks, alerts) {
+define('admin/settings', ['uploader', 'mousetrap', 'hooks', 'alerts', 'settings'], function (uploader, mousetrap, hooks, alerts, settings) {
 	const Settings = {};
 
 	Settings.populateTOC = function () {
@@ -65,6 +65,11 @@ define('admin/settings', ['uploader', 'mousetrap', 'hooks', 'alerts'], function 
 
 		saveBtn.off('click').on('click', function (e) {
 			e.preventDefault();
+
+			const ok = settings.check(document.querySelectorAll('#content [data-field][pattern]'));
+			if (!ok) {
+				return;
+			}
 
 			saveFields(fields, function onFieldsSaved(err) {
 				if (err) {

--- a/public/src/modules/settings.js
+++ b/public/src/modules/settings.js
@@ -517,6 +517,12 @@ define('settings', ['hooks', 'alerts'], function (hooks, alerts) {
 		save: function (hash, formEl, callback) {
 			formEl = $(formEl);
 
+			const controls = formEl.get(0).querySelectorAll('input[name][pattern]');
+			const ok = Settings.check(controls);
+			if (!ok) {
+				return;
+			}
+
 			if (formEl.length) {
 				const values = helper.serializeForm(formEl);
 
@@ -558,6 +564,26 @@ define('settings', ['hooks', 'alerts'], function (hooks, alerts) {
 					}
 				});
 			}
+		},
+		check: function (controls) {
+			const onTrigger = (e) => {
+				const wrapper = e.target.closest('.form-group');
+				if (wrapper) {
+					wrapper.classList.add('has-error');
+				}
+
+				e.target.removeEventListener('invalid', onTrigger);
+			};
+
+			return Array.prototype.map.call(controls, (controlEl) => {
+				const wrapper = controlEl.closest('.form-group');
+				if (wrapper) {
+					wrapper.classList.remove('has-error');
+				}
+
+				controlEl.addEventListener('invalid', onTrigger);
+				return controlEl.reportValidity();
+			}).every(Boolean);
 		},
 	};
 

--- a/src/views/admin/partials/api/sorted-list/form.tpl
+++ b/src/views/admin/partials/api/sorted-list/form.tpl
@@ -3,7 +3,7 @@
     <input type="hidden" name="timestamp" />
     <div class="form-group">
         <label for="uid">[[admin/settings/api:uid]]</label>
-        <input type="number" name="uid" class="form-control" placeholder="1" min="0" />
+        <input type="text" inputmode="numeric" pattern="\d+" name="uid" class="form-control" placeholder="1" />
         <p class="help-text">
             [[admin/settings/api:uid-help-text]]
         </p>

--- a/src/views/admin/partials/temporary-ban.tpl
+++ b/src/views/admin/partials/temporary-ban.tpl
@@ -3,7 +3,7 @@
 		<div class="col-xs-4">
 			<div class="form-group">
 				<label for="length">[[admin/manage/users:temp-ban.length]]</label>
-				<input class="form-control" id="length" name="length" type="number" min="0" value="1" />
+				<input class="form-control" id="length" name="length" type="text" pattern="\d+" value="1" />
 			</div>
 		</div>
 		<div class="col-xs-8">

--- a/src/views/admin/partials/temporary-mute.tpl
+++ b/src/views/admin/partials/temporary-mute.tpl
@@ -3,7 +3,7 @@
 		<div class="col-xs-4">
 			<div class="form-group">
 				<label for="length">[[admin/manage/users:temp-ban.length]]</label>
-				<input class="form-control" id="length" name="length" type="number" min="0" value="1" />
+				<input class="form-control" id="length" name="length" type="text" inputmode="numeric" pattern="\d+" value="1" />
 			</div>
 		</div>
 		<div class="col-xs-8">

--- a/src/views/admin/settings/advanced.tpl
+++ b/src/views/admin/settings/advanced.tpl
@@ -121,7 +121,7 @@
 			</div>
 			<div class="form-group">
 				<label for="hsts-maxage">[[admin/settings/advanced:hsts.maxAge]]</label>
-				<input class="form-control" id="hsts-maxage" type="text" pattern="\d+" placeholder="31536000" data-field="hsts-maxage" /><br />
+				<input class="form-control" id="hsts-maxage" type="text" inputmode="numeric" pattern="\d+" placeholder="31536000" data-field="hsts-maxage" /><br />
 			</div>
 			<div class="checkbox">
 				<label class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
@@ -157,14 +157,14 @@
 			</div>
 			<div class="form-group">
 				<label for="eventLoopLagThreshold">[[admin/settings/advanced:traffic.event-lag]]</label>
-				<input class="form-control" id="eventLoopLagThreshold" type="number" data-field="eventLoopLagThreshold" placeholder="Default: 70" step="10" min="10" value="70" />
+				<input class="form-control" id="eventLoopLagThreshold" type="text" inputmode="numeric" pattern="\d+" data-field="eventLoopLagThreshold" placeholder="Default: 70" step="10" min="10" value="70" />
 				<p class="help-block">
 					[[admin/settings/advanced:traffic.event-lag-help]]
 				</p>
 			</div>
 			<div class="form-group">
 				<label for="eventLoopInterval">[[admin/settings/advanced:traffic.lag-check-interval]]</label>
-				<input class="form-control" id="eventLoopInterval" type="number" data-field="eventLoopInterval" placeholder="Default: 500" value="500" step="50" />
+				<input class="form-control" id="eventLoopInterval" type="text" inputmode="numeric" pattern="\d+" data-field="eventLoopInterval" placeholder="Default: 500" value="500" step="50" />
 				<p class="help-block">
 					[[admin/settings/advanced:traffic.lag-check-interval-help]]
 				</p>

--- a/src/views/admin/settings/advanced.tpl
+++ b/src/views/admin/settings/advanced.tpl
@@ -121,7 +121,7 @@
 			</div>
 			<div class="form-group">
 				<label for="hsts-maxage">[[admin/settings/advanced:hsts.maxAge]]</label>
-				<input class="form-control" id="hsts-maxage" type="number" placeholder="31536000" data-field="hsts-maxage" /><br />
+				<input class="form-control" id="hsts-maxage" type="text" pattern="\d+" placeholder="31536000" data-field="hsts-maxage" /><br />
 			</div>
 			<div class="checkbox">
 				<label class="mdl-switch mdl-js-switch mdl-js-ripple-effect">

--- a/src/views/admin/settings/cookies.tpl
+++ b/src/views/admin/settings/cookies.tpl
@@ -55,7 +55,7 @@
 
 			<div class="form-group">
 				<label for="maxUserSessions">[[admin/settings/cookies:max-user-sessions]]</label>
-				<input class="form-control" id="maxUserSessions" type="number" placeholder="10" data-field="maxUserSessions" /><br />
+				<input class="form-control" id="maxUserSessions" type="text" inputmode="numeric" pattern="\d+" placeholder="10" data-field="maxUserSessions" /><br />
 				<p class="help-block">
 					[[admin/settings/cookies:blank-default]]
 				</p>

--- a/src/views/admin/settings/email.tpl
+++ b/src/views/admin/settings/email.tpl
@@ -50,13 +50,13 @@
 	<div class="col-sm-10 col-xs-12">
 		<div class="form-group form-inline">
 			<label for="emailConfirmInterval">[[admin/settings/user:email-confirm-interval]]</label>
-			<input class="form-control" data-field="emailConfirmInterval" type="number" id="emailConfirmInterval" placeholder="10" />
+			<input class="form-control" data-field="emailConfirmInterval" type="text" inputmode="numeric" pattern="\d+" id="emailConfirmInterval" placeholder="10" />
 			<label for="emailConfirmInterval">[[admin/settings/user:email-confirm-interval2]]</label>
 		</div>
 
 		<div class="form-group">
 			<label for="emailConfirmExpiry">[[admin/settings/email:confirmation.expiry]]</label>
-			<input class="form-control" data-field="emailConfirmExpiry" type="number" id="emailConfirmExpiry" placeholder="24" />
+			<input class="form-control" data-field="emailConfirmExpiry" type="text" inputmode="numeric" pattern="\d+" id="emailConfirmExpiry" placeholder="24" />
 		</div>
 
 		<div class="checkbox">
@@ -97,7 +97,7 @@
 
 			<div class="form-group">
 				<label for="digestHour"><strong>[[admin/settings/email:subscriptions.hour]]</strong></label>
-				<input type="number" class="form-control input-lg" id="digestHour" data-field="digestHour" placeholder="17" min="0" max="24" />
+				<input type="text" inputmode="numeric" pattern="\d{1,2}" class="form-control input-lg" id="digestHour" data-field="digestHour" placeholder="17" title="[[admin/settings/email:subscriptions.hour-hint]]" />
 				<p class="help-block">
 					[[admin/settings/email:subscriptions.hour-help]]
 				</p>

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -158,21 +158,21 @@
 		<form>
 			<div class="form-group">
 				<label for="timeagoCutoff">[[admin/settings/post:timestamp.cut-off]]</label>
-				<input type="number" class="form-control" id="timeagoCutoff" data-field="timeagoCutoff"  />
+				<input type="text" inputmode="numeric" pattern="\d+" class="form-control" id="timeagoCutoff" data-field="timeagoCutoff"  />
 				<p class="help-block">
 					[[admin/settings/post:timestamp.cut-off-help]]
 				</p>
 			</div>
 			<div class="form-group">
 				<label for="necroThreshold">[[admin/settings/post:timestamp.necro-threshold]]</label>
-				<input type="number" class="form-control" id="necroThreshold" data-field="necroThreshold"  />
+				<input type="text" inputmode="numeric" pattern="\d+" class="form-control" id="necroThreshold" data-field="necroThreshold"  />
 				<p class="help-block">
 					[[admin/settings/post:timestamp.necro-threshold-help]]
 				</p>
 			</div>
 			<div class="form-group">
 				<label for="incrementTopicViewsInterval">[[admin/settings/post:timestamp.topic-views-interval]]</label>
-				<input type="number" class="form-control" id="incrementTopicViewsInterval" data-field="incrementTopicViewsInterval"  />
+				<input type="text" inputmode="numeric" pattern="\d+" class="form-control" id="incrementTopicViewsInterval" data-field="incrementTopicViewsInterval"  />
 				<p class="help-block">
 					[[admin/settings/post:timestamp.topic-views-interval-help]]
 				</p>

--- a/src/views/admin/settings/uploads.tpl
+++ b/src/views/admin/settings/uploads.tpl
@@ -137,7 +137,7 @@
 		<div class="row">
 			<div class="form-group col-sm-6">
 				<label for="orphanExpiryDays">[[admin/settings/uploads:orphanExpiryDays]]</label>
-				<input id="orphanExpiryDays" type="number" min="0" placeholder="0" class="form-control" data-field="orphanExpiryDays" />
+				<input id="orphanExpiryDays" type="text" inputmode="numeric" pattern="\d+" placeholder="0" class="form-control" data-field="orphanExpiryDays" />
 				<p class="help-block">[[admin/settings/uploads:orphanExpiryDays-help]]</p>
 			</div>
 		</div>

--- a/src/views/admin/settings/user.tpl
+++ b/src/views/admin/settings/user.tpl
@@ -179,7 +179,7 @@
 			</div>
 			<div class="form-group">
 				<label for="autoApproveTime">[[admin/settings/user:registration-queue-auto-approve-time]]</label>
-				<input id="autoApproveTime" type="number" class="form-control" data-field="autoApproveTime" placeholder="0">
+				<input id="autoApproveTime" type="text" inputmode="numeric" pattern="\d+" class="form-control" data-field="autoApproveTime" placeholder="0">
 				<p class="help-block">
 					[[admin/settings/user:registration-queue-auto-approve-time-help]]
 				</p>
@@ -201,14 +201,14 @@
 
 			<div class="form-group">
 				<label for="maximumInvites">[[admin/settings/user:max-invites]]</label>
-				<input id="maximumInvites" type="number" class="form-control" data-field="maximumInvites" placeholder="0">
+				<input id="maximumInvites" type="text" inputmode="numeric" pattern="\d+" class="form-control" data-field="maximumInvites" placeholder="0">
 				<p class="help-block">
 					[[admin/settings/user:max-invites-help]]
 				</p>
 			</div>
 			<div class="form-group">
 				<label for="inviteExpiration">[[admin/settings/user:invite-expiration]]</label>
-				<input id="inviteExpiration" type="number" class="form-control" data-field="inviteExpiration" placeholder="7">
+				<input id="inviteExpiration" type="text" inputmode="numeric" pattern="\d+" class="form-control" data-field="inviteExpiration" placeholder="7">
 				<p class="help-block">
 					[[admin/settings/user:invite-expiration-help]]
 				</p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/923011/203866774-36255133-2898-4a7d-8b03-611208d13a47.png)

Transparent enhancement to allow for error capturing using native browser form validation tools. Applies only to `input`s with a `pattern` attribute.

Integrates with settings v1 (`.prepare()` in ACP) and v2 (`meta.settings.save()`)