### PR TITLE
ci: only publish latest docker tag from master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,7 +45,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.x
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker images


### PR DESCRIPTION
`latest` tag is currently v2. That happened because of the backported change which is newer than any commits to `master`.

However, this logically shouldn't happen. The expectation for latest would be that it has the, well, the code from the highest version released, not literally the latest commit no matter where it came from. Thankfully metadata action allows for conditional tags and even has a helper for default branch making it not hard-coded (so if NodeBB decided to migrate to `main` or someone in their fork did it'd still work).

The result would be that `latest` tag is the latest code in `master`, which I see as similar to the default git workflow (`master` is just latest code, `vX.Y` branches or tags are for using proper releases).