### PR TITLE
Refactor `helpers.loginUser`

### DIFF
--- a/test/controllers-admin.js
+++ b/test/controllers-admin.js
@@ -4,6 +4,7 @@ const async = require('async');
 const assert = require('assert');
 const nconf = require('nconf');
 const request = require('request');
+const requestAsync = require('request-promise-native');
 
 const db = require('./mocks/databasemock');
 const categories = require('../src/categories');
@@ -65,17 +66,16 @@ describe('Admin Controllers', () => {
 		});
 	});
 
-	it('should 403 if user is not admin', (done) => {
-		helpers.loginUser('admin', 'barbar', (err, data) => {
-			assert.ifError(err);
-			jar = data.jar;
-			request(`${nconf.get('url')}/admin`, { jar: jar }, (err, res, body) => {
-				assert.ifError(err);
-				assert.equal(res.statusCode, 403);
-				assert(body);
-				done();
-			});
+	it('should 403 if user is not admin', async () => {
+		({ jar } = await helpers.loginUser('admin', 'barbar'));
+		const { statusCode, body } = await requestAsync(`${nconf.get('url')}/admin`, {
+			jar: jar,
+			simple: false,
+			resolveWithFullResponse: true,
 		});
+
+		assert.equal(statusCode, 403);
+		assert(body);
 	});
 
 	it('should load admin dashboard', (done) => {

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -67,10 +67,10 @@ describe('Messaging Library', () => {
 		await Groups.join('administrators', mocks.users.foo.uid);
 		await User.setSetting(mocks.users.baz.uid, 'restrictChat', '1');
 
-		({ jar: mocks.users.foo.jar, csrf_token: mocks.users.foo.csrf } = await util.promisify(helpers.loginUser)('foo', 'barbar'));
-		({ jar: mocks.users.bar.jar, csrf_token: mocks.users.bar.csrf } = await util.promisify(helpers.loginUser)('bar', 'bazbaz'));
-		({ jar: mocks.users.baz.jar, csrf_token: mocks.users.baz.csrf } = await util.promisify(helpers.loginUser)('baz', 'quuxquux'));
-		({ jar: mocks.users.herp.jar, csrf_token: mocks.users.herp.csrf } = await util.promisify(helpers.loginUser)('herp', 'derpderp'));
+		({ jar: mocks.users.foo.jar, csrf_token: mocks.users.foo.csrf } = await helpers.loginUser('foo', 'barbar'));
+		({ jar: mocks.users.bar.jar, csrf_token: mocks.users.bar.csrf } = await helpers.loginUser('bar', 'bazbaz'));
+		({ jar: mocks.users.baz.jar, csrf_token: mocks.users.baz.csrf } = await helpers.loginUser('baz', 'quuxquux'));
+		({ jar: mocks.users.herp.jar, csrf_token: mocks.users.herp.csrf } = await helpers.loginUser('herp', 'derpderp'));
 
 		chatMessageDelay = meta.config.chatMessageDelay;
 		meta.config.chatMessageDelay = 0;
@@ -277,7 +277,7 @@ describe('Messaging Library', () => {
 
 		it('should change owner if owner is deleted', async () => {
 			const sender = await User.create({ username: 'deleted_chat_user', password: 'barbar' });
-			const { jar: senderJar, csrf_token: senderCsrf } = await util.promisify(helpers.loginUser)('deleted_chat_user', 'barbar');
+			const { jar: senderJar, csrf_token: senderCsrf } = await helpers.loginUser('deleted_chat_user', 'barbar');
 
 			const receiver = await User.create({ username: 'receiver' });
 			const { response } = await request(`${nconf.get('url')}/api/v3/chats`, {
@@ -851,7 +851,7 @@ describe('Messaging Library', () => {
 		});
 
 		it('should return 404 if user is not in room', async () => {
-			const data = await util.promisify(helpers.loginUser)('baz', 'quuxquux');
+			const data = await helpers.loginUser('baz', 'quuxquux');
 			const response = await request(`${nconf.get('url')}/api/user/baz/chats/${roomId}`, {
 				resolveWithFullResponse: true,
 				simple: false,

--- a/test/user/emails.js
+++ b/test/user/emails.js
@@ -150,7 +150,6 @@ describe('email confirmation (v3 api)', () => {
 			resolve({ jar, response, body });
 		});
 	});
-	const login = util.promisify(helpers.loginUser);
 
 	before(async () => {
 		// If you're running this file directly, uncomment these lines
@@ -219,7 +218,7 @@ describe('email confirmation (v3 api)', () => {
 	it('should still confirm the email (as email is set in user hash)', async () => {
 		await user.email.remove(userObj.uid);
 		await user.setUserField(userObj.uid, 'email', 'test@example.org');
-		({ jar } = await login('email-test', 'abcdef')); // email removal logs out everybody
+		({ jar } = await helpers.loginUser('email-test', 'abcdef')); // email removal logs out everybody
 		await groups.join('administrators', userObj.uid);
 
 		const { res, body } = await helpers.request('post', `/api/v3/users/${userObj.uid}/emails/${encodeURIComponent('test@example.org')}/confirm`, {


### PR DESCRIPTION
Rewrote `helpers.loginUser` to be fully async, and started fixing all invocations of it to also be async.

Realized only halfway through that our promisify lib also callbackifies, so I didn't need to rewrite the calls to it. Oh well. Did it anyway. :smile: 

----

More importantly, this also extends the helper with a third argument allowing you to pass in additional items to the form payload.