### PR TITLE
ci: multi-platform docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,4 +54,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x,linux/riscv64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,4 +54,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,3 +55,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,3 +54,4 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le,linux/s390x,linux/riscv64

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/build
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
-COPY --chown=node:node install/package.json /usr/src/app/package.json
+COPY --chown=node:node install/package.json /usr/src/build/package.json
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM --platform=$BUILDPLATFORM node:lts as npm
 
 RUN mkdir -p /usr/src/app && \
     chown -R node:node /usr/src/app
@@ -11,8 +11,22 @@ COPY --chown=node:node install/package.json /usr/src/app/package.json
 
 USER node
 
-RUN npm install --omit=dev && \
-    npm cache clean --force
+RUN npm install --omit=dev
+
+
+FROM node:lts
+
+RUN mkdir -p /usr/src/app && \
+    chown -R node:node /usr/src/app
+WORKDIR /usr/src/app
+
+ARG NODE_ENV
+ENV NODE_ENV $NODE_ENV
+
+COPY --chown=node:node --from=npm /usr/src/app /usr/src/app
+
+USER node
+
 
 COPY --chown=node:node . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY --chown=node:node install/package.json /usr/src/app/package.json
 
 USER node
 
-RUN npm install --only=prod && \
+RUN npm install --omit=dev && \
     npm cache clean --force
 
 COPY --chown=node:node . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
-RUN npm rebuild && \
-    npm cache clean --force
+RUN if [ "$TARGETPLATFORM" != "$BUILDPLATFORM"]; then \ 
+    npm install --omit=dev && \
+    npm rebuild && \
+    npm cache clean --force; fi
 
 COPY --chown=node:node --from=npm /usr/src/app /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM --platform=$BUILDPLATFORM node:lts as npm
 
-RUN mkdir -p /usr/src/app && \
-    chown -R node:node /usr/src/app
-WORKDIR /usr/src/app
+RUN mkdir -p /usr/src/build && \
+    chown -R node:node /usr/src/build
+WORKDIR /usr/src/build
 
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
@@ -23,13 +23,12 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
-COPY --chown=node:node --from=npm /usr/src/app /usr/src/app
+COPY --chown=node:node --from=npm /usr/src/build /usr/src/app
 
 USER node
 
-RUN if [ "$TARGETPLATFORM" != "$BUILDPLATFORM" ]; then \ 
-    npm rebuild && \
-    npm cache clean --force; fi
+RUN npm rebuild && \
+    npm cache clean --force
 
 COPY --chown=node:node . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER node
 RUN npm install --omit=dev
 
 
-FROM node:lts
+FROM --platform=$TARGETPLATFORM node:lts
 
 RUN mkdir -p /usr/src/app && \
     chown -R node:node /usr/src/app
@@ -23,15 +23,13 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
-RUN if [ "$TARGETPLATFORM" != "$BUILDPLATFORM" ]; then \ 
-    npm install --omit=dev && \
-    npm rebuild && \
-    npm cache clean --force; fi
-
 COPY --chown=node:node --from=npm /usr/src/app /usr/src/app
 
 USER node
 
+RUN if [ "$TARGETPLATFORM" != "$BUILDPLATFORM" ]; then \ 
+    npm rebuild && \
+    npm cache clean --force; fi
 
 COPY --chown=node:node . /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
-RUN if [ "$TARGETPLATFORM" != "$BUILDPLATFORM"]; then \ 
+RUN if [ "$TARGETPLATFORM" != "$BUILDPLATFORM" ]; then \ 
     npm install --omit=dev && \
     npm rebuild && \
     npm cache clean --force; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER node
 RUN npm install --omit=dev
 
 
-FROM --platform=$TARGETPLATFORM node:lts
+FROM node:lts
 
 RUN mkdir -p /usr/src/app && \
     chown -R node:node /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
+RUN npm rebuild && \
+    npm cache clean --force
+
 COPY --chown=node:node --from=npm /usr/src/app /usr/src/app
 
 USER node


### PR DESCRIPTION
The goal of this PR is to expand the platforms supported by the pre-built docker image to include arm platforms supported by node (arm/v7 and arm64/v8).

This allows usage on e.g. SBCs (Raspberry Pies, etc.) or ARM servers which are becoming more common across clouds.

Note that currently building the image yourself there (or via docker-compose) worked - it's just the published images that were amd64 only.

The workflow already set up QEMU, but didn't specify platforms to build for resulting in amd64-only images.
Unfortunately, builds with QEMU are really slow - the workflow was taking literally 30 minutes to run. To resolve this I also added build caching and modified the docker image to a two-stage image where the first stage is running on the build platform and installing npm packages and the second on the target platform (and using `npm rebuild` to ensure binary packages are compiled correctly).

This increases amd64 build time, but in Actions it's only by around 15-20 seconds (from ~1:30 to ~1:50), which I don't think is a big deal.

The total multi-arch build time increased to around 8 minutes, which I think is decently reasonable (and thanks to the cache a build without dependency updates takes slightly less time than current builds).

Also, while technically the `node` image supports x390 and ppc64le, not only are these architectures not nearly as popular as arm, but I've also had some issues with installing packages for npm there, because sharp doesn't provide prebuilt binaries for them (at least x390)