### PR TITLE
fix: add an additional check on page load to enforce `requireEmailAddress` setting

### DIFF
--- a/public/language/en-GB/user.json
+++ b/public/language/en-GB/user.json
@@ -223,5 +223,6 @@
 	"emailUpdate.optional": "<strong>This field is optional</strong>. You are not obligated to provide your email address, but without a validated email you will not be able to recover your account or login with your email.",
 	"emailUpdate.required": "<strong>This field is required</strong>.",
 	"emailUpdate.change-instructions": "A confirmation email will be sent to the entered email address with a unique link. Accessing that link will confirm your ownership of the email address and it will become active on your account. At any time, you are able to update your email on file from within your account page.",
-	"emailUpdate.password-challenge": "Please enter your password in order to verify account ownership."
+	"emailUpdate.password-challenge": "Please enter your password in order to verify account ownership.",
+	"emailUpdate.pending": "Your email address has not yet been confirmed, but an email has been sent out requesting confirmation. If you wish to invalidate that request and send a new confirmation request, please fill in the form below."
 }

--- a/src/user/interstitials.js
+++ b/src/user/interstitials.js
@@ -28,9 +28,10 @@ Interstitials.email = async (data) => {
 		return data;
 	}
 
-	const [isAdminOrGlobalMod, hasPassword] = await Promise.all([
+	const [isAdminOrGlobalMod, hasPassword, hasPending] = await Promise.all([
 		user.isAdminOrGlobalMod(data.req.uid),
 		user.hasPassword(data.userData.uid),
+		user.email.isValidationPending(data.userData.uid),
 	]);
 
 	let email;
@@ -44,6 +45,7 @@ Interstitials.email = async (data) => {
 			email,
 			requireEmailAddress: meta.config.requireEmailAddress,
 			issuePasswordChallenge: !!data.userData.uid && hasPassword,
+			hasPending,
 		},
 		callback: async (userData, formData) => {
 			// Validate and send email confirmation

--- a/src/views/partials/email_update.tpl
+++ b/src/views/partials/email_update.tpl
@@ -1,4 +1,9 @@
 <div>
+	{{{ if hasPending }}}
+	<div class="alert alert-info">
+		<p>[[user:emailUpdate.pending]]</p>
+	</div>
+	{{{ end }}}
 	<p>[[user:emailUpdate.intro]]</p>
 	{{{ if requireEmailAddress }}}
 	<p>[[user:emailUpdate.required]]</p>

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -415,20 +415,28 @@ describe('Controllers', () => {
 
 			it('should throw error if email is not valid', async () => {
 				const uid = await user.create({ username: 'interstiuser1' });
-				try {
-					const result = await user.interstitials.email({
-						userData: { uid: uid, updateEmail: true },
-						req: { uid: uid },
-						interstitials: [],
-					});
-					assert.strictEqual(result.interstitials[0].template, 'partials/email_update');
-					await result.interstitials[0].callback({ uid }, {
-						email: 'invalidEmail',
-					});
-					assert(false);
-				} catch (err) {
-					assert.strictEqual(err.message, '[[error:invalid-email]]');
-				}
+				const result = await user.interstitials.email({
+					userData: { uid: uid, updateEmail: true },
+					req: { uid: uid },
+					interstitials: [],
+				});
+				assert.strictEqual(result.interstitials[0].template, 'partials/email_update');
+				assert.rejects(result.interstitials[0].callback({ uid }, {
+					email: 'invalidEmail',
+				}), { message: '[[error:invalid-email]]' });
+			});
+
+			it('should reject an email that comprises only whitespace', async () => {
+				const uid = await user.create({ username: utils.generateUUID().slice(0, 10) });
+				const result = await user.interstitials.email({
+					userData: { uid: uid, updateEmail: true },
+					req: { uid: uid },
+					interstitials: [],
+				});
+				assert.strictEqual(result.interstitials[0].template, 'partials/email_update');
+				assert.rejects(result.interstitials[0].callback({ uid }, {
+					email: '    ',
+				}), { message: '[[error:invalid-email]]' });
 			});
 
 			it('should set req.session.emailChanged to 1', async () => {
@@ -564,6 +572,56 @@ describe('Controllers', () => {
 				const userData = await user.getUserData(uid);
 				assert.strictEqual(userData.email, `${username}@nodebb.com`);
 				assert.strictEqual(userData['email:confirmed'], 1);
+			});
+
+			describe('blocking access for unconfirmed emails', () => {
+				let jar;
+				let token;
+
+				before(async () => {
+					jar = await helpers.registerUser({
+						username: utils.generateUUID().slice(0, 10),
+						password: utils.generateUUID(),
+					});
+					token = await helpers.getCsrfToken(jar);
+				});
+
+				it('should not apply if requireEmailAddress is not enabled', async () => {
+					meta.config.requireEmailAddress = 0;
+
+					const res = await requestAsync(`${nconf.get('url')}/register/complete`, {
+						method: 'post',
+						jar,
+						json: true,
+						followRedirect: false,
+						simple: false,
+						resolveWithFullResponse: true,
+						headers: {
+							'x-csrf-token': token,
+						},
+						form: {
+							email: `${utils.generateUUID().slice(0, 10)}@example.org`,
+							gdpr_agree_data: 'on',
+							gdpr_agree_email: 'on',
+						},
+					});
+
+					assert.strictEqual(res.headers.location, `${nconf.get('relative_path')}/`);
+					meta.config.requireEmailAddress = 1;
+				});
+
+				it('should continue to redirect back to interstitial after an email is entered, as it is not confirmed', async () => {
+					const res = await requestAsync(`${nconf.get('url')}/recent`, {
+						jar,
+						json: true,
+						resolveWithFullResponse: true,
+						followRedirect: false,
+						simple: false,
+					});
+
+					assert.strictEqual(res.statusCode, 307);
+					assert.strictEqual(res.headers.location, `${nconf.get('relative_path')}/me/edit/email`);
+				});
 			});
 		});
 


### PR DESCRIPTION
The old behaviour would require that an email be entered, but did not block access to the forum (nor did it ensure that the email was verified).

The new behaviour (if the setting is enabled) will ensure that only those users with a confirmed email can continue through.

The only exceptions are super admins (so they don't get locked out).
