### PR TITLE
feat: add force flag to plugin install in cli

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -175,9 +175,10 @@ program
 program
 	.command('install [plugin]')
 	.description('Launch the NodeBB web installer for configuration setup or install a plugin')
-	.action((plugin) => {
+	.option('-f, --force', 'Force plugin installation even if it may be incompatible with currently installed NodeBB version')
+	.action((plugin, options) => {
 		if (plugin) {
-			require('./manage').install(plugin);
+			require('./manage').install(plugin, options);
 		} else {
 			require('./setup').webInstall();
 		}

--- a/src/cli/manage.js
+++ b/src/cli/manage.js
@@ -14,7 +14,10 @@ const analytics = require('../analytics');
 const reset = require('./reset');
 const { pluginNamePattern, themeNamePattern, paths } = require('../constants');
 
-async function install(plugin) {
+async function install(plugin, options) {
+	if (!options) {
+		options = {};
+	}
 	try {
 		await db.init();
 		if (!pluginNamePattern.test(plugin)) {
@@ -31,7 +34,11 @@ async function install(plugin) {
 		const nbbVersion = require(paths.currentPackage).version;
 		const suggested = await plugins.suggest(plugin, nbbVersion);
 		if (!suggested.version) {
-			throw new Error(suggested.message);
+			if (!options.force) {
+				throw new Error(suggested.message);
+			}
+			winston.warn(`${suggested.message} Proceeding with installation anyway due to force option being provided`);
+			suggested.version = 'latest';
 		}
 		winston.info('Installing Plugin `%s@%s`', plugin, suggested.version);
 		await plugins.toggleInstall(plugin, suggested.version);


### PR DESCRIPTION
As was suggested in https://github.com/NodeBB/NodeBB/issues/11060#issuecomment-1353599263 I added a `--force` flag to the `install` command that lets the user bypass version check.