### PR TITLE
fix: update openapi spec to specify optional `expiry` argument available to be passed in via request body.

### DIFF
--- a/public/openapi/write/topics/tid/pin.yaml
+++ b/public/openapi/write/topics/tid/pin.yaml
@@ -11,6 +11,17 @@ put:
       required: true
       description: a valid topic id
       example: 1
+  requestBody:
+    required: false
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            expiry:
+              type: number
+              description: A UNIX timestamp representing the moment the topic will be unpinned.
+              example: 1585337827953
   responses:
     '200':
       description: Topic successfully pinned

--- a/test/api.js
+++ b/test/api.js
@@ -447,7 +447,10 @@ describe('API', async () => {
 
 					let body = {};
 					let type = 'json';
-					if (context[method].hasOwnProperty('requestBody') && context[method].requestBody.content['application/json']) {
+					if (
+						context[method].hasOwnProperty('requestBody') &&
+						context[method].requestBody.required !== false &&
+						context[method].requestBody.content['application/json']) {
 						body = buildBody(context[method].requestBody.content['application/json'].schema.properties);
 					} else if (context[method].hasOwnProperty('requestBody') && context[method].requestBody.content['multipart/form-data']) {
 						type = 'form';


### PR DESCRIPTION
Also updated test runner to ignore any request bodies in spec that are explicitly not required.
