### PR TITLE
fix: upload modal error handler

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -115,6 +115,7 @@
 	"guest-upload-disabled": "Guest uploading has been disabled",
 	"cors-error": "Unable to upload image due to misconfigured CORS",
 	"upload-ratelimit-reached": "You have uploaded too many files at one time. Please try again later.",
+	"upload-error-fallback": "Unable to upload image — %1",
 
   	"scheduling-to-past": "Please select a date in the future.",
   	"invalid-schedule-date": "Please enter a valid date and time.",

--- a/public/src/modules/uploader.js
+++ b/public/src/modules/uploader.js
@@ -72,7 +72,7 @@ define('uploader', ['jquery-form'], function () {
 			},
 			error: function (xhr) {
 				xhr = maybeParse(xhr);
-				showAlert(uploadModal, 'error', xhr.responseJSON ? (xhr.responseJSON.error || xhr.statusText) : 'error uploading, code : ' + xhr.status);
+				showAlert(uploadModal, 'error', xhr.responseJSON?.status?.message || `[[error:upload-error-fallback, ${xhr.status} ${xhr.statusText}]]`);
 			},
 			uploadProgress: function (event, position, total, percent) {
 				uploadModal.find('#upload-progress-bar').css('width', percent + '%');


### PR DESCRIPTION
The underlying API call was updated to v3 style (with standard status/response object in response body), so the existing code always falls back to the default error instead of showing the more specific error sent back by the backend.

Also, the fallback wasn't internationalized, so that's done to.
