### PR TITLE
feat: autoinstall plugins on setup

### DIFF
--- a/src/controllers/admin/plugins.js
+++ b/src/controllers/admin/plugins.js
@@ -15,8 +15,8 @@ pluginsController.get = async function (req, res) {
 	]);
 
 	const compatiblePkgNames = compatible.map(pkgData => pkgData.name);
-	const installedPlugins = compatible.filter(plugin => plugin && plugin.installed);
-	const activePlugins = all.filter(plugin => plugin && plugin.installed && plugin.active);
+	const installedPlugins = compatible.filter(plugin => plugin && (plugin.installed || (nconf.get('plugins:active') && plugin.active)));
+	const activePlugins = all.filter(plugin => plugin && (plugin.installed || nconf.get('plugins:active')) && plugin.active);
 
 	const trendingScores = trending.reduce((memo, cur) => {
 		memo[cur.label] = cur.value;

--- a/src/install.js
+++ b/src/install.js
@@ -9,6 +9,7 @@ const nconf = require('nconf');
 const _ = require('lodash');
 
 const utils = require('./utils');
+const { paths } = require('./constants');
 
 const install = module.exports;
 const questions = {};
@@ -563,6 +564,16 @@ async function checkUpgrade() {
 	}
 }
 
+async function installPlugins() {
+	const pluginInstall = require('./plugins');
+	const nbbVersion = require(paths.currentPackage).version;
+	await Promise.all((await pluginInstall.getActive()).map(async (id) => {
+		if (await pluginInstall.isInstalled(id)) return;
+		const version = await pluginInstall.suggest(id, nbbVersion);
+		await pluginInstall.toggleInstall(id, version.version);
+	}));
+}
+
 install.setup = async function () {
 	try {
 		checkSetupFlagEnv();
@@ -580,6 +591,7 @@ install.setup = async function () {
 		await enableDefaultPlugins();
 		await setCopyrightWidget();
 		await copyFavicon();
+		if (nconf.get('plugins:autoinstall')) await installPlugins();
 		await checkUpgrade();
 
 		const data = {

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -234,6 +234,13 @@ Plugins.normalise = async function (apiReturn) {
 		pluginMap[plugin.id].outdated = semver.gt(pluginMap[plugin.id].latest, pluginMap[plugin.id].version);
 	});
 
+	if (nconf.get('plugins:active')) {
+		nconf.get('plugins:active').forEach((id) => {
+			pluginMap[id] = pluginMap[id] || {};
+			pluginMap[id].active = true;
+		});
+	}
+
 	const pluginArray = Object.values(pluginMap);
 
 	pluginArray.sort((a, b) => {

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -109,7 +109,7 @@ module.exports = function (Plugins) {
 			Plugins.isActive(id),
 		]);
 		const type = installed ? 'uninstall' : 'install';
-		if (active) {
+		if (active && !nconf.get('plugins:active')) {
 			await Plugins.toggleActive(id);
 		}
 		await runPackageManagerCommandAsync(type, id, version || 'latest');
@@ -121,7 +121,7 @@ module.exports = function (Plugins) {
 	function runPackageManagerCommand(command, pkgName, version, callback) {
 		cproc.execFile(packageManagerExecutable, [
 			packageManagerCommands[packageManager][command],
-			pkgName + (command === 'install' ? `@${version}` : ''),
+			pkgName + (command === 'install' && version ? `@${version}` : ''),
 			'--save',
 		], (err, stdout) => {
 			if (err) {


### PR DESCRIPTION
related to #10766, #10767 and #10036

Adds a `plugins:autoinstall` config option that installs all active, but not yet installed plugins on setup.

Intended to be primarily used with `plugins:active`, but it doesn't require it.

Note that it will fail setup if a plugin can't be installed - this is intended (but if you believe it's better to fail quietly I can change that).

Additionally there is a small `plugins:active` specific change to the admin page allowing for installing/uninstalling active plugins set via config without them disappearing from the active page (primarily to handle the case of not using autoinstall - since the admin will then be able to simply install everything active from the ACP)