### PR TITLE
fix: update main post timestamp when rescheduling #11296

### DIFF
--- a/src/topics/scheduled.js
+++ b/src/topics/scheduled.js
@@ -60,6 +60,7 @@ Scheduled.pin = async function (tid, topicData) {
 };
 
 Scheduled.reschedule = async function ({ cid, tid, timestamp, uid }) {
+	const mainPid = await topics.getTopicField(tid, 'mainPid');
 	await Promise.all([
 		db.sortedSetsAdd([
 			'topics:scheduled',
@@ -67,6 +68,7 @@ Scheduled.reschedule = async function ({ cid, tid, timestamp, uid }) {
 			'topics:tid',
 			`cid:${cid}:uid:${uid}:tids`,
 		], timestamp, tid),
+		posts.setPostField(mainPid, 'timestamp', timestamp),
 		shiftPostTimes(tid, timestamp),
 	]);
 	return topics.updateLastPostTimeFromLastPid(tid);


### PR DESCRIPTION
Correct patch for #11296.

I had a deep dive into this the day before to make sure not cause some unintended bugs (like messing with unread status etc., it's been 2 years :)).

The Topics.updateLastPostTimeFromLastPid call at the end of Scheduled.reschedule method is responsible of updating `topics:recent`. It works for topics with more than 1 post, but for topics with only main post it does not because new timestamp is not applied to main post.

Current fix does not work for topics with only main post since that last call overwrites it.

Their order on category views depends on cid:${cid}:tids:pinned, so they're not affected by recent timestamp there. Also `topics:recent` is updated correctly when the post is published when its scheduled time has come (and became unpinned).