### PR TITLE
docs: fix openapi spec to include fullname and displayname where necessary

### DIFF
--- a/public/openapi/components/schemas/UserObject.yaml
+++ b/public/openapi/components/schemas/UserObject.yaml
@@ -546,10 +546,6 @@ UserObjectSlim:
       type: string
       description: A friendly name for a given user account
       example: Dragon Fruit
-    displayname:
-      type: string
-      description: This is either username or fullname depending on forum and user settings
-      example: Dragon Fruit
     userslug:
       type: string
       description: An URL-safe variant of the username (i.e. lower-cased, spaces removed, etc.)
@@ -598,6 +594,14 @@ UserObjectSlim:
       type: number
       description: A UNIX timestamp representing the moment the user's account was created
       example: 1585337827953
+    fullname:
+      type: string
+      example: Mr. Dragon Fruit Jr.
+      nullable: true
+    displayname:
+      type: string
+      description: This is either username or fullname depending on forum and user settings
+      example: Dragon Fruit
     'icon:text':
       type: string
       description: A single-letter representation of a username. This is used in the auto-generated icon given to users without an avatar
@@ -630,10 +634,6 @@ UserObjectACP:
     username:
       type: string
       description: A friendly name for a given user account
-      example: Dragon Fruit
-    displayname:
-      type: string
-      description: This is either username or fullname depending on forum and user settings
       example: Dragon Fruit
     userslug:
       type: string
@@ -675,6 +675,14 @@ UserObjectACP:
       type: number
       description: Whether the user has confirmed their email address or not
       example: 1
+    fullname:
+      type: string
+      example: Mr. Dragon Fruit Jr.
+      nullable: true
+    displayname:
+      type: string
+      description: This is either username or fullname depending on forum and user settings
+      example: Dragon Fruit
     'icon:text':
       type: string
       description: A single-letter representation of a username. This is used in the auto-generated icon given to users without an avatar

--- a/public/openapi/read/users.yaml
+++ b/public/openapi/read/users.yaml
@@ -38,9 +38,6 @@ get:
                         username:
                           type: string
                           description: A friendly name for a given user account
-                        displayname:
-                          type: string
-                          description: This is either username or fullname depending on forum and user settings
                         userslug:
                           type: string
                           description: An URL-safe variant of the username (i.e. lower-cased, spaces
@@ -69,6 +66,14 @@ get:
                           type: number
                           description: A UNIX timestamp representing the moment the user's account was
                             created
+                        fullname:
+                          type: string
+                          example: Mr. Dragon Fruit Jr.
+                          nullable: true
+                        displayname:
+                          type: string
+                          description: This is either username or fullname depending on forum and user settings
+                          example: Dragon Fruit
                         icon:text:
                           type: string
                           description: A single-letter representation of a username. This is used in the


### PR DESCRIPTION
I am not certain when this mismatch started, why it happened, or why our tests did not catch it, because tests currently pass on `develop` branch.

However they do not pass on my local machine, and these changes fix it. Let's see if it blows up tests via our github ci pipeline...
