### PR TITLE
Show error alert if password change fails

### DIFF
--- a/public/src/client/account/edit/password.js
+++ b/public/src/client/account/edit/password.js
@@ -77,6 +77,7 @@ define('forum/account/edit/password', [
 							ajaxify.go('user/' + ajaxify.data.userslug + '/edit');
 						}
 					})
+					.catch(alerts.error)
 					.finally(() => {
 						btn.removeClass('disabled').find('i').addClass('hide');
 						currentPassword.val('');


### PR DESCRIPTION
This seems to have broken at some point (works on v1.14.3 at least), and just clears the input and prints an unhandled promise rejection in console. Catching and alerting the user seems like the correct thing to do here, to display potential errors (like incorrect current password) to the user.