### PR TITLE
ci: use GitHub Actions expression instead of handlebars template

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.x
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch,enable={{#if is_default_branch}}false{{else}}true{{/if}}
+            type=ref,event=branch,enable=${{ github.event.repository.default_branch != github.ref }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v4


### PR DESCRIPTION
Apparently Docker Meta Actions overrides, not merely adds, handlebars helpers. So `#if` just doesn't exist and errors out...

As such here is an equivalent using GitHub Actions expression (and this time I tested that it works...)