### PR TITLE
refactor: audit all routes in v3 write API to conform to updated best practices

### DIFF
--- a/public/openapi/write/categories/cid/moderator/uid.yaml
+++ b/public/openapi/write/categories/cid/moderator/uid.yaml
@@ -30,6 +30,100 @@ put:
                 $ref: ../../../../components/schemas/Status.yaml#/Status
               response:
                 type: object
+                properties:
+                  labels:
+                    type: object
+                    properties:
+                      users:
+                        type: array
+                        items:
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
+                      groups:
+                        type: array
+                        items:
+                          type: string
+                          description: Language key of the privilege name's user-friendly name
+                  users:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        uid:
+                          type: number
+                          description: A user identifier
+                          example: 1
+                        username:
+                          type: string
+                          description: A friendly name for a given user account
+                          example: Dragon Fruit
+                        displayname:
+                          type: string
+                          description: This is either username or fullname depending on forum and user settings
+                          example: Dragon Fruit
+                        picture:
+                          type: string
+                          description: A URL pointing to a picture to be used as the user's avatar
+                          example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
+                          nullable: true
+                        'icon:text':
+                          type: string
+                          description: A single-letter representation of a username. This is used in the auto-generated icon given to users without an avatar
+                          example: D
+                        'icon:bgColor':
+                          type: string
+                          description: A six-character hexadecimal colour code assigned to the user. This value is used in conjunction with `icon:text` for the user's auto-generated icon
+                          example: '#9c27b0'
+                        banned:
+                          type: number
+                          description: A Boolean representing whether a user is banned or not
+                          example: 0
+                        banned_until_readable:
+                          type: string
+                          description: An ISO 8601 formatted date string representing the moment a ban will be lifted, or the words "Not Banned"
+                          example: Not Banned
+                        privileges:
+                          type: object
+                          additionalProperties:
+                            type: boolean
+                            description: A set of privileges with either true or false
+                  groups:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        nameEscaped:
+                          type: string
+                        privileges:
+                          type: object
+                          additionalProperties:
+                            type: boolean
+                            description: A set of privileges with either true or false
+                        isPrivate:
+                          type: boolean
+                        isSystem:
+                          type: boolean
+                  keys:
+                    type: object
+                    properties:
+                      users:
+                        type: array
+                        items:
+                          type: string
+                          description: "Privilege name"
+                      groups:
+                        type: array
+                        items:
+                          type: string
+                          description: "Privilege name"
+                  columnCountUserOther:
+                    type: number
+                    description: "The number of additional user privileges added by plugins"
+                  columnCountGroupOther:
+                    type: number
+                    description: "The number of additional user privileges added by plugins"
 delete:
   tags:
     - categories

--- a/public/openapi/write/categories/cid/privileges/privilege.yaml
+++ b/public/openapi/write/categories/cid/privileges/privilege.yaml
@@ -59,19 +59,44 @@ put:
                     items:
                       type: object
                       properties:
-                        name:
+                        uid:
+                          type: number
+                          description: A user identifier
+                          example: 1
+                        username:
                           type: string
-                        nameEscaped:
+                          description: A friendly name for a given user account
+                          example: Dragon Fruit
+                        displayname:
                           type: string
+                          description: This is either username or fullname depending on forum and user settings
+                          example: Dragon Fruit
+                        picture:
+                          type: string
+                          description: A URL pointing to a picture to be used as the user's avatar
+                          example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
+                          nullable: true
+                        'icon:text':
+                          type: string
+                          description: A single-letter representation of a username. This is used in the auto-generated icon given to users without an avatar
+                          example: D
+                        'icon:bgColor':
+                          type: string
+                          description: A six-character hexadecimal colour code assigned to the user. This value is used in conjunction with `icon:text` for the user's auto-generated icon
+                          example: '#9c27b0'
+                        banned:
+                          type: number
+                          description: A Boolean representing whether a user is banned or not
+                          example: 0
+                        banned_until_readable:
+                          type: string
+                          description: An ISO 8601 formatted date string representing the moment a ban will be lifted, or the words "Not Banned"
+                          example: Not Banned
                         privileges:
                           type: object
                           additionalProperties:
                             type: boolean
                             description: A set of privileges with either true or false
-                        isPrivate:
-                          type: boolean
-                        isSystem:
-                          type: boolean
                   groups:
                     type: array
                     items:
@@ -170,19 +195,44 @@ delete:
                     items:
                       type: object
                       properties:
-                        name:
+                        uid:
+                          type: number
+                          description: A user identifier
+                          example: 1
+                        username:
                           type: string
-                        nameEscaped:
+                          description: A friendly name for a given user account
+                          example: Dragon Fruit
+                        displayname:
                           type: string
+                          description: This is either username or fullname depending on forum and user settings
+                          example: Dragon Fruit
+                        picture:
+                          type: string
+                          description: A URL pointing to a picture to be used as the user's avatar
+                          example: 'https://images.unsplash.com/photo-1560070094-e1f2ddec4337?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=256&h=256&q=80'
+                          nullable: true
+                        'icon:text':
+                          type: string
+                          description: A single-letter representation of a username. This is used in the auto-generated icon given to users without an avatar
+                          example: D
+                        'icon:bgColor':
+                          type: string
+                          description: A six-character hexadecimal colour code assigned to the user. This value is used in conjunction with `icon:text` for the user's auto-generated icon
+                          example: '#9c27b0'
+                        banned:
+                          type: number
+                          description: A Boolean representing whether a user is banned or not
+                          example: 0
+                        banned_until_readable:
+                          type: string
+                          description: An ISO 8601 formatted date string representing the moment a ban will be lifted, or the words "Not Banned"
+                          example: Not Banned
                         privileges:
                           type: object
                           additionalProperties:
                             type: boolean
                             description: A set of privileges with either true or false
-                        isPrivate:
-                          type: boolean
-                        isSystem:
-                          type: boolean
                   groups:
                     type: array
                     items:

--- a/public/openapi/write/topics/tid/events.yaml
+++ b/public/openapi/write/topics/tid/events.yaml
@@ -22,64 +22,67 @@ get:
               status:
                 $ref: ../../../components/schemas/Status.yaml#/Status
               response:
-                type: array
-                description: A list of the topic events that still remain
-                items:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      description: A valid event type
-                    id:
-                      type: number
-                      description: Unique identifier for this topic event
-                    timestamp:
-                      type: number
-                    timestampISO:
-                      type: string
-                      description: An ISO 8601 formatted date string (complementing `timestamp`)
-                    icon:
-                      type: string
-                      description: FontAwesome icon name
-                      example: fa-bullhorn
-                    text:
-                      type: string
-                      description: A language key
-                    uid:
-                      type: number
-                    user:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    description: A list of the topic events that still remain
+                    items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          description: A valid event type
+                        id:
+                          type: number
+                          description: Unique identifier for this topic event
+                        timestamp:
+                          type: number
+                        timestampISO:
+                          type: string
+                          description: An ISO 8601 formatted date string (complementing `timestamp`)
+                        icon:
+                          type: string
+                          description: FontAwesome icon name
+                          example: fa-bullhorn
+                        text:
+                          type: string
+                          description: A language key
                         uid:
                           type: number
-                          description: A user identifier
-                        username:
-                          type: string
-                          description: A friendly name for a given user account
-                        displayname:
-                          type: string
-                          description: This is either username or fullname depending on forum and user settings
-                        userslug:
-                          type: string
-                          description: An URL-safe variant of the username (i.e. lower-cased, spaces
-                            removed, etc.)
-                        picture:
-                          nullable: true
-                          type: string
-                        icon:text:
-                          type: string
-                          description: A single-letter representation of a username. This is used in the
-                            auto-generated icon given to users
-                            without an avatar
-                        icon:bgColor:
-                          type: string
-                          description: A six-character hexadecimal colour code assigned to the user. This
-                            value is used in conjunction with
-                            `icon:text` for the user's
-                            auto-generated icon
-                          example: "#f44336"
-                  required:
-                    - type
-                    - id
-                    - timestamp
-                    - timestampISO
+                        user:
+                          type: object
+                          properties:
+                            uid:
+                              type: number
+                              description: A user identifier
+                            username:
+                              type: string
+                              description: A friendly name for a given user account
+                            displayname:
+                              type: string
+                              description: This is either username or fullname depending on forum and user settings
+                            userslug:
+                              type: string
+                              description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                removed, etc.)
+                            picture:
+                              nullable: true
+                              type: string
+                            icon:text:
+                              type: string
+                              description: A single-letter representation of a username. This is used in the
+                                auto-generated icon given to users
+                                without an avatar
+                            icon:bgColor:
+                              type: string
+                              description: A six-character hexadecimal colour code assigned to the user. This
+                                value is used in conjunction with
+                                `icon:text` for the user's
+                                auto-generated icon
+                              example: "#f44336"
+                      required:
+                        - type
+                        - id
+                        - timestamp
+                        - timestampISO

--- a/public/openapi/write/topics/tid/thumbs.yaml
+++ b/public/openapi/write/topics/tid/thumbs.yaml
@@ -109,8 +109,18 @@ put:
               status:
                 $ref: ../../../components/schemas/Status.yaml#/Status
               response:
-                type: object
-                properties: {}
+                type: array
+                description: A list of the topic thumbnails in the destination topic
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    url:
+                      type: string
+                      description: Path to a topic thumbnail
 delete:
   tags:
     - topics

--- a/public/openapi/write/topics/tid/thumbs/order.yaml
+++ b/public/openapi/write/topics/tid/thumbs/order.yaml
@@ -37,5 +37,15 @@ put:
               status:
                 $ref: ../../../../components/schemas/Status.yaml#/Status
               response:
-                type: object
-                properties: {}
+                type: array
+                description: A list of the topic thumbnails in the new order
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    url:
+                      type: string
+                      description: Path to a topic thumbnail

--- a/src/api/admin.js
+++ b/src/api/admin.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const meta = require('../meta');
+const analytics = require('../analytics');
+const privileges = require('../privileges');
+
+const adminApi = module.exports;
+
+adminApi.updateSetting = async (caller, { setting, value }) => {
+	const ok = await privileges.admin.can('admin:settings', caller.uid);
+	if (!ok) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	await meta.configs.set(setting, value);
+};
+
+adminApi.getAnalyticsKeys = async () => {
+	const keys = await analytics.getKeys();
+
+	// Sort keys alphabetically
+	return keys.sort((a, b) => (a < b ? -1 : 1));
+};
+
+adminApi.getAnalyticsData = async (caller, { set, until, amount, units }) => {
+	// Default returns views from past 24 hours, by hour
+	if (!amount) {
+		if (units === 'days') {
+			amount = 30;
+		} else {
+			amount = 24;
+		}
+	}
+	const getStats = units === 'days' ? analytics.getDailyStatsForSet : analytics.getHourlyStatsForSet;
+	return await getStats(`analytics:${set}`, parseInt(until, 10) || Date.now(), amount);
+};

--- a/src/api/files.js
+++ b/src/api/files.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const fs = require('fs').promises;
+
+const filesApi = module.exports;
+
+// path assertion and traversal guarding logic is in src/middleware/assert.js
+
+filesApi.delete = async (_, { path }) => await fs.unlink(path);
+
+filesApi.createFolder = async (_, { path }) => await fs.mkdir(path);

--- a/src/api/flags.js
+++ b/src/api/flags.js
@@ -25,6 +25,15 @@ flagsApi.create = async (caller, data) => {
 	return flagObj;
 };
 
+flagsApi.get = async (caller, { flagId }) => {
+	const isPrivileged = await user.isPrivileged(caller.uid);
+	if (!isPrivileged) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	return await flags.get(flagId);
+};
+
 flagsApi.update = async (caller, data) => {
 	const allowed = await user.isPrivileged(caller.uid);
 	if (!allowed) {
@@ -37,6 +46,8 @@ flagsApi.update = async (caller, data) => {
 	await flags.update(flagId, caller.uid, data);
 	return await flags.getHistory(flagId);
 };
+
+flagsApi.delete = async (_, { flagId }) => await flags.purge([flagId]);
 
 flagsApi.appendNote = async (caller, data) => {
 	const allowed = await user.isPrivileged(caller.uid);

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,4 +9,5 @@ module.exports = {
 	chats: require('./chats'),
 	categories: require('./categories'),
 	flags: require('./flags'),
+	files: require('./files'),
 };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+	admin: require('./admin'),
 	users: require('./users'),
 	groups: require('./groups'),
 	topics: require('./topics'),

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -333,3 +333,17 @@ postsAPI.restoreDiff = async (caller, data) => {
 	const edit = await posts.diffs.restore(data.pid, data.since, caller.uid, apiHelpers.buildReqObject(caller));
 	websockets.in(`topic_${edit.topic.tid}`).emit('event:post_edited', edit);
 };
+
+postsAPI.deleteDiff = async (caller, { pid, timestamp }) => {
+	const cid = await posts.getCidByPid(pid);
+	const [isAdmin, isModerator] = await Promise.all([
+		privileges.users.isAdministrator(caller.uid),
+		privileges.users.isModerator(caller.uid, cid),
+	]);
+
+	if (!(isAdmin || isModerator)) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	await posts.diffs.delete(pid, timestamp, caller.uid);
+};

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const util = require('util');
+const path = require('path');
+const fs = require('fs').promises;
+
 const validator = require('validator');
 const winston = require('winston');
 
@@ -14,15 +18,30 @@ const plugins = require('../plugins');
 const events = require('../events');
 const translator = require('../translator');
 const sockets = require('../socket.io');
+const utils = require('../utils');
 
 const usersAPI = module.exports;
+
+const hasAdminPrivilege = async (uid, privilege) => {
+	const ok = await privileges.admin.can(`admin:${privilege}`, uid);
+	if (!ok) {
+		throw new Error('[[error:no-privileges]]');
+	}
+};
 
 usersAPI.create = async function (caller, data) {
 	if (!data) {
 		throw new Error('[[error:invalid-data]]');
 	}
+	await hasAdminPrivilege(caller.uid, 'users');
+
 	const uid = await user.create(data);
 	return await user.getUserData(uid);
+};
+
+usersAPI.get = async (caller, { uid }) => {
+	const userData = await user.getUserData(uid);
+	return await user.hidePrivateData(userData, caller.uid);
 };
 
 usersAPI.update = async function (caller, data) {
@@ -90,6 +109,8 @@ usersAPI.deleteAccount = async function (caller, { uid, password }) {
 };
 
 usersAPI.deleteMany = async function (caller, data) {
+	await hasAdminPrivilege(caller.uid, 'users');
+
 	if (await canDeleteUids(data.uids)) {
 		await Promise.all(data.uids.map(uid => processDeletion({ uid, method: 'delete', caller })));
 	}
@@ -286,6 +307,188 @@ usersAPI.unmute = async function (caller, data) {
 	});
 };
 
+usersAPI.generateToken = async (caller, { uid, description }) => {
+	await hasAdminPrivilege(caller.uid, 'settings');
+	if (parseInt(uid, 10) !== parseInt(caller.uid, 10)) {
+		throw new Error('[[error:invalid-uid]]');
+	}
+
+	const settings = await meta.settings.get('core.api');
+	settings.tokens = settings.tokens || [];
+
+	const newToken = {
+		token: utils.generateUUID(),
+		uid: caller.uid,
+		description: description || '',
+		timestamp: Date.now(),
+	};
+	settings.tokens.push(newToken);
+	await meta.settings.set('core.api', settings);
+
+	return newToken;
+};
+
+usersAPI.deleteToken = async (caller, { uid, token }) => {
+	await hasAdminPrivilege(caller.uid, 'settings');
+	if (parseInt(uid, 10) !== parseInt(caller.uid, 10)) {
+		throw new Error('[[error:invalid-uid]]');
+	}
+
+	const settings = await meta.settings.get('core.api');
+	const beforeLen = settings.tokens.length;
+	settings.tokens = settings.tokens.filter(tokenObj => tokenObj.token !== token);
+	if (beforeLen !== settings.tokens.length) {
+		await meta.settings.set('core.api', settings);
+		return true;
+	}
+
+	return false;
+};
+
+const getSessionAsync = util.promisify((sid, callback) => {
+	db.sessionStore.get(sid, (err, sessionObj) => callback(err, sessionObj || null));
+});
+
+usersAPI.revokeSession = async (caller, { uid, uuid }) => {
+	// Only admins or global mods (besides the user themselves) can revoke sessions
+	if (parseInt(uid, 10) !== caller.uid && !await user.isAdminOrGlobalMod(caller.uid)) {
+		throw new Error('[[error:invalid-uid]]');
+	}
+
+	const sids = await db.getSortedSetRange(`uid:${uid}:sessions`, 0, -1);
+	let _id;
+	for (const sid of sids) {
+		/* eslint-disable no-await-in-loop */
+		const sessionObj = await getSessionAsync(sid);
+		if (sessionObj && sessionObj.meta && sessionObj.meta.uuid === uuid) {
+			_id = sid;
+			break;
+		}
+	}
+
+	if (!_id) {
+		throw new Error('[[error:no-session-found]]');
+	}
+
+	await user.auth.revokeSession(_id, uid);
+};
+
+usersAPI.invite = async (caller, { emails, groupsToJoin, uid }) => {
+	if (!emails || !Array.isArray(groupsToJoin)) {
+		throw new Error('[[error:invalid-data]]');
+	}
+
+	// For simplicity, this API route is restricted to self-use only. This can change if needed.
+	if (parseInt(caller.uid, 10) !== parseInt(uid, 10)) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const canInvite = await privileges.users.hasInvitePrivilege(caller.uid);
+	if (!canInvite) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const { registrationType } = meta.config;
+	const isAdmin = await user.isAdministrator(caller.uid);
+	if (registrationType === 'admin-invite-only' && !isAdmin) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const inviteGroups = (await groups.getUserInviteGroups(caller.uid)).map(group => group.name);
+	const cannotInvite = groupsToJoin.some(group => !inviteGroups.includes(group));
+	if (groupsToJoin.length > 0 && cannotInvite) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const max = meta.config.maximumInvites;
+	const emailsArr = emails.split(',').map(email => email.trim()).filter(Boolean);
+
+	for (const email of emailsArr) {
+		/* eslint-disable no-await-in-loop */
+		let invites = 0;
+		if (max) {
+			invites = await user.getInvitesNumber(caller.uid);
+		}
+		if (!isAdmin && max && invites >= max) {
+			throw new Error(`[[error:invite-maximum-met, ${invites}, ${max}]]`);
+		}
+
+		await user.sendInvitationEmail(caller.uid, email, groupsToJoin);
+	}
+};
+
+usersAPI.getInviteGroups = async (caller, { uid }) => {
+	// For simplicity, this API route is restricted to self-use only. This can change if needed.
+	if (parseInt(uid, 10) !== parseInt(caller.uid, 10)) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	const userInviteGroups = await groups.getUserInviteGroups(uid);
+	return userInviteGroups.map(group => group.displayName);
+};
+
+usersAPI.addEmail = async (caller, { email, skipConfirmation, uid }) => {
+	const canManageUsers = await privileges.admin.can('admin:users', caller.uid);
+	skipConfirmation = canManageUsers && skipConfirmation;
+
+	if (skipConfirmation) {
+		await user.setUserField(uid, 'email', email);
+		await user.email.confirmByUid(uid);
+	} else {
+		await usersAPI.update(caller, { uid, email });
+	}
+
+	return await db.getSortedSetRangeByScore('email:uid', 0, 500, uid, uid);
+};
+
+usersAPI.listEmails = async (caller, { uid }) => {
+	const [isPrivileged, { showemail }] = await Promise.all([
+		user.isPrivileged(caller.uid),
+		user.getSettings(uid),
+	]);
+	const isSelf = caller.uid === parseInt(uid, 10);
+
+	if (isSelf || isPrivileged || showemail) {
+		return await db.getSortedSetRangeByScore('email:uid', 0, 500, uid, uid);
+	}
+
+	return null;
+};
+
+usersAPI.getEmail = async (caller, { uid, email }) => {
+	const [isPrivileged, { showemail }, exists] = await Promise.all([
+		user.isPrivileged(caller.uid),
+		user.getSettings(uid),
+		db.isSortedSetMember('email:uid', email.toLowerCase()),
+	]);
+	const isSelf = caller.uid === parseInt(uid, 10);
+
+	return exists && (isSelf || isPrivileged || showemail);
+};
+
+usersAPI.confirmEmail = async (caller, { uid, email, sessionId }) => {
+	const [pending, current, canManage] = await Promise.all([
+		user.email.isValidationPending(uid, email),
+		user.getUserField(uid, 'email'),
+		privileges.admin.can('admin:users', caller.uid),
+	]);
+
+	if (!canManage) {
+		throw new Error('[[error:no-privileges]]');
+	}
+
+	if (pending) { // has active confirmation request
+		const code = await db.get(`confirm:byUid:${uid}`);
+		await user.email.confirmByCode(code, sessionId);
+		return true;
+	} else if (current && current === email) { // i.e. old account w/ unconf. email in user hash
+		await user.email.confirmByUid(uid);
+		return true;
+	}
+
+	return false;
+};
+
 async function isPrivilegedOrSelfAndPasswordMatch(caller, data) {
 	const { uid } = caller;
 	const isSelf = parseInt(uid, 10) === parseInt(data.uid, 10);
@@ -440,6 +643,37 @@ usersAPI.changePicture = async (caller, data) => {
 		picture: picture,
 		'icon:bgColor': data.bgColor,
 	}, ['picture', 'icon:bgColor']);
+};
+
+const exportMetadata = new Map([
+	['posts', ['csv', 'text/csv']],
+	['uploads', ['zip', 'application/zip']],
+	['profile', ['json', 'application/json']],
+]);
+
+const prepareExport = async ({ uid, type }) => {
+	const [extension] = exportMetadata.get(type);
+	const filename = `${uid}_${type}.${extension}`;
+	try {
+		const stat = await fs.stat(path.join(__dirname, '../../build/export', filename));
+		return stat;
+	} catch (e) {
+		return false;
+	}
+};
+
+usersAPI.checkExportByType = async (caller, { uid, type }) => await prepareExport({ uid, type });
+
+usersAPI.getExportByType = async (caller, { uid, type }) => {
+	const [extension, mime] = exportMetadata.get(type);
+	const filename = `${uid}_${type}.${extension}`;
+
+	const exists = await prepareExport({ uid, type });
+	if (exists) {
+		return { filename, mime };
+	}
+
+	return false;
 };
 
 usersAPI.generateExport = async (caller, { uid, type }) => {

--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -490,6 +490,10 @@ helpers.formatApiResponse = async (statusCode, res, payload) => {
 			case '[[error:invalid-uid]]':
 				statusCode = 401;
 				break;
+
+			case '[[error:no-topic]]':
+				statusCode = 404;
+				break;
 		}
 
 		if (message.startsWith('[[error:required-parameters-missing, ')) {

--- a/src/controllers/write/admin.js
+++ b/src/controllers/write/admin.js
@@ -1,42 +1,30 @@
 'use strict';
 
-const meta = require('../../meta');
-const privileges = require('../../privileges');
-const analytics = require('../../analytics');
-
+const api = require('../../api');
 const helpers = require('../helpers');
 
 const Admin = module.exports;
 
 Admin.updateSetting = async (req, res) => {
-	const ok = await privileges.admin.can('admin:settings', req.uid);
+	await api.admin.updateSetting(req, {
+		setting: req.params.setting,
+		value: req.body.value,
+	});
 
-	if (!ok) {
-		return helpers.formatApiResponse(403, res);
-	}
-
-	await meta.configs.set(req.params.setting, req.body.value);
 	helpers.formatApiResponse(200, res);
 };
 
 Admin.getAnalyticsKeys = async (req, res) => {
-	let keys = await analytics.getKeys();
-
-	// Sort keys alphabetically
-	keys = keys.sort((a, b) => (a < b ? -1 : 1));
-
-	helpers.formatApiResponse(200, res, { keys });
+	helpers.formatApiResponse(200, res, {
+		keys: await api.admin.getAnalyticsKeys(),
+	});
 };
 
 Admin.getAnalyticsData = async (req, res) => {
-	// Default returns views from past 24 hours, by hour
-	if (!req.query.amount) {
-		if (req.query.units === 'days') {
-			req.query.amount = 30;
-		} else {
-			req.query.amount = 24;
-		}
-	}
-	const getStats = req.query.units === 'days' ? analytics.getDailyStatsForSet : analytics.getHourlyStatsForSet;
-	helpers.formatApiResponse(200, res, await getStats(`analytics:${req.params.set}`, parseInt(req.query.until, 10) || Date.now(), req.query.amount));
+	helpers.formatApiResponse(200, res, await api.admin.getAnalyticsData(req, {
+		set: req.params.set,
+		until: parseInt(req.query.until, 10) || Date.now(),
+		amount: req.query.amount,
+		units: req.query.units,
+	}));
 };

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const privileges = require('../../privileges');
 const categories = require('../../categories');
 const api = require('../../api');
 
@@ -8,75 +7,56 @@ const helpers = require('../helpers');
 
 const Categories = module.exports;
 
-const hasAdminPrivilege = async (uid) => {
-	const ok = await privileges.admin.can(`admin:categories`, uid);
-	if (!ok) {
-		throw new Error('[[error:no-privileges]]');
-	}
-};
-
 Categories.get = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.categories.get(req, req.params));
 };
 
 Categories.create = async (req, res) => {
-	await hasAdminPrivilege(req.uid);
-
 	const response = await api.categories.create(req, req.body);
 	helpers.formatApiResponse(200, res, response);
 };
 
 Categories.update = async (req, res) => {
-	await hasAdminPrivilege(req.uid);
+	await api.categories.update(req, {
+		cid: req.params.cid,
+		values: req.body,
+	});
 
-	const payload = {};
-	payload[req.params.cid] = req.body;
-	await api.categories.update(req, payload);
 	const categoryObjs = await categories.getCategories([req.params.cid]);
 	helpers.formatApiResponse(200, res, categoryObjs[0]);
 };
 
 Categories.delete = async (req, res) => {
-	await hasAdminPrivilege(req.uid);
-
 	await api.categories.delete(req, { cid: req.params.cid });
 	helpers.formatApiResponse(200, res);
 };
 
 Categories.getPrivileges = async (req, res) => {
-	if (!await privileges.admin.can('admin:privileges', req.uid)) {
-		throw new Error('[[error:no-privileges]]');
-	}
-
-	const privilegeSet = await api.categories.getPrivileges(req, req.params.cid);
+	const privilegeSet = await api.categories.getPrivileges(req, { cid: req.params.cid });
 	helpers.formatApiResponse(200, res, privilegeSet);
 };
 
 Categories.setPrivilege = async (req, res) => {
-	if (!await privileges.admin.can('admin:privileges', req.uid)) {
-		throw new Error('[[error:no-privileges]]');
-	}
+	const { cid, privilege } = req.params;
 
 	await api.categories.setPrivilege(req, {
-		...req.params,
+		cid,
+		privilege,
 		member: req.body.member,
 		set: req.method === 'PUT',
 	});
 
-	const privilegeSet = await api.categories.getPrivileges(req, req.params.cid);
+	const privilegeSet = await api.categories.getPrivileges(req, { cid: req.params.cid });
 	helpers.formatApiResponse(200, res, privilegeSet);
 };
 
 Categories.setModerator = async (req, res) => {
-	if (!await privileges.admin.can('admin:admins-mods', req.uid)) {
-		throw new Error('[[error:no-privileges]]');
-	}
-	const privilegeList = await privileges.categories.getUserPrivilegeList();
-	await api.categories.setPrivilege(req, {
+	await api.categories.setModerator(req, {
 		cid: req.params.cid,
-		privilege: privilegeList,
 		member: req.params.uid,
 		set: req.method === 'PUT',
 	});
-	helpers.formatApiResponse(200, res);
+
+	const privilegeSet = await api.categories.getPrivileges(req, { cid: req.params.cid });
+	helpers.formatApiResponse(200, res, privilegeSet);
 };

--- a/src/controllers/write/chats.js
+++ b/src/controllers/write/chats.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const api = require('../../api');
-const messaging = require('../../messaging');
-
 const helpers = require('../helpers');
 
 const Chats = module.exports;
@@ -10,9 +8,7 @@ const Chats = module.exports;
 Chats.list = async (req, res) => {
 	const page = (isFinite(req.query.page) && parseInt(req.query.page, 10)) || 1;
 	const perPage = (isFinite(req.query.perPage) && parseInt(req.query.perPage, 10)) || 20;
-	const start = Math.max(0, page - 1) * perPage;
-	const stop = start + perPage;
-	const { rooms } = await messaging.getRecentChats(req.uid, req.uid, start, stop);
+	const { rooms } = await api.chats.list(req, { page, perPage });
 
 	helpers.formatApiResponse(200, res, { rooms });
 };
@@ -23,21 +19,20 @@ Chats.create = async (req, res) => {
 };
 
 Chats.exists = async (req, res) => {
+	// yes, this is fine. Room existence is checked via middleware :)
 	helpers.formatApiResponse(200, res);
 };
 
 Chats.get = async (req, res) => {
-	const roomObj = await messaging.loadRoom(req.uid, {
+	helpers.formatApiResponse(200, res, await api.chats.get(req, {
 		uid: req.query.uid || req.uid,
 		roomId: req.params.roomId,
-	});
-
-	helpers.formatApiResponse(200, res, roomObj);
+	}));
 };
 
 Chats.post = async (req, res) => {
 	const messageObj = await api.chats.post(req, {
-		...req.body,
+		message: req.body.message,
 		roomId: req.params.roomId,
 	});
 
@@ -46,7 +41,7 @@ Chats.post = async (req, res) => {
 
 Chats.rename = async (req, res) => {
 	const roomObj = await api.chats.rename(req, {
-		...req.body,
+		name: req.body.name,
 		roomId: req.params.roomId,
 	});
 
@@ -64,15 +59,16 @@ Chats.mark = async (req, res) => {
 };
 
 Chats.users = async (req, res) => {
-	const users = await api.chats.users(req, {
-		...req.params,
-	});
+	const { roomId } = req.params;
+	const users = await api.chats.users(req, { roomId });
+
 	helpers.formatApiResponse(200, res, users);
 };
 
 Chats.invite = async (req, res) => {
+	const { uids } = req.body;
 	const users = await api.chats.invite(req, {
-		...req.body,
+		uids,
 		roomId: req.params.roomId,
 	});
 
@@ -80,8 +76,9 @@ Chats.invite = async (req, res) => {
 };
 
 Chats.kick = async (req, res) => {
+	const { uids } = req.body;
 	const users = await api.chats.kick(req, {
-		...req.body,
+		uids,
 		roomId: req.params.roomId,
 	});
 
@@ -89,9 +86,9 @@ Chats.kick = async (req, res) => {
 };
 
 Chats.kickUser = async (req, res) => {
-	req.body.uids = [req.params.uid];
+	const uids = [req.params.uid];
 	const users = await api.chats.kick(req, {
-		...req.body,
+		uids,
 		roomId: req.params.roomId,
 	});
 
@@ -100,40 +97,38 @@ Chats.kickUser = async (req, res) => {
 
 Chats.messages = {};
 Chats.messages.list = async (req, res) => {
-	const messages = await messaging.getMessages({
-		callerUid: req.uid,
-		uid: req.query.uid || req.uid,
-		roomId: req.params.roomId,
-		start: parseInt(req.query.start, 10) || 0,
-		count: 50,
-	});
+	const uid = req.query.uid || req.uid;
+	const { roomId } = req.params;
+	const start = parseInt(req.query.start, 10) || 0;
+	const { messages } = await api.chats.listMessages(req, { uid, roomId, start });
 
 	helpers.formatApiResponse(200, res, { messages });
 };
 
 Chats.messages.get = async (req, res) => {
-	const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
-	helpers.formatApiResponse(200, res, messages.pop());
+	const { mid, roomId } = req.params;
+
+	helpers.formatApiResponse(200, res, await api.chats.getMessage(req, { mid, roomId }));
 };
 
 Chats.messages.edit = async (req, res) => {
-	await messaging.canEdit(req.params.mid, req.uid);
-	await messaging.editMessage(req.uid, req.params.mid, req.params.roomId, req.body.message);
+	const { mid, roomId } = req.params;
+	const { message } = req.body;
+	await api.chats.editMessage(req, { mid, roomId, message });
 
-	const messages = await messaging.getMessagesData([req.params.mid], req.uid, req.params.roomId, false);
-	helpers.formatApiResponse(200, res, messages.pop());
+	helpers.formatApiResponse(200, res, await api.chats.getMessage(req, { mid, roomId }));
 };
 
 Chats.messages.delete = async (req, res) => {
-	await messaging.canDelete(req.params.mid, req.uid);
-	await messaging.deleteMessage(req.params.mid, req.uid);
+	const { mid } = req.params;
+	await api.chats.deleteMessage(req, { mid });
 
 	helpers.formatApiResponse(200, res);
 };
 
 Chats.messages.restore = async (req, res) => {
-	await messaging.canDelete(req.params.mid, req.uid);
-	await messaging.restoreMessage(req.params.mid, req.uid);
+	const { mid } = req.params;
+	await api.chats.restoreMessage(req, { mid });
 
 	helpers.formatApiResponse(200, res);
 };

--- a/src/controllers/write/files.js
+++ b/src/controllers/write/files.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const fs = require('fs').promises;
 const helpers = require('../helpers');
+const api = require('../../api');
 
 const Files = module.exports;
 
 Files.delete = async (req, res) => {
-	await fs.unlink(res.locals.cleanedPath);
+	await api.files.delete(req, { path: res.locals.cleanedPath });
 	helpers.formatApiResponse(200, res);
 };
 
 Files.createFolder = async (req, res) => {
-	await fs.mkdir(res.locals.folderPath);
+	await api.files.createFolder(req, { path: res.locals.folderPath });
 	helpers.formatApiResponse(200, res);
 };

--- a/src/controllers/write/flags.js
+++ b/src/controllers/write/flags.js
@@ -1,53 +1,48 @@
 'use strict';
 
 const user = require('../../user');
-const flags = require('../../flags');
 const api = require('../../api');
 const helpers = require('../helpers');
 
 const Flags = module.exports;
 
 Flags.create = async (req, res) => {
-	const flagObj = await api.flags.create(req, { ...req.body });
+	const { type, id, reason } = req.body;
+	const flagObj = await api.flags.create(req, { type, id, reason });
 	helpers.formatApiResponse(200, res, await user.isPrivileged(req.uid) ? flagObj : undefined);
 };
 
 Flags.get = async (req, res) => {
-	const isPrivileged = await user.isPrivileged(req.uid);
-	if (!isPrivileged) {
-		return helpers.formatApiResponse(403, res);
-	}
-
-	helpers.formatApiResponse(200, res, await flags.get(req.params.flagId));
+	helpers.formatApiResponse(200, res, await api.flags.get(req, req.params.flagId));
 };
 
 Flags.update = async (req, res) => {
+	const { state, assignee } = req.body;
 	const history = await api.flags.update(req, {
 		flagId: req.params.flagId,
-		...req.body,
+		state,
+		assignee,
 	});
 
 	helpers.formatApiResponse(200, res, { history });
 };
 
 Flags.delete = async (req, res) => {
-	await flags.purge([req.params.flagId]);
+	await api.flags.delete(req, { flagId: req.params.flagId });
 	helpers.formatApiResponse(200, res);
 };
 
 Flags.appendNote = async (req, res) => {
+	const { note, datetime } = req.body;
 	const payload = await api.flags.appendNote(req, {
 		flagId: req.params.flagId,
-		...req.body,
+		note,
+		datetime,
 	});
 
 	helpers.formatApiResponse(200, res, payload);
 };
 
 Flags.deleteNote = async (req, res) => {
-	const payload = await api.flags.deleteNote(req, {
-		...req.params,
-	});
-
-	helpers.formatApiResponse(200, res, payload);
+	helpers.formatApiResponse(200, res, await api.flags.deleteNote(req, req.params));
 };

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const posts = require('../../posts');
-const privileges = require('../../privileges');
-
 const api = require('../../api');
 const helpers = require('../helpers');
-const apiHelpers = require('../../api/helpers');
 
 const Posts = module.exports;
 
@@ -18,7 +15,6 @@ Posts.edit = async (req, res) => {
 		...req.body,
 		pid: req.params.pid,
 		uid: req.uid,
-		req: apiHelpers.buildReqObject(req),
 	});
 
 	helpers.formatApiResponse(200, res, editResult);
@@ -96,21 +92,7 @@ Posts.restoreDiff = async (req, res) => {
 };
 
 Posts.deleteDiff = async (req, res) => {
-	if (!parseInt(req.params.pid, 10)) {
-		throw new Error('[[error:invalid-data]]');
-	}
-
-	const cid = await posts.getCidByPid(req.params.pid);
-	const [isAdmin, isModerator] = await Promise.all([
-		privileges.users.isAdministrator(req.uid),
-		privileges.users.isModerator(req.uid, cid),
-	]);
-
-	if (!(isAdmin || isModerator)) {
-		return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-	}
-
-	await posts.diffs.delete(req.params.pid, req.params.timestamp, req.uid);
+	await api.posts.deleteDiff(req, { ...req.params });
 
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/controllers/write/users.js
+++ b/src/controllers/write/users.js
@@ -1,35 +1,15 @@
 'use strict';
 
-const util = require('util');
 const nconf = require('nconf');
 const path = require('path');
 const crypto = require('crypto');
-const fs = require('fs').promises;
 
-const db = require('../../database');
 const api = require('../../api');
-const groups = require('../../groups');
-const meta = require('../../meta');
-const privileges = require('../../privileges');
 const user = require('../../user');
-const utils = require('../../utils');
 
 const helpers = require('../helpers');
 
 const Users = module.exports;
-
-const exportMetadata = new Map([
-	['posts', ['csv', 'text/csv']],
-	['uploads', ['zip', 'application/zip']],
-	['profile', ['json', 'application/json']],
-]);
-
-const hasAdminPrivilege = async (uid, privilege) => {
-	const ok = await privileges.admin.can(`admin:${privilege}`, uid);
-	if (!ok) {
-		throw new Error('[[error:no-privileges]]');
-	}
-};
 
 Users.redirectBySlug = async (req, res) => {
 	const uid = await user.getUidByUserslug(req.params.userslug);
@@ -44,7 +24,6 @@ Users.redirectBySlug = async (req, res) => {
 };
 
 Users.create = async (req, res) => {
-	await hasAdminPrivilege(req.uid, 'users');
 	const userObj = await api.users.create(req, req.body);
 	helpers.formatApiResponse(200, res, userObj);
 };
@@ -54,9 +33,7 @@ Users.exists = async (req, res) => {
 };
 
 Users.get = async (req, res) => {
-	const userData = await user.getUserData(req.params.uid);
-	const publicUserData = await user.hidePrivateData(userData, req.uid);
-	helpers.formatApiResponse(200, res, publicUserData);
+	helpers.formatApiResponse(200, res, await api.users.get(req, { ...req.params }));
 };
 
 Users.update = async (req, res) => {
@@ -80,7 +57,6 @@ Users.deleteAccount = async (req, res) => {
 };
 
 Users.deleteMany = async (req, res) => {
-	await hasAdminPrivilege(req.uid, 'users');
 	await api.users.deleteMany(req, req.body);
 	helpers.formatApiResponse(200, res);
 };
@@ -131,155 +107,50 @@ Users.unmute = async (req, res) => {
 };
 
 Users.generateToken = async (req, res) => {
-	await hasAdminPrivilege(req.uid, 'settings');
-	if (parseInt(req.params.uid, 10) !== parseInt(req.user.uid, 10)) {
-		return helpers.formatApiResponse(401, res);
-	}
-
-	const settings = await meta.settings.get('core.api');
-	settings.tokens = settings.tokens || [];
-
-	const newToken = {
-		token: utils.generateUUID(),
-		uid: req.user.uid,
-		description: req.body.description || '',
-		timestamp: Date.now(),
-	};
-	settings.tokens.push(newToken);
-	await meta.settings.set('core.api', settings);
-	helpers.formatApiResponse(200, res, newToken);
+	const { description } = req.body;
+	const token = await api.users.generateToken(req, { description, ...req.params });
+	helpers.formatApiResponse(200, res, token);
 };
 
 Users.deleteToken = async (req, res) => {
-	await hasAdminPrivilege(req.uid, 'settings');
-	if (parseInt(req.params.uid, 10) !== parseInt(req.user.uid, 10)) {
-		return helpers.formatApiResponse(401, res);
-	}
-
-	const settings = await meta.settings.get('core.api');
-	const beforeLen = settings.tokens.length;
-	settings.tokens = settings.tokens.filter(tokenObj => tokenObj.token !== req.params.token);
-	if (beforeLen !== settings.tokens.length) {
-		await meta.settings.set('core.api', settings);
-		helpers.formatApiResponse(200, res);
-	} else {
-		helpers.formatApiResponse(404, res);
-	}
+	const ok = await api.users.deleteToken(req, { ...req.params });
+	helpers.formatApiResponse(ok ? 200 : 404, res);
 };
 
-const getSessionAsync = util.promisify((sid, callback) => {
-	db.sessionStore.get(sid, (err, sessionObj) => callback(err, sessionObj || null));
-});
-
 Users.revokeSession = async (req, res) => {
-	// Only admins or global mods (besides the user themselves) can revoke sessions
-	if (parseInt(req.params.uid, 10) !== req.uid && !await user.isAdminOrGlobalMod(req.uid)) {
-		return helpers.formatApiResponse(404, res);
-	}
-
-	const sids = await db.getSortedSetRange(`uid:${req.params.uid}:sessions`, 0, -1);
-	let _id;
-	for (const sid of sids) {
-		/* eslint-disable no-await-in-loop */
-		const sessionObj = await getSessionAsync(sid);
-		if (sessionObj && sessionObj.meta && sessionObj.meta.uuid === req.params.uuid) {
-			_id = sid;
-			break;
-		}
-	}
-
-	if (!_id) {
-		throw new Error('[[error:no-session-found]]');
-	}
-
-	await user.auth.revokeSession(_id, req.params.uid);
+	await api.users.revokeSession(req, { ...req.params });
 	helpers.formatApiResponse(200, res);
 };
 
 Users.invite = async (req, res) => {
 	const { emails, groupsToJoin = [] } = req.body;
 
-	if (!emails || !Array.isArray(groupsToJoin)) {
-		return helpers.formatApiResponse(400, res, new Error('[[error:invalid-data]]'));
-	}
-
-	// For simplicity, this API route is restricted to self-use only. This can change if needed.
-	if (parseInt(req.user.uid, 10) !== parseInt(req.params.uid, 10)) {
-		return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-	}
-
-	const canInvite = await privileges.users.hasInvitePrivilege(req.uid);
-	if (!canInvite) {
-		return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-	}
-
-	const { registrationType } = meta.config;
-	const isAdmin = await user.isAdministrator(req.uid);
-	if (registrationType === 'admin-invite-only' && !isAdmin) {
-		return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-	}
-
-	const inviteGroups = (await groups.getUserInviteGroups(req.uid)).map(group => group.name);
-	const cannotInvite = groupsToJoin.some(group => !inviteGroups.includes(group));
-	if (groupsToJoin.length > 0 && cannotInvite) {
-		return helpers.formatApiResponse(403, res, new Error('[[error:no-privileges]]'));
-	}
-
-	const max = meta.config.maximumInvites;
-	const emailsArr = emails.split(',').map(email => email.trim()).filter(Boolean);
-
-	for (const email of emailsArr) {
-		/* eslint-disable no-await-in-loop */
-		let invites = 0;
-		if (max) {
-			invites = await user.getInvitesNumber(req.uid);
-		}
-		if (!isAdmin && max && invites >= max) {
-			return helpers.formatApiResponse(403, res, new Error(`[[error:invite-maximum-met, ${invites}, ${max}]]`));
+	try {
+		await api.users.invite(req, { emails, groupsToJoin, ...req.params });
+		helpers.formatApiResponse(200, res);
+	} catch (e) {
+		if (e.message.startsWith('[[error:invite-maximum-met')) {
+			return helpers.formatApiResponse(403, res, e);
 		}
 
-		await user.sendInvitationEmail(req.uid, email, groupsToJoin);
+		throw e;
 	}
-
-	return helpers.formatApiResponse(200, res);
 };
 
 Users.getInviteGroups = async function (req, res) {
-	if (parseInt(req.params.uid, 10) !== parseInt(req.user.uid, 10)) {
-		return helpers.formatApiResponse(401, res);
-	}
-
-	const userInviteGroups = await groups.getUserInviteGroups(req.params.uid);
-	return helpers.formatApiResponse(200, res, userInviteGroups.map(group => group.displayName));
+	return helpers.formatApiResponse(200, res, await api.users.getInviteGroups(req, { ...req.params }));
 };
 
 Users.addEmail = async (req, res) => {
-	const canManageUsers = await privileges.admin.can('admin:users', req.uid);
-	const skipConfirmation = canManageUsers && req.body.skipConfirmation;
+	const { email, skipConfirmation } = req.body;
+	const emails = await api.users.addEmail(req, { email, skipConfirmation, ...req.params });
 
-	if (skipConfirmation) {
-		await user.setUserField(req.params.uid, 'email', req.body.email);
-		await user.email.confirmByUid(req.params.uid);
-	} else {
-		await api.users.update(req, {
-			uid: req.params.uid,
-			email: req.body.email,
-		});
-	}
-
-	const emails = await db.getSortedSetRangeByScore('email:uid', 0, 500, req.params.uid, req.params.uid);
 	helpers.formatApiResponse(200, res, { emails });
 };
 
 Users.listEmails = async (req, res) => {
-	const [isPrivileged, { showemail }] = await Promise.all([
-		user.isPrivileged(req.uid),
-		user.getSettings(req.params.uid),
-	]);
-	const isSelf = req.uid === parseInt(req.params.uid, 10);
-
-	if (isSelf || isPrivileged || showemail) {
-		const emails = await db.getSortedSetRangeByScore('email:uid', 0, 500, req.params.uid, req.params.uid);
+	const emails = await api.users.listEmails(req, { ...req.params });
+	if (emails) {
 		helpers.formatApiResponse(200, res, { emails });
 	} else {
 		helpers.formatApiResponse(204, res);
@@ -287,79 +158,38 @@ Users.listEmails = async (req, res) => {
 };
 
 Users.getEmail = async (req, res) => {
-	const [isPrivileged, { showemail }, exists] = await Promise.all([
-		user.isPrivileged(req.uid),
-		user.getSettings(req.params.uid),
-		db.isSortedSetMember('email:uid', req.params.email.toLowerCase()),
-	]);
-	const isSelf = req.uid === parseInt(req.params.uid, 10);
-
-	if (exists && (isSelf || isPrivileged || showemail)) {
-		helpers.formatApiResponse(204, res);
-	} else {
-		helpers.formatApiResponse(404, res);
-	}
+	const ok = await api.users.getEmail(req, { ...req.params });
+	helpers.formatApiResponse(ok ? 204 : 404, res);
 };
 
 Users.confirmEmail = async (req, res) => {
-	const [pending, current, canManage] = await Promise.all([
-		user.email.isValidationPending(req.params.uid, req.params.email),
-		user.getUserField(req.params.uid, 'email'),
-		privileges.admin.can('admin:users', req.uid),
-	]);
-
-	if (!canManage) {
-		return helpers.notAllowed(req, res);
-	}
-
-	if (pending) { // has active confirmation request
-		const code = await db.get(`confirm:byUid:${req.params.uid}`);
-		await user.email.confirmByCode(code, req.session.id);
-		helpers.formatApiResponse(200, res);
-	} else if (current && current === req.params.email) { // i.e. old account w/ unconf. email in user hash
-		await user.email.confirmByUid(req.params.uid);
-		helpers.formatApiResponse(200, res);
-	} else {
-		helpers.formatApiResponse(404, res);
-	}
-};
-
-const prepareExport = async (req, res) => {
-	const [extension] = exportMetadata.get(req.params.type);
-	const filename = `${req.params.uid}_${req.params.type}.${extension}`;
-	try {
-		const stat = await fs.stat(path.join(__dirname, '../../../build/export', filename));
-		const modified = new Date(stat.mtimeMs);
-		res.set('Last-Modified', modified.toUTCString());
-		res.set('ETag', `"${crypto.createHash('md5').update(String(stat.mtimeMs)).digest('hex')}"`);
-		res.status(204);
-		return true;
-	} catch (e) {
-		res.status(404);
-		return false;
-	}
+	const ok = await api.users.confirmEmail(req, {
+		sessionId: req.session.id,
+		...req.params,
+	});
+	helpers.formatApiResponse(ok ? 200 : 404, res);
 };
 
 Users.checkExportByType = async (req, res) => {
-	await prepareExport(req, res);
-	res.end();
+	const stat = await api.users.checkExportByType(req, { ...req.params });
+	const modified = new Date(stat.mtimeMs);
+	res.set('Last-Modified', modified.toUTCString());
+	res.set('ETag', `"${crypto.createHash('md5').update(String(stat.mtimeMs)).digest('hex')}"`);
+	res.sendStatus(204);
 };
 
-Users.getExportByType = async (req, res) => {
-	const [extension, mime] = exportMetadata.get(req.params.type);
-	const filename = `${req.params.uid}_${req.params.type}.${extension}`;
-
-	const exists = await prepareExport(req, res);
-	if (!exists) {
-		return res.end();
+Users.getExportByType = async (req, res, next) => {
+	const data = await api.users.getExportByType(req, ({ ...req.params }));
+	if (!data) {
+		return next();
 	}
 
 	res.status(200);
-	res.sendFile(filename, {
+	res.sendFile(data.filename, {
 		root: path.join(__dirname, '../../../build/export'),
 		headers: {
-			'Content-Type': mime,
-			'Content-Disposition': `attachment; filename=${filename}`,
+			'Content-Type': data.mime,
+			'Content-Disposition': `attachment; filename=${data.filename}`,
 		},
 	}, (err) => {
 		if (err) {

--- a/test/categories.js
+++ b/test/categories.js
@@ -371,9 +371,11 @@ describe('Categories', () => {
 		});
 
 		it('should error if you try to set parent as self', async () => {
-			const updateData = {};
-			updateData[cid] = {
-				parentCid: cid,
+			const updateData = {
+				cid,
+				values: {
+					parentCid: cid,
+				},
 			};
 			let err;
 			try {
@@ -389,9 +391,11 @@ describe('Categories', () => {
 			const parentCid = parentCategory.cid;
 			const childCategory = await Categories.create({ name: 'child1', description: 'wanna be parent', parentCid: parentCid });
 			const child1Cid = childCategory.cid;
-			const updateData = {};
-			updateData[parentCid] = {
-				parentCid: child1Cid,
+			const updateData = {
+				cid: parentCid,
+				values: {
+					parentCid: child1Cid,
+				},
 			};
 			let err;
 			try {
@@ -403,22 +407,24 @@ describe('Categories', () => {
 		});
 
 		it('should update category data', async () => {
-			const updateData = {};
-			updateData[cid] = {
-				name: 'new name',
-				description: 'new description',
-				parentCid: 0,
-				order: 3,
-				icon: 'fa-hammer',
+			const updateData = {
+				cid,
+				values: {
+					name: 'new name',
+					description: 'new description',
+					parentCid: 0,
+					order: 3,
+					icon: 'fa-hammer',
+				},
 			};
 			await apiCategories.update({ uid: adminUid }, updateData);
 
 			const data = await Categories.getCategoryData(cid);
-			assert.equal(data.name, updateData[cid].name);
-			assert.equal(data.description, updateData[cid].description);
-			assert.equal(data.parentCid, updateData[cid].parentCid);
-			assert.equal(data.order, updateData[cid].order);
-			assert.equal(data.icon, updateData[cid].icon);
+			assert.equal(data.name, updateData.values.name);
+			assert.equal(data.description, updateData.values.description);
+			assert.equal(data.parentCid, updateData.values.parentCid);
+			assert.equal(data.order, updateData.values.order);
+			assert.equal(data.icon, updateData.values.icon);
 		});
 
 		it('should properly order categories', async () => {
@@ -427,12 +433,12 @@ describe('Categories', () => {
 			const c2 = await Categories.create({ name: 'c2', description: 'd2', parentCid: p1.cid, order: 2 });
 			const c3 = await Categories.create({ name: 'c3', description: 'd3', parentCid: p1.cid, order: 3 });
 			// move c1 to second place
-			await apiCategories.update({ uid: adminUid }, { [c1.cid]: { order: 2 } });
+			await apiCategories.update({ uid: adminUid }, { cid: c1.cid, values: { order: 2 } });
 			let cids = await db.getSortedSetRange(`cid:${p1.cid}:children`, 0, -1);
 			assert.deepStrictEqual(cids.map(Number), [c2.cid, c1.cid, c3.cid]);
 
 			// move c3 to front
-			await apiCategories.update({ uid: adminUid }, { [c3.cid]: { order: 1 } });
+			await apiCategories.update({ uid: adminUid }, { cid: c3.cid, values: { order: 1 } });
 			cids = await db.getSortedSetRange(`cid:${p1.cid}:children`, 0, -1);
 			assert.deepStrictEqual(cids.map(Number), [c3.cid, c2.cid, c1.cid]);
 		});

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -199,6 +199,7 @@ helpers.copyFile = function (source, target, callback) {
 };
 
 helpers.invite = async function (body, uid, jar, csrf_token) {
+	console.log('making call');
 	const res = await requestAsync.post(`${nconf.get('url')}/api/v3/users/${uid}/invites`, {
 		jar: jar,
 		// using "form" since client "api" module make requests with "application/x-www-form-urlencoded" content-type
@@ -209,6 +210,7 @@ helpers.invite = async function (body, uid, jar, csrf_token) {
 		simple: false,
 		resolveWithFullResponse: true,
 	});
+	console.log(res.statusCode, res.body);
 
 	res.body = JSON.parse(res.body);
 	return { res, body };

--- a/test/user.js
+++ b/test/user.js
@@ -2142,7 +2142,7 @@ describe('User', () => {
 				assert.strictEqual(res.statusCode, 403);
 			});
 
-			it('should error if ouf of invitations', async () => {
+			it('should error if out of invitations', async () => {
 				meta.config.maximumInvites = 1;
 				const { res } = await helpers.invite({ emails: 'invite6@test.com', groupsToJoin: [] }, inviterUid, jar, csrf_token);
 				assert.strictEqual(res.statusCode, 403);
@@ -2339,14 +2339,7 @@ describe('User', () => {
 					resolveWithFullResponse: true,
 				});
 
-				assert.strictEqual(res.statusCode, 401);
-				assert.deepStrictEqual(res.body, {
-					status: {
-						code: 'not-authorised',
-						message: 'A valid login session was not found. Please log in and try again.',
-					},
-					response: {},
-				});
+				assert.strictEqual(res.statusCode, 403);
 			});
 		});
 	});


### PR DESCRIPTION
After discussion with @baris, we decided that the library methods in `src/api/*` were to be maintained going forward.
Originally, they were created to be a common code path for both the write API and socket.io.
There was discussion over whether `src/api/*` methods were _transitional_, or whether there were additional benefits.

@julian argued that it may be better to move all the logic back into the controllers themselves once the socket.io routes were removed in v3.

@baris argued that it is better to maintain the library methods in `src/api/*` as then plugins can call them directly as opposed to having to hack together a call to the controller in `src/controllers`, and pass in a req-like object.

@julian also realized that tests would be simpler without the layer of having to make a websocket (or HTTP) call if the controller logic itself could be executed directly.

Therefore:

* If a controller does not have a corresponding `src/api/*` method, one should be created.
* We will maintain `src/api/*` methods.
* The methods will be refactored if necessary to contain the minimal logic required. At most it should just call the `src/api/*` method, and return the API response
* Any logic checks in the v3 controller methods should be moved to the corresponding `src/api/*` method.
* Any socket.io methods should be untouched, as;
    - Additional checks do not hurt anything
    - If touched in `develop`, they may conflict badly in v3 since the socket.io methods are slated for removal
