### PR TITLE
ci: publish containers to ghcr instead of docker hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,13 +13,14 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 permissions:
   contents: read
+  packages: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -32,14 +33,15 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: nodebb/docker
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
[Docker is sunsetting free organization accounts](https://blog.alexellis.io/docker-is-deleting-open-source-images/) ([official FAQ](https://web.docker.com/rs/790-SSB-375/images/privatereposfaq.pdf)), which means that any organization that doesn't upgrade to a paid tier that costs at least $300/year (with the 5 user minimum, billed annually. With monthly billing the price jumps to $420/year) and doesn't qualify for the very restrictive open source program (which requires "Not having a pathway to commercialization" - so NodeBB doesn't fulfill the criteria) will have their accounts **deleted in a month**.\*

There is currently no official downgrade path to a personal account - from my understanding it might be possible to manually swap the names (rename the organization and create a new user with the original name), but I'm not entirely sure and it leaves a (hopefully short) time during which a malicious actor can hijack the namespace.

Fortunately, GitHub offers an alternative. Part of [GitHub Packages](https://github.com/features/packages) is GitHub Container Registry, which is free for public repositories and well integrated with GitHub.

The changes to the GitHub Actions file required are fairly minimal. The biggest required difference will be the name of the image - it'll require prefixing with `ghcr.io` to make docker use the right registry.

I have however elected to parametrize the image a bit more to make it also work well when running on forks without any additional setup - by publishing to the full repository name (`username/repository`) - which for NodeBB means the image will live under `ghcr.io/nodebb/nodebb`.

\* the account will be suspended on April 14, but public repositories will remain accessible for further 30 days. So for NodeBB this means that pulls will fail in 60 days, but there won't be new releases after April 14, but pulls will work a bit longer.


Tasks:
- [x] Make GitHub Actions publish to GHCR
- [ ] Migrate current tags to GHCR (pull from docker and push all tags to GHCR)
- [ ] Note the change in documentation (err... are there actually any current docker docs?)