### PR TITLE
Replace csurf with csrf-sync

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -55,7 +55,7 @@
         "cookie-parser": "1.4.6",
         "cron": "2.2.0",
         "cropperjs": "1.5.13",
-        "csurf": "1.11.0",
+        "csrf-sync": "4.0.0",
         "daemon": "1.1.0",
         "diff": "5.1.0",
         "esbuild": "0.17.4",

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -9,6 +9,7 @@ const categories = require('../categories');
 const plugins = require('../plugins');
 const translator = require('../translator');
 const languages = require('../languages');
+const { generateToken } = require('../middleware/csrf');
 
 const apiController = module.exports;
 
@@ -64,7 +65,7 @@ apiController.loadConfig = async function (req) {
 		'cache-buster': meta.config['cache-buster'] || '',
 		topicPostSort: meta.config.topicPostSort || 'oldest_to_newest',
 		categoryTopicSort: meta.config.categoryTopicSort || 'newest_to_oldest',
-		csrf_token: req.uid >= 0 && req.csrfToken && req.csrfToken(),
+		csrf_token: req.uid >= 0 ? generateToken(req) : undefined,
 		searchEnabled: plugins.hooks.hasListeners('filter:search.query'),
 		searchDefaultInQuick: meta.config.searchDefaultInQuick || 'titles',
 		bootswatchSkin: meta.config.bootswatchSkin || '',

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -65,7 +65,7 @@ apiController.loadConfig = async function (req) {
 		'cache-buster': meta.config['cache-buster'] || '',
 		topicPostSort: meta.config.topicPostSort || 'oldest_to_newest',
 		categoryTopicSort: meta.config.categoryTopicSort || 'newest_to_oldest',
-		csrf_token: req.uid >= 0 ? generateToken(req) : undefined,
+		csrf_token: req.uid >= 0 ? generateToken(req) : false,
 		searchEnabled: plugins.hooks.hasListeners('filter:search.query'),
 		searchDefaultInQuick: meta.config.searchDefaultInQuick || 'titles',
 		bootswatchSkin: meta.config.bootswatchSkin || '',

--- a/src/middleware/csrf.js
+++ b/src/middleware/csrf.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { csrfSync } = require('csrf-sync');
+
+const {
+	generateToken,
+	csrfSynchronisedProtection,
+} = csrfSync({
+	size: 64
+});
+
+module.exports = {
+	generateToken,
+	csrfSynchronisedProtection,
+};

--- a/src/middleware/csrf.js
+++ b/src/middleware/csrf.js
@@ -6,6 +6,13 @@ const {
 	generateToken,
 	csrfSynchronisedProtection,
 } = csrfSync({
+	getTokenFromRequest: (req) => {
+		if (req.headers['x-csrf-token']) {
+			return req.headers['x-csrf-token'];
+		} else if (req.query) {
+			return req.query._csrf;
+		}
+	},
 	size: 64,
 });
 

--- a/src/middleware/csrf.js
+++ b/src/middleware/csrf.js
@@ -6,7 +6,7 @@ const {
 	generateToken,
 	csrfSynchronisedProtection,
 } = csrfSync({
-	size: 64
+	size: 64,
 });
 
 module.exports = {

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -2,7 +2,7 @@
 
 const async = require('async');
 const path = require('path');
-const csrf = require('csurf');
+const { csrfSynchronisedProtection } = require('./csrf');
 const validator = require('validator');
 const nconf = require('nconf');
 const toobusy = require('toobusy-js');
@@ -34,7 +34,7 @@ middleware.regexes = {
 	timestampedUpload: /^\d+-.+$/,
 };
 
-const csrfMiddleware = csrf();
+const csrfMiddleware = csrfSynchronisedProtection;
 
 middleware.applyCSRF = function (req, res, next) {
 	if (req.uid >= 0) {

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -2,11 +2,11 @@
 
 const async = require('async');
 const path = require('path');
-const { csrfSynchronisedProtection } = require('./csrf');
 const validator = require('validator');
 const nconf = require('nconf');
 const toobusy = require('toobusy-js');
 const util = require('util');
+const { csrfSynchronisedProtection } = require('./csrf');
 
 const plugins = require('../plugins');
 const meta = require('../meta');

--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -10,6 +10,7 @@ const meta = require('../meta');
 const controllers = require('../controllers');
 const helpers = require('../controllers/helpers');
 const plugins = require('../plugins');
+const { generateToken } = require('../middleware/csrf');
 
 let loginStrategies = [];
 
@@ -108,7 +109,7 @@ Auth.reloadRoutes = async function (params) {
 				};
 
 				if (strategy.checkState !== false) {
-					req.session.ssoState = req.csrfToken && req.csrfToken();
+					req.session.ssoState = generateToken(req, true);
 					opts.state = req.session.ssoState;
 				}
 


### PR DESCRIPTION
I'm the author of `csrf-sync`, this is my first time looking through the NodeBB codebase. As a result of trying to get `csrf-sync` to work with NodeBB, I ended up making a few improvements to `csrf-sync` and releasing v4, this makes `csrf-sync`'s default behavior much similar to `csurf`, without compromising security, but also making it much more plug-and-play during replacement. I have gotten this working locally.

As per the contribution guide, I tried running `npm test` and 8 tests passed, then one failed:

```
error [user.create] Validation email failed to send
```

But the contribution guide does not detail how the email should be configured for testing. and I shouldn't have to configure an actual emailer to run the tests, imo.

This should fix issue #11046 .

I manually tested by running via grunt, logging in as a user, creating a new user, logging in as that user in another browser session, then sending chats between the users. No CSRF errors were encountered and tokens were included in the requests as expected.

Please note this PR currently assumes that the csrf token **is always expected to be in the header**. This PR will **NOT** work if there are cases where the token is submitted inside the request body.

If there are cases where the token is submitted via the request body instead of the header, please let me know and I can update the PR.