### PR TITLE
fix: import resolution within plugin modules

### DIFF
--- a/src/meta/js.js
+++ b/src/meta/js.js
@@ -40,14 +40,24 @@ async function linkModules() {
 	await Promise.all(Object.keys(modules).map(async (relPath) => {
 		const srcPath = path.join(__dirname, '../../', modules[relPath]);
 		const destPath = path.join(__dirname, '../../build/public/src/modules', relPath);
+		const destDir = path.dirname(destPath);
+
 		const [stats] = await Promise.all([
 			fs.promises.stat(srcPath),
-			mkdirp(path.dirname(destPath)),
+			mkdirp(destDir),
 		]);
+
 		if (stats.isDirectory()) {
 			await file.linkDirs(srcPath, destPath, true);
 		} else {
-			await fs.promises.copyFile(srcPath, destPath);
+			// Get the relative path to the destination directory
+			const relPath = path.relative(destDir, srcPath)
+				// and convert to a posix path
+				.split(path.sep).join(path.posix.sep);
+
+			// Instead of copying file, create a new file re-exporting it
+			// This way, imports in modules are resolved correctly
+			await fs.promises.writeFile(destPath, `export * from '${relPath}'`);
 		}
 	}));
 }


### PR DESCRIPTION
Before, relative-path imports within modules from plugins would fail, since the module file was copied. Now, we just create a new file which re-exports the original module entry point.

This allows Webpack to correctly resolve the imports. This change is necessary for nodebb-plugin-customize on NodeBB v2 (currently it claims to work but the ACP plugin page is broken).