### PR TITLE
wrap quotes to prevent stripping leading 0

### DIFF
--- a/src/user/admin.js
+++ b/src/user/admin.js
@@ -70,12 +70,11 @@ module.exports = function (User) {
 
 			let line = '';
 			usersData.forEach((user, index) => {
-				line += `${fields.map(field => {
-					if ( /^\d+$/.test(user[field])) {
-						return `'${user[field]}'`;
-					}
-					return user[field]
-				}).join(',')}`;
+				line += `${fields
+					.map((field) =>
+						isFinite(user[field]) ? `'${user[field]}'` : user[field]
+					)
+					.join(",")}`;
 				if (showIps) {
 					userIPs = ips[index] ? ips[index].join(',') : '';
 					line += `,"${userIPs}"\n`;

--- a/src/user/admin.js
+++ b/src/user/admin.js
@@ -71,10 +71,8 @@ module.exports = function (User) {
 			let line = '';
 			usersData.forEach((user, index) => {
 				line += `${fields
-					.map((field) =>
-						isFinite(user[field]) ? `'${user[field]}'` : user[field]
-					)
-					.join(",")}`;
+					.map(field => (isFinite(user[field]) ? `'${user[field]}'` : user[field]))
+					.join(',')}`;
 				if (showIps) {
 					userIPs = ips[index] ? ips[index].join(',') : '';
 					line += `,"${userIPs}"\n`;

--- a/src/user/admin.js
+++ b/src/user/admin.js
@@ -70,7 +70,12 @@ module.exports = function (User) {
 
 			let line = '';
 			usersData.forEach((user, index) => {
-				line += `${fields.map(field => user[field]).join(',')}`;
+				line += `${fields.map(field => {
+					if ( /^\d+$/.test(user[field])) {
+						return `'${user[field]}'`;
+					}
+					return user[field]
+				}).join(',')}`;
 				if (showIps) {
 					userIPs = ips[index] ? ips[index].join(',') : '';
 					line += `,"${userIPs}"\n`;


### PR DESCRIPTION
If the field is a number, wrap it in quotes to prevent Excel from stripping leading zeros