### PR TITLE
fix: #11259, clean old emails when updating via admin

### DIFF
--- a/src/upgrades/2.8.7/fix-email-sorted-sets.js
+++ b/src/upgrades/2.8.7/fix-email-sorted-sets.js
@@ -1,0 +1,46 @@
+'use strict';
+
+
+const db = require('../../database');
+const batch = require('../../batch');
+
+
+module.exports = {
+	name: 'Fix user email sorted sets',
+	timestamp: Date.UTC(2023, 1, 4),
+	method: async function () {
+		const { progress } = this;
+		const bulkRemove = [];
+		await batch.processSortedSet('email:uid', async (data) => {
+			progress.incr(data.length);
+			const usersData = await db.getObjects(data.map(d => `user:${d.score}`));
+			data.forEach((emailData, index) => {
+				const { score: uid, value: email } = emailData;
+				const userData = usersData[index];
+				// user no longer exists or doesn't have email set in user hash
+				// remove the email/uid pair from email:uid, email:sorted
+				if (!userData || !userData.email) {
+					bulkRemove.push(['email:uid', email]);
+					bulkRemove.push(['email:sorted', `${email.toLowerCase()}:${uid}`]);
+					return;
+				}
+
+				// user has email but doesn't match whats stored in user hash, gh#11259
+				if (userData.email && userData.email.toLowerCase() !== email.toLowerCase()) {
+					bulkRemove.push(['email:uid', email]);
+					bulkRemove.push(['email:sorted', `${email.toLowerCase()}:${uid}`]);
+				}
+			});
+		}, {
+			batch: 500,
+			withScores: true,
+			progress: progress,
+		});
+
+		await batch.processArray(bulkRemove, async (bulk) => {
+			await db.sortedSetRemoveBulk(bulk);
+		}, {
+			batch: 500,
+		});
+	},
+};

--- a/src/user/email.js
+++ b/src/user/email.js
@@ -39,7 +39,7 @@ UserEmail.remove = async function (uid, sessionId) {
 		db.sortedSetRemove('email:uid', email.toLowerCase()),
 		db.sortedSetRemove('email:sorted', `${email.toLowerCase()}:${uid}`),
 		user.email.expireValidation(uid),
-		user.auth.revokeAllSessions(uid, sessionId),
+		sessionId ? user.auth.revokeAllSessions(uid, sessionId) : Promise.resolve(),
 		events.log({ type: 'email-change', email, newEmail: '' }),
 	]);
 };
@@ -69,7 +69,7 @@ UserEmail.expireValidation = async (uid) => {
 };
 
 UserEmail.canSendValidation = async (uid, email) => {
-	const pending = UserEmail.isValidationPending(uid, email);
+	const pending = await UserEmail.isValidationPending(uid, email);
 	if (!pending) {
 		return true;
 	}
@@ -196,6 +196,20 @@ UserEmail.confirmByUid = async function (uid) {
 		throw new Error('[[error:invalid-email]]');
 	}
 
+	// If another uid has the same email throw error
+	const oldUid = await db.sortedSetScore('email:uid', currentEmail.toLowerCase());
+	if (oldUid && oldUid !== parseInt(uid, 10)) {
+		throw new Error('[[error:email-taken]]');
+	}
+
+	const confirmedEmails = await db.getSortedSetRangeByScore(`email:uid`, 0, -1, uid, uid);
+	if (confirmedEmails.length) {
+		// remove old email of user by uid
+		await db.sortedSetsRemoveRangeByScore([`email:uid`], uid, uid);
+		await db.sortedSetRemoveBulk(
+			confirmedEmails.map(email => [`email:sorted`, `${email.toLowerCase()}:${uid}`])
+		);
+	}
 	await Promise.all([
 		db.sortedSetAddBulk([
 			['email:uid', uid, currentEmail.toLowerCase()],

--- a/test/user/emails.js
+++ b/test/user/emails.js
@@ -120,7 +120,7 @@ describe('email confirmation (library methods)', () => {
 			await user.email.sendValidationEmail(uid, {
 				email,
 			});
-			const ok = await user.email.canSendValidation(uid, 'test@example.com');
+			const ok = await user.email.canSendValidation(uid, email);
 
 			assert.strictEqual(ok, false);
 		});
@@ -131,7 +131,7 @@ describe('email confirmation (library methods)', () => {
 				email,
 			});
 			await db.pexpire(`confirm:byUid:${uid}`, 1000);
-			const ok = await user.email.canSendValidation(uid, 'test@example.com');
+			const ok = await user.email.canSendValidation(uid, email);
 
 			assert(ok);
 		});


### PR DESCRIPTION
when admin is changing users email check if it's available and remove old email of user first 
upgrade script to cleanup email:uid, email:sorted, will remove entries if user doesn't exist or doesn't have email or if entry in user hash doesn't match entry in email:uid 
fix missing ! in email interstitial
fix missing await in canSendValidation,
fix broken tests
don't pass sessionId to email.remove if admin is changing/removing email