### PR TITLE
feat(routes): allow remounting /categories

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -75,14 +75,15 @@ _mounts.tags = (app, name, middleware, controllers) => {
 	setupPageRoute(app, `/${name}/:tag`, [middleware.privateTagListing], controllers.tags.getTag);
 	setupPageRoute(app, `/${name}`, [middleware.privateTagListing], controllers.tags.getTags);
 };
-
-_mounts.category = (app, name, middleware, controllers) => {
+_mounts.categories = (app, name, middleware, controllers) => {
 	setupPageRoute(app, '/categories', [], controllers.categories.list);
 	setupPageRoute(app, '/popular', [], controllers.popular.get);
 	setupPageRoute(app, '/recent', [], controllers.recent.get);
 	setupPageRoute(app, '/top', [], controllers.top.get);
 	setupPageRoute(app, '/unread', [middleware.ensureLoggedIn], controllers.unread.get);
+};
 
+_mounts.category = (app, name, middleware, controllers) => {
 	setupPageRoute(app, `/${name}/:category_id/:slug/:topic_index`, [], controllers.category.get);
 	setupPageRoute(app, `/${name}/:category_id/:slug?`, [], controllers.category.get);
 };
@@ -108,7 +109,7 @@ module.exports = async function (app, middleware) {
 	};
 
 	// Allow plugins/themes to mount some routes elsewhere
-	const remountable = ['admin', 'category', 'topic', 'post', 'users', 'user', 'groups', 'tags'];
+	const remountable = ['admin', 'categories', 'category', 'topic', 'post', 'users', 'user', 'groups', 'tags'];
 	const { mounts } = await plugins.hooks.fire('filter:router.add', {
 		mounts: remountable.reduce((memo, mount) => {
 			memo[mount] = mount;


### PR DESCRIPTION
A fairly trivial refactor that'd allow plugins to more simply change the terminology around categories, by also remounting the route for listing them. It was already possible to remount `/category/:cid` routes, but presumably because of one being singular and the other plural, `/categories` didn't get that privilege.
For that reason I extracted out all listing routes to a separate `_mounts.categories` function

Ref for someone wanting to change categories to something else: https://community.nodebb.org/topic/16938/is-it-possible-to-change-categories