### PR TITLE
fix: go back to post queue after deleting an account in post queue

### DIFF
--- a/public/src/client/post-queue.js
+++ b/public/src/client/post-queue.js
@@ -138,15 +138,15 @@ define('forum/post-queue', [
 							break;
 
 						case 'delete-account':
-							AccountsDelete.account(uid, ajaxify.refresh);
+							AccountsDelete.account(uid, ajaxify.go.bind(null, 'post-queue'));
 							break;
 
 						case 'delete-content':
-							AccountsDelete.content(uid, ajaxify.refresh);
+							AccountsDelete.content(uid, ajaxify.go.bind(null, 'post-queue'));
 							break;
 
 						case 'delete-all':
-							AccountsDelete.purge(uid, ajaxify.refresh);
+							AccountsDelete.purge(uid, ajaxify.go.bind(null, 'post-queue'));
 							break;
 
 						default:


### PR DESCRIPTION
It makes little sense to refresh the page as the content no longer exists, so just go back to the post queue list.
