### PR TITLE
refactor: started work on porting posting and topic-related socket methods to write API

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -164,6 +164,8 @@ paths:
     $ref: 'write/posts/pid/diffs/since.yaml'
   /posts/{pid}/diffs/{timestamp}:
     $ref: 'write/posts/pid/diffs/timestamp.yaml'
+  /posts/{pid}/replies:
+    $ref: 'write/posts/pid/replies.yaml'
   /chats/:
     $ref: 'write/chats.yaml'
   /chats/{roomId}:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -142,6 +142,10 @@ paths:
     $ref: 'write/topics/tid/events.yaml'
   /topics/{tid}/events/{eventId}:
     $ref: 'write/topics/tid/events/eventId.yaml'
+  /topics/{tid}/read:
+    $ref: 'write/topics/tid/read.yaml'
+  /topics/{tid}/bump:
+    $ref: 'write/topics/tid/bump.yaml'
   /posts/{pid}:
     $ref: 'write/posts/pid.yaml'
   /posts/{pid}/index:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -144,6 +144,8 @@ paths:
     $ref: 'write/topics/tid/events/eventId.yaml'
   /posts/{pid}:
     $ref: 'write/posts/pid.yaml'
+  /posts/{pid}/index:
+    $ref: 'write/posts/pid/index.yaml'
   /posts/{pid}/raw:
     $ref: 'write/posts/pid/raw.yaml'
   /posts/{pid}/summary:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -144,6 +144,10 @@ paths:
     $ref: 'write/topics/tid/events/eventId.yaml'
   /posts/{pid}:
     $ref: 'write/posts/pid.yaml'
+  /posts/{pid}/raw:
+    $ref: 'write/posts/pid/raw.yaml'
+  /posts/{pid}/summary:
+    $ref: 'write/posts/pid/summary.yaml'
   /posts/{pid}/state:
     $ref: 'write/posts/pid/state.yaml'
   /posts/{pid}/move:

--- a/public/openapi/write/posts/pid/index.yaml
+++ b/public/openapi/write/posts/pid/index.yaml
@@ -1,0 +1,28 @@
+get:
+  tags:
+    - posts
+  summary: get post index
+  description: This operation retrieves a post's index relative to its topic
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post index successfully retrieved.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  index:
+                    type: number

--- a/public/openapi/write/posts/pid/raw.yaml
+++ b/public/openapi/write/posts/pid/raw.yaml
@@ -1,0 +1,28 @@
+get:
+  tags:
+    - posts
+  summary: get post's raw content
+  description: This operation retrieves a post's raw content (unparsed by markdown, etc.)
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post raw content successfully retrieved.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  content:
+                    type: string

--- a/public/openapi/write/posts/pid/replies.yaml
+++ b/public/openapi/write/posts/pid/replies.yaml
@@ -1,0 +1,234 @@
+get:
+  tags:
+    - posts
+  summary: get post replies
+  description: This operation retrieves a post's direct replies
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post replies successfully retrieved.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  replies:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        pid:
+                          type: number
+                        uid:
+                          type: number
+                          description: A user identifier
+                        tid:
+                          type: number
+                          description: A topic identifier
+                        content:
+                          type: string
+                        timestamp:
+                          type: number
+                        votes:
+                          type: number
+                        deleted:
+                          type: number
+                        upvotes:
+                          type: number
+                        downvotes:
+                          type: number
+                        bookmarks:
+                          type: number
+                        deleterUid:
+                          type: number
+                        edited:
+                          type: number
+                        timestampISO:
+                          type: string
+                          description: An ISO 8601 formatted date string (complementing `timestamp`)
+                        editedISO:
+                          type: string
+                        index:
+                          type: number
+                        user:
+                          type: object
+                          properties:
+                            uid:
+                              type: number
+                              description: A user identifier
+                            username:
+                              type: string
+                              description: A friendly name for a given user account
+                            displayname:
+                              type: string
+                              description: This is either username or fullname depending on forum and user settings
+                            userslug:
+                              type: string
+                              description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                removed, etc.)
+                            reputation:
+                              type: number
+                            postcount:
+                              type: number
+                            topiccount:
+                              type: number
+                            picture:
+                              type: string
+                              nullable: true
+                            signature:
+                              type: string
+                            banned:
+                              type: number
+                            banned:expire:
+                              type: number
+                            status:
+                              type: string
+                            lastonline:
+                              type: number
+                            groupTitle:
+                              nullable: true
+                              type: string
+                            groupTitleArray:
+                              type: array
+                              items:
+                                type: string
+                            muted:
+                              type: boolean
+                              description: Whether or not the user has been muted.
+                            mutedUntil:
+                              type: number
+                              description: A UNIX timestamp representing the moment a muted state will be lifted.
+                              nullable: true
+                            icon:text:
+                              type: string
+                              description: A single-letter representation of a username. This is used in the
+                                auto-generated icon given to users without
+                                an avatar
+                            icon:bgColor:
+                              type: string
+                              description: A six-character hexadecimal colour code assigned to the user. This
+                                value is used in conjunction with
+                                `icon:text` for the user's auto-generated
+                                icon
+                              example: "#f44336"
+                            lastonlineISO:
+                              type: string
+                            banned_until:
+                              type: number
+                            banned_until_readable:
+                              type: string
+                            selectedGroups:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  name:
+                                    type: string
+                                  slug:
+                                    type: string
+                                  labelColor:
+                                    type: string
+                                  textColor:
+                                    type: string
+                                  icon:
+                                    type: string
+                                  userTitle:
+                                    type: string
+                            custom_profile_info:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  content:
+                                    type: string
+                                    description: HTML that is injected into `topic.tpl` of themes that support custom profile info
+                        editor:
+                          nullable: true
+                        bookmarked:
+                          type: boolean
+                        upvoted:
+                          type: boolean
+                        downvoted:
+                          type: boolean
+                        replies:
+                          type: object
+                          properties:
+                            hasMore:
+                              type: boolean
+                            users:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  username:
+                                    type: string
+                                    description: A friendly name for a given user account
+                                  userslug:
+                                    type: string
+                                    description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                                      removed, etc.)
+                                  picture:
+                                    type: string
+                                  uid:
+                                    type: number
+                                    description: A user identifier
+                                  icon:text:
+                                    type: string
+                                    description: A single-letter representation of a username. This is used in the
+                                      auto-generated icon given to users without
+                                      an avatar
+                                  icon:bgColor:
+                                    type: string
+                                    description: A six-character hexadecimal colour code assigned to the user. This
+                                      value is used in conjunction with
+                                      `icon:text` for the user's auto-generated
+                                      icon
+                                    example: "#f44336"
+                                  administrator:
+                                    type: boolean
+                            text:
+                              type: string
+                            count:
+                              type: number
+                        selfPost:
+                          type: boolean
+                        events:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              type:
+                                type: string
+                              id:
+                                type: number
+                              timestamp:
+                                type: number
+                              timestampISO:
+                                type: string
+                        topicOwnerPost:
+                          type: boolean
+                        display_edit_tools:
+                          type: boolean
+                        display_delete_tools:
+                          type: boolean
+                        display_moderator_tools:
+                          type: boolean
+                        display_move_tools:
+                          type: boolean
+                        display_post_menu:
+                          type: boolean
+                        flagId:
+                          type: number
+                          description: The flag identifier, if this particular post has been flagged before

--- a/public/openapi/write/posts/pid/summary.yaml
+++ b/public/openapi/write/posts/pid/summary.yaml
@@ -1,0 +1,70 @@
+get:
+  tags:
+    - posts
+  summary: get post summary
+  description: |
+    This operation retrieves a post full summary.
+
+    This differs from the "get a post" call in that it will return the following additional information:
+
+      * A minimal user object
+      * A topic object
+      * A category object
+      * Post content is run through the parser
+
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post summary successfully retrieved.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  pid:
+                    type: number
+                  tid:
+                    type: number
+                    description: A topic identifier
+                  content:
+                    type: string
+                  uid:
+                    type: number
+                    description: A user identifier
+                  timestamp:
+                    type: number
+                  deleted:
+                    type: number
+                  upvotes:
+                    type: number
+                  downvotes:
+                    type: number
+                  replies:
+                    type: number
+                  votes:
+                    type: number
+                  timestampISO:
+                    type: string
+                  user:
+                    type: object
+                    additionalProperties: {}
+                  topic:
+                    type: object
+                    additionalProperties: {}
+                  category:
+                    type: object
+                    additionalProperties: {}
+                  isMainPost:
+                    type: boolean

--- a/public/openapi/write/topics/tid/bump.yaml
+++ b/public/openapi/write/topics/tid/bump.yaml
@@ -1,0 +1,29 @@
+put:
+  tags:
+    - topics
+  summary: mark topic unread for all
+  description: |
+    This operation marks a topic as unread for all users.
+
+    **Note**: This is a privileged call and can only be executed by administrators, global moderators, or the moderator for the category of the passed-in topic.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully marked unread for all
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/openapi/write/topics/tid/read.yaml
+++ b/public/openapi/write/topics/tid/read.yaml
@@ -1,0 +1,52 @@
+delete:
+  tags:
+    - topics
+  summary: mark topic unread
+  description: This operation marks a topic as unread for the calling user.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully marked unread.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}
+put:
+  tags:
+    - topics
+  summary: mark topic read
+  description: This operation marks a topic as read for the calling user.
+  parameters:
+    - in: path
+      name: tid
+      schema:
+        type: string
+      required: true
+      description: a valid topic id
+      example: 1
+  responses:
+    '200':
+      description: Topic successfully marked read
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -250,7 +250,7 @@ define('forum/topic', [
 			destroyed = false;
 
 			async function renderPost(pid) {
-				const postData = postCache[pid] || await socket.emit('posts.getPostSummaryByPid', { pid: pid });
+				const postData = postCache[pid] || await api.get(`/posts/${pid}/summary`);
 				$('#post-tooltip').remove();
 				if (postData && ajaxify.data.template.topic) {
 					postCache[pid] = postData;

--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -326,7 +326,7 @@ define('forum/topic', [
 			currentUrl = newUrl;
 
 			if (index >= elementCount && app.user.uid) {
-				socket.emit('topics.markAsRead', [ajaxify.data.tid]);
+				api.put(`/topics/${ajaxify.data.tid}/read`);
 			}
 
 			updateUserBookmark(index);

--- a/public/src/client/topic/postTools.js
+++ b/public/src/client/topic/postTools.js
@@ -313,13 +313,9 @@ define('forum/topic/postTools', [
 			if (selectedNode.text && toPid && toPid === selectedNode.pid) {
 				return quote(selectedNode.text);
 			}
-			socket.emit('posts.getRawPost', toPid, function (err, post) {
-				if (err) {
-					return alerts.error(err);
-				}
 
-				quote(post);
-			});
+			const { content } = await api.get(`/posts/${toPid}/raw`);
+			quote(content);
 		});
 	}
 

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -60,6 +60,28 @@ define('forum/topic/threadTools', [
 			return false;
 		});
 
+		topicContainer.on('click', '[component="topic/mark-unread"]', function () {
+			topicCommand('del', '/read', undefined, () => {
+				if (app.previousUrl && !app.previousUrl.match('^/topic')) {
+					ajaxify.go(app.previousUrl, function () {
+						handleBack.onBackClicked(true);
+					});
+				} else if (ajaxify.data.category) {
+					ajaxify.go('category/' + ajaxify.data.category.slug, handleBack.onBackClicked);
+				}
+
+				alerts.success('[[topic:mark_unread.success]]');
+			});
+		});
+
+		topicContainer.on('click', '[component="topic/mark-unread-for-all"]', function () {
+			const btn = $(this);
+			topicCommand('put', '/bump', undefined, () => {
+				alerts.success('[[topic:markAsUnreadForAll.success]]');
+				btn.parents('.thread-tools.open').find('.dropdown-toggle').trigger('click');
+			});
+		});
+
 		topicContainer.on('click', '[component="topic/event/delete"]', function () {
 			const eventId = $(this).attr('data-topic-event-id');
 			const eventEl = $(this).parents('[component="topic/event"]');
@@ -72,38 +94,6 @@ define('forum/topic/threadTools', [
 						.catch(alerts.error);
 				}
 			});
-		});
-
-		// todo: should also use topicCommand, but no write api call exists for this yet
-		topicContainer.on('click', '[component="topic/mark-unread"]', function () {
-			socket.emit('topics.markUnread', tid, function (err) {
-				if (err) {
-					return alerts.error(err);
-				}
-
-				if (app.previousUrl && !app.previousUrl.match('^/topic')) {
-					ajaxify.go(app.previousUrl, function () {
-						handleBack.onBackClicked(true);
-					});
-				} else if (ajaxify.data.category) {
-					ajaxify.go('category/' + ajaxify.data.category.slug, handleBack.onBackClicked);
-				}
-
-				alerts.success('[[topic:mark_unread.success]]');
-			});
-			return false;
-		});
-
-		topicContainer.on('click', '[component="topic/mark-unread-for-all"]', function () {
-			const btn = $(this);
-			socket.emit('topics.markAsUnreadForAll', [tid], function (err) {
-				if (err) {
-					return alerts.error(err);
-				}
-				alerts.success('[[topic:markAsUnreadForAll.success]]');
-				btn.parents('.thread-tools.open').find('.dropdown-toggle').trigger('click');
-			});
-			return false;
 		});
 
 		topicContainer.on('click', '[component="topic/move"]', function () {

--- a/public/src/client/unread.js
+++ b/public/src/client/unread.js
@@ -2,8 +2,8 @@
 
 
 define('forum/unread', [
-	'forum/header/unread', 'topicSelect', 'components', 'topicList', 'categorySelector', 'alerts',
-], function (headerUnread, topicSelect, components, topicList, categorySelector, alerts) {
+	'forum/header/unread', 'topicSelect', 'components', 'topicList', 'categorySelector', 'alerts', 'api',
+], function (headerUnread, topicSelect, components, topicList, categorySelector, alerts, api) {
 	const Unread = {};
 
 	Unread.init = function () {
@@ -37,11 +37,8 @@ define('forum/unread', [
 			if (!tids.length) {
 				return;
 			}
-			socket.emit('topics.markAsRead', tids, function (err) {
-				if (err) {
-					return alerts.error(err);
-				}
 
+			Promise.all(tids.map(async tid => api.put(`/topics/${tid}/read`))).then(() => {
 				doneRemovingTids(tids);
 			});
 		}

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -41,6 +41,16 @@ postsAPI.get = async function (caller, data) {
 	return post;
 };
 
+postsAPI.getIndex = async (caller, { pid, sort }) => {
+	const tid = await posts.getPostField(pid, 'tid');
+	const topicPrivileges = await privileges.topics.get(tid, caller.uid);
+	if (!topicPrivileges.read || !topicPrivileges['topics:read']) {
+		return null;
+	}
+
+	return await posts.getPidIndex(pid, tid, sort);
+};
+
 postsAPI.getSummary = async (caller, { pid }) => {
 	const tid = await posts.getPostField(pid, 'tid');
 	const topicPrivileges = await privileges.topics.get(tid, caller.uid);

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -44,6 +44,18 @@ Posts.get = async (req, res) => {
 	helpers.formatApiResponse(200, res, post);
 };
 
+Posts.getIndex = async (req, res) => {
+	const { pid } = req.params;
+	const { sort } = req.body;
+
+	const index = await api.posts.getIndex(req, { pid, sort });
+	if (index === null) {
+		return helpers.formatApiResponse(404, res, new Error('[[error:no-post]]'));
+	}
+
+	helpers.formatApiResponse(200, res, { index });
+};
+
 Posts.getSummary = async (req, res) => {
 	const post = await api.posts.getSummary(req, { pid: req.params.pid });
 	if (!post) {

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -7,7 +7,30 @@ const helpers = require('../helpers');
 const Posts = module.exports;
 
 Posts.get = async (req, res) => {
-	helpers.formatApiResponse(200, res, await api.posts.get(req, { pid: req.params.pid }));
+	const post = await api.posts.get(req, { pid: req.params.pid });
+	if (!post) {
+		return helpers.formatApiResponse(404, res, new Error('[[error:no-post]]'));
+	}
+
+	helpers.formatApiResponse(200, res, post);
+};
+
+Posts.getSummary = async (req, res) => {
+	const post = await api.posts.getSummary(req, { pid: req.params.pid });
+	if (!post) {
+		return helpers.formatApiResponse(404, res, new Error('[[error:no-post]]'));
+	}
+
+	helpers.formatApiResponse(200, res, post);
+};
+
+Posts.getRaw = async (req, res) => {
+	const content = await api.posts.getRaw(req, { pid: req.params.pid });
+	if (content === null) {
+		return helpers.formatApiResponse(404, res, new Error('[[error:no-post]]'));
+	}
+
+	helpers.formatApiResponse(200, res, { content });
 };
 
 Posts.edit = async (req, res) => {

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -160,3 +160,12 @@ Posts.deleteDiff = async (req, res) => {
 
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };
+
+Posts.getReplies = async (req, res) => {
+	const replies = await api.posts.getReplies(req, { ...req.params });
+	if (replies === null) {
+		return helpers.formatApiResponse(404, res, new Error('[[error:no-post]]'));
+	}
+
+	helpers.formatApiResponse(200, res, { replies });
+};

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -181,3 +181,21 @@ Topics.deleteEvent = async (req, res) => {
 
 	helpers.formatApiResponse(200, res);
 };
+
+Topics.markRead = async (req, res) => {
+	await api.topics.markRead(req, { ...req.params });
+
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.markUnread = async (req, res) => {
+	await api.topics.markUnread(req, { ...req.params });
+
+	helpers.formatApiResponse(200, res);
+};
+
+Topics.bump = async (req, res) => {
+	await api.topics.bump(req, { ...req.params });
+
+	helpers.formatApiResponse(200, res);
+};

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -270,7 +270,7 @@ middleware.validateAuth = helpers.try(async (req, res, next) => {
 
 middleware.checkRequired = function (fields, req, res, next) {
 	// Used in API calls to ensure that necessary parameters/data values are present
-	const missing = fields.filter(field => !req.body.hasOwnProperty(field));
+	const missing = fields.filter(field => !req.body.hasOwnProperty(field) && !req.query.hasOwnProperty(field));
 
 	if (!missing.length) {
 		return next();

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -15,6 +15,7 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid', [middleware.ensureLoggedIn, middleware.checkRequired.bind(null, ['content'])], controllers.write.posts.edit);
 	setupApiRoute(router, 'delete', '/:pid', middlewares, controllers.write.posts.purge);
 
+	setupApiRoute(router, 'get', '/:pid/index', [middleware.assert.post], controllers.write.posts.getIndex);
 	setupApiRoute(router, 'get', '/:pid/raw', [middleware.assert.post], controllers.write.posts.getRaw);
 	setupApiRoute(router, 'get', '/:pid/summary', [middleware.assert.post], controllers.write.posts.getSummary);
 

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -35,6 +35,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);
 	setupApiRoute(router, 'delete', '/:pid/diffs/:timestamp', middlewares, controllers.write.posts.deleteDiff);
 
+	setupApiRoute(router, 'get', '/:pid/replies', [middleware.assert.post], controllers.write.posts.getReplies);
+
 	// Shorthand route to access post routes by topic index
 	router.all('/+byIndex/:index*?', [middleware.checkRequired.bind(null, ['tid'])], controllers.write.posts.redirectByIndex);
 

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -34,5 +34,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);
 	setupApiRoute(router, 'delete', '/:pid/diffs/:timestamp', middlewares, controllers.write.posts.deleteDiff);
 
+	// Shorthand route to access post routes by topic index
+	router.all('/+byIndex/:index*?', [middleware.checkRequired.bind(null, ['tid'])], controllers.write.posts.redirectByIndex);
+
 	return router;
 };

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -8,28 +8,31 @@ const routeHelpers = require('../helpers');
 const { setupApiRoute } = routeHelpers;
 
 module.exports = function () {
-	const middlewares = [middleware.ensureLoggedIn];
+	const middlewares = [middleware.ensureLoggedIn, middleware.assert.post];
 
-	setupApiRoute(router, 'get', '/:pid', [], controllers.write.posts.get);
+	setupApiRoute(router, 'get', '/:pid', [middleware.assert.post], controllers.write.posts.get);
 	// There is no POST route because you POST to a topic to create a new post. Intuitive, no?
-	setupApiRoute(router, 'put', '/:pid', [...middlewares, middleware.checkRequired.bind(null, ['content'])], controllers.write.posts.edit);
-	setupApiRoute(router, 'delete', '/:pid', [...middlewares, middleware.assert.post], controllers.write.posts.purge);
+	setupApiRoute(router, 'put', '/:pid', [middleware.ensureLoggedIn, middleware.checkRequired.bind(null, ['content'])], controllers.write.posts.edit);
+	setupApiRoute(router, 'delete', '/:pid', middlewares, controllers.write.posts.purge);
 
-	setupApiRoute(router, 'put', '/:pid/state', [...middlewares, middleware.assert.post], controllers.write.posts.restore);
-	setupApiRoute(router, 'delete', '/:pid/state', [...middlewares, middleware.assert.post], controllers.write.posts.delete);
+	setupApiRoute(router, 'get', '/:pid/raw', [middleware.assert.post], controllers.write.posts.getRaw);
+	setupApiRoute(router, 'get', '/:pid/summary', [middleware.assert.post], controllers.write.posts.getSummary);
 
-	setupApiRoute(router, 'put', '/:pid/move', [...middlewares, middleware.assert.post, middleware.checkRequired.bind(null, ['tid'])], controllers.write.posts.move);
+	setupApiRoute(router, 'put', '/:pid/state', middlewares, controllers.write.posts.restore);
+	setupApiRoute(router, 'delete', '/:pid/state', middlewares, controllers.write.posts.delete);
 
-	setupApiRoute(router, 'put', '/:pid/vote', [...middlewares, middleware.checkRequired.bind(null, ['delta']), middleware.assert.post], controllers.write.posts.vote);
-	setupApiRoute(router, 'delete', '/:pid/vote', [...middlewares, middleware.assert.post], controllers.write.posts.unvote);
+	setupApiRoute(router, 'put', '/:pid/move', [...middlewares, middleware.checkRequired.bind(null, ['tid'])], controllers.write.posts.move);
 
-	setupApiRoute(router, 'put', '/:pid/bookmark', [...middlewares, middleware.assert.post], controllers.write.posts.bookmark);
-	setupApiRoute(router, 'delete', '/:pid/bookmark', [...middlewares, middleware.assert.post], controllers.write.posts.unbookmark);
+	setupApiRoute(router, 'put', '/:pid/vote', [...middlewares, middleware.checkRequired.bind(null, ['delta'])], controllers.write.posts.vote);
+	setupApiRoute(router, 'delete', '/:pid/vote', middlewares, controllers.write.posts.unvote);
+
+	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
+	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
 
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
-	setupApiRoute(router, 'put', '/:pid/diffs/:since', [...middlewares, middleware.assert.post], controllers.write.posts.restoreDiff);
-	setupApiRoute(router, 'delete', '/:pid/diffs/:timestamp', [...middlewares, middleware.assert.post], controllers.write.posts.deleteDiff);
+	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);
+	setupApiRoute(router, 'delete', '/:pid/diffs/:timestamp', middlewares, controllers.write.posts.deleteDiff);
 
 	return router;
 };

--- a/src/routes/write/topics.js
+++ b/src/routes/write/topics.js
@@ -44,5 +44,9 @@ module.exports = function () {
 	setupApiRoute(router, 'get', '/:tid/events', [middleware.assert.topic], controllers.write.topics.getEvents);
 	setupApiRoute(router, 'delete', '/:tid/events/:eventId', [middleware.assert.topic], controllers.write.topics.deleteEvent);
 
+	setupApiRoute(router, 'put', '/:tid/read', [...middlewares, middleware.assert.topic], controllers.write.topics.markRead);
+	setupApiRoute(router, 'delete', '/:tid/read', [...middlewares, middleware.assert.topic], controllers.write.topics.markUnread);
+	setupApiRoute(router, 'put', '/:tid/bump', [...middlewares, middleware.assert.topic], controllers.write.topics.bump);
+
 	return router;
 };

--- a/src/socket.io/index.js
+++ b/src/socket.io/index.js
@@ -272,3 +272,13 @@ Sockets.getCountInRoom = function (room) {
 	const roomMap = Sockets.server.sockets.adapter.rooms.get(room);
 	return roomMap ? roomMap.size : 0;
 };
+
+Sockets.warnDeprecated = (socket, replacement) => {
+	if (socket.previousEvents && socket.emit) {
+		socket.emit('event:deprecated_call', {
+			eventName: socket.previousEvents[socket.previousEvents.length - 1],
+			replacement: replacement,
+		});
+	}
+	winston.warn(`[deprecated]\n ${new Error('-').stack.split('\n').slice(2, 5).join('\n')}\n     use ${replacement}`);
+};

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -13,10 +13,19 @@ const notifications = require('../notifications');
 const utils = require('../utils');
 const events = require('../events');
 
+const api = require('../api');
+const sockets = require('.');
+
 const SocketPosts = module.exports;
 
 require('./posts/votes')(SocketPosts);
 require('./posts/tools')(SocketPosts);
+
+SocketPosts.getRawPost = async function (socket, pid) {
+	sockets.warnDeprecated(socket, 'GET /api/v3/posts/:pid/raw');
+
+	return await api.posts.getRaw(socket, { pid });
+};
 
 SocketPosts.getPostSummaryByIndex = async function (socket, data) {
 	if (data.index < 0) {
@@ -63,19 +72,10 @@ SocketPosts.getPostTimestampByIndex = async function (socket, data) {
 };
 
 SocketPosts.getPostSummaryByPid = async function (socket, data) {
-	if (!data || !data.pid) {
-		throw new Error('[[error:invalid-data]]');
-	}
-	const { pid } = data;
-	const tid = await posts.getPostField(pid, 'tid');
-	const topicPrivileges = await privileges.topics.get(tid, socket.uid);
-	if (!topicPrivileges['topics:read']) {
-		throw new Error('[[error:no-privileges]]');
-	}
+	sockets.warnDeprecated(socket, 'GET /api/v3/posts/:pid/summary');
 
-	const postsData = await posts.getPostSummaryByPids([pid], socket.uid, { stripTags: false });
-	posts.modifyPostByPrivilege(postsData[0], topicPrivileges);
-	return postsData[0];
+	const { pid } = data;
+	return await api.posts.getSummary(socket, { pid });
 };
 
 SocketPosts.getCategory = async function (socket, pid) {

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -8,7 +8,6 @@ const privileges = require('../privileges');
 const plugins = require('../plugins');
 const meta = require('../meta');
 const topics = require('../topics');
-const user = require('../user');
 const notifications = require('../notifications');
 const utils = require('../utils');
 const events = require('../events');
@@ -91,21 +90,13 @@ SocketPosts.getPidIndex = async function (socket, data) {
 };
 
 SocketPosts.getReplies = async function (socket, pid) {
+	sockets.warnDeprecated(socket, 'GET /api/v3/posts/:pid/replies');
+
 	if (!utils.isNumber(pid)) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const { topicPostSort } = await user.getSettings(socket.uid);
-	const pids = await posts.getPidsFromSet(`pid:${pid}:replies`, 0, -1, topicPostSort === 'newest_to_oldest');
 
-	let [postData, postPrivileges] = await Promise.all([
-		posts.getPostsByPids(pids, socket.uid),
-		privileges.posts.get(pids, socket.uid),
-	]);
-	postData = await topics.addPostData(postData, socket.uid);
-	postData.forEach((postData, index) => posts.modifyPostByPrivilege(postData, postPrivileges[index]));
-	postData = postData.filter((postData, index) => postData && postPrivileges[index].read);
-	postData = await user.blocks.filter(socket.uid, postData);
-	return postData;
+	return await api.posts.getReplies(socket, { pid });
 };
 
 SocketPosts.accept = async function (socket, data) {

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -28,6 +28,8 @@ SocketPosts.getRawPost = async function (socket, pid) {
 };
 
 SocketPosts.getPostSummaryByIndex = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'GET /api/v3/posts/byIndex/:index/summary?tid=:tid');
+
 	if (data.index < 0) {
 		data.index = 0;
 	}
@@ -42,14 +44,7 @@ SocketPosts.getPostSummaryByIndex = async function (socket, data) {
 		return 0;
 	}
 
-	const topicPrivileges = await privileges.topics.get(data.tid, socket.uid);
-	if (!topicPrivileges['topics:read']) {
-		throw new Error('[[error:no-privileges]]');
-	}
-
-	const postsData = await posts.getPostSummaryByPids([pid], socket.uid, { stripTags: false });
-	posts.modifyPostByPrivilege(postsData[0], topicPrivileges);
-	return postsData[0];
+	return await api.posts.getSummary(socket, { pid });
 };
 
 SocketPosts.getPostTimestampByIndex = async function (socket, data) {
@@ -83,10 +78,16 @@ SocketPosts.getCategory = async function (socket, pid) {
 };
 
 SocketPosts.getPidIndex = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'GET /api/v3/posts/:pid/index');
+
 	if (!data) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	return await posts.getPidIndex(data.pid, data.tid, data.topicPostSort);
+
+	return await api.posts.getIndex(socket, {
+		pid: data.pid,
+		sort: data.topicPostSort,
+	});
 };
 
 SocketPosts.getReplies = async function (socket, pid) {

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -18,21 +18,6 @@ const SocketPosts = module.exports;
 require('./posts/votes')(SocketPosts);
 require('./posts/tools')(SocketPosts);
 
-SocketPosts.getRawPost = async function (socket, pid) {
-	const canRead = await privileges.posts.can('topics:read', pid, socket.uid);
-	if (!canRead) {
-		throw new Error('[[error:no-privileges]]');
-	}
-
-	const postData = await posts.getPostFields(pid, ['content', 'deleted']);
-	if (postData.deleted) {
-		throw new Error('[[error:no-post]]');
-	}
-	postData.pid = pid;
-	const result = await plugins.hooks.fire('filter:post.getRawPost', { uid: socket.uid, postData: postData });
-	return result.postData.content;
-};
-
 SocketPosts.getPostSummaryByIndex = async function (socket, data) {
 	if (data.index < 0) {
 		data.index = 0;

--- a/test/posts.js
+++ b/test/posts.js
@@ -838,37 +838,37 @@ describe('Post\'s', () => {
 			}
 		});
 
-		it('should fail to get raw post because of privilege', (done) => {
-			socketPosts.getRawPost({ uid: 0 }, pid, (err) => {
-				assert.equal(err.message, '[[error:no-privileges]]');
-				done();
-			});
+		it('should fail to get raw post because of privilege', async () => {
+			const content = await apiPosts.getRaw({ uid: 0 }, { pid });
+			assert.strictEqual(content, null);
 		});
 
-		it('should fail to get raw post because post is deleted', (done) => {
-			posts.setPostField(pid, 'deleted', 1, (err) => {
-				assert.ifError(err);
-				socketPosts.getRawPost({ uid: voterUid }, pid, (err) => {
-					assert.equal(err.message, '[[error:no-post]]');
-					done();
-				});
-			});
+		it('should fail to get raw post because post is deleted', async () => {
+			await posts.setPostField(pid, 'deleted', 1);
+			const content = await apiPosts.getRaw({ uid: voterUid }, { pid });
+			assert.strictEqual(content, null);
 		});
 
-		it('should get raw post content', (done) => {
-			posts.setPostField(pid, 'deleted', 0, (err) => {
-				assert.ifError(err);
-				socketPosts.getRawPost({ uid: voterUid }, pid, (err, postContent) => {
-					assert.ifError(err);
-					assert.equal(postContent, 'raw content');
-					done();
-				});
-			});
+		it('should allow privileged users to view the deleted post\'s raw content', async () => {
+			await posts.setPostField(pid, 'deleted', 1);
+			const content = await apiPosts.getRaw({ uid: globalModUid }, { pid });
+			assert.strictEqual(content, 'raw content');
+		});
+
+		it('should get raw post content', async () => {
+			await posts.setPostField(pid, 'deleted', 0);
+			const postContent = await apiPosts.getRaw({ uid: voterUid }, { pid });
+			assert.equal(postContent, 'raw content');
 		});
 
 		it('should get post', async () => {
 			const postData = await apiPosts.get({ uid: voterUid }, { pid });
 			assert(postData);
+		});
+
+		it('shold get post summary', async () => {
+			const summary = await apiPosts.getSummary({ uid: voterUid }, { pid });
+			assert(summary);
 		});
 
 		it('should get post category', (done) => {

--- a/test/posts.js
+++ b/test/posts.js
@@ -879,35 +879,20 @@ describe('Post\'s', () => {
 			});
 		});
 
-		it('should error with invalid data', (done) => {
-			socketPosts.getPidIndex({ uid: voterUid }, null, (err) => {
-				assert.equal(err.message, '[[error:invalid-data]]');
-				done();
-			});
+		it('should get pid index', async () => {
+			const index = await apiPosts.getIndex({ uid: voterUid }, { pid: pid, sort: 'oldest_to_newest' });
+			assert.strictEqual(index, 4);
 		});
 
-		it('should get pid index', (done) => {
-			socketPosts.getPidIndex({ uid: voterUid }, { pid: pid, tid: topicData.tid, topicPostSort: 'oldest_to_newest' }, (err, index) => {
-				assert.ifError(err);
-				assert.equal(index, 4);
-				done();
-			});
-		});
-
-		it('should get pid index in reverse', (done) => {
-			topics.reply({
+		it('should get pid index in reverse', async () => {
+			const postData = await topics.reply({
 				uid: voterUid,
 				tid: topicData.tid,
 				content: 'raw content',
-			}, (err, postData) => {
-				assert.ifError(err);
-
-				socketPosts.getPidIndex({ uid: voterUid }, { pid: postData.pid, tid: topicData.tid, topicPostSort: 'newest_to_oldest' }, (err, index) => {
-					assert.ifError(err);
-					assert.equal(index, 1);
-					done();
-				});
 			});
+
+			const index = await apiPosts.getIndex({ uid: voterUid }, { pid: postData.pid, sort: 'newest_to_oldest' });
+			assert.equal(index, 1);
 		});
 	});
 

--- a/test/topics.js
+++ b/test/topics.js
@@ -1470,29 +1470,18 @@ describe('Topic\'s', () => {
 			});
 		});
 
-		it('should fail with invalid data', (done) => {
-			socketTopics.markUnread({ uid: adminUid }, null, (err) => {
-				assert.equal(err.message, '[[error:invalid-data]]');
-				done();
-			});
+		it('should fail with invalid data', async () => {
+			assert.rejects(apiTopics.markUnread({ uid: adminUid }, null), '[[error:invalid-data]]');
 		});
 
-		it('should fail if topic does not exist', (done) => {
-			socketTopics.markUnread({ uid: adminUid }, 1231082, (err) => {
-				assert.equal(err.message, '[[error:no-topic]]');
-				done();
-			});
+		it('should fail if topic does not exist', async () => {
+			assert.rejects(apiTopics.markUnread({ uid: adminUid }, { tid: 1231082 }), '[[error:no-topic]]');
 		});
 
-		it('should mark topic unread', (done) => {
-			socketTopics.markUnread({ uid: adminUid }, tid, (err) => {
-				assert.ifError(err);
-				topics.hasReadTopic(tid, adminUid, (err, hasRead) => {
-					assert.ifError(err);
-					assert.equal(hasRead, false);
-					done();
-				});
-			});
+		it('should mark topic unread', async () => {
+			await apiTopics.markUnread({ uid: adminUid }, { tid });
+			const hasRead = await topics.hasReadTopic(tid, adminUid);
+			assert.equal(hasRead, false);
 		});
 
 		it('should fail with invalid data', (done) => {
@@ -1566,51 +1555,25 @@ describe('Topic\'s', () => {
 			});
 		});
 
-		it('should fail with invalid data', (done) => {
-			socketTopics.markAsUnreadForAll({ uid: adminUid }, null, (err) => {
-				assert.equal(err.message, '[[error:invalid-tid]]');
-				done();
-			});
+		it('should fail with invalid data', async () => {
+			assert.rejects(apiTopics.bump({ uid: adminUid }, null, '[[error:invalid-tid]]'));
 		});
 
-		it('should fail with invalid data', (done) => {
-			socketTopics.markAsUnreadForAll({ uid: 0 }, [tid], (err) => {
-				assert.equal(err.message, '[[error:no-privileges]]');
-				done();
-			});
+		it('should fail with invalid data', async () => {
+			assert.rejects(apiTopics.bump({ uid: 0 }, { tid: [tid] }, '[[error:no-privileges]]'));
 		});
 
-		it('should fail if user is not admin', (done) => {
-			socketTopics.markAsUnreadForAll({ uid: uid }, [tid], (err) => {
-				assert.equal(err.message, '[[error:no-privileges]]');
-				done();
-			});
+		it('should fail if user is not admin', async () => {
+			assert.rejects(apiTopics.bump({ uid: uid }, { tid }, '[[error:no-privileges]]'));
 		});
 
-		it('should fail if topic does not exist', (done) => {
-			socketTopics.markAsUnreadForAll({ uid: uid }, [12312313], (err) => {
-				assert.equal(err.message, '[[error:no-topic]]');
-				done();
-			});
-		});
+		it('should mark topic unread for everyone', async () => {
+			await apiTopics.bump({ uid: adminUid }, { tid });
+			const adminRead = await topics.hasReadTopic(tid, adminUid);
+			const regularRead = await topics.hasReadTopic(tid, uid);
 
-		it('should mark topic unread for everyone', (done) => {
-			socketTopics.markAsUnreadForAll({ uid: adminUid }, [tid], (err) => {
-				assert.ifError(err);
-				async.parallel({
-					adminRead: function (next) {
-						topics.hasReadTopic(tid, adminUid, next);
-					},
-					regularRead: function (next) {
-						topics.hasReadTopic(tid, uid, next);
-					},
-				}, (err, results) => {
-					assert.ifError(err);
-					assert.equal(results.adminRead, false);
-					assert.equal(results.regularRead, false);
-					done();
-				});
-			});
+			assert.equal(adminRead, false);
+			assert.equal(regularRead, false);
 		});
 
 		it('should not do anything if tids is empty array', (done) => {


### PR DESCRIPTION
The following socket calls have been *deprecated*:

* `posts.getRawPost`
* `posts.getPostSummaryByIndex`
* `posts.getPostSummaryByPid`
* `posts.getPidIndex`
* `topics.markAsRead`
* `topics.markUnread`
* `topics.markAsUnreadForAll`

These new Write API routes have been added:

- `GET /api/v3/posts/:pid/raw`
- `GET /api/v3/posts/:pid/summary`
- `GET /api/v3/posts/:pid/index` (takes optional `sort` query parameter)
- `ALL /api/v3/posts/byIndex/:index` (takes required `tid` query or request body parameter)
- `PUT/DELETE /api/v3/topics/:tid/read`
- `PUT /api/v3/topics/:tid/bump` (privileged only)