### PR TITLE
feat: middleware.handleMultipart, applies on API routes — invokes multipart middleware based on content-type header

### DIFF
--- a/public/src/modules/api.js
+++ b/public/src/modules/api.js
@@ -65,7 +65,8 @@ async function xhr(options, cb) {
 
 	const res = await fetch(url, options);
 	const { headers } = res;
-	const isJSON = headers.get('content-type').startsWith('application/json');
+	const contentType = headers.get('content-type');
+	const isJSON = contentType && contentType.startsWith('application/json');
 
 	let response;
 	if (isJSON) {

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -6,6 +6,7 @@ const validator = require('validator');
 const nconf = require('nconf');
 const toobusy = require('toobusy-js');
 const util = require('util');
+const multipart = require('connect-multiparty');
 const { csrfSynchronisedProtection } = require('./csrf');
 
 const plugins = require('../plugins');
@@ -27,6 +28,7 @@ const delayCache = cacheCreate({
 	ttl: 1000 * 60,
 	max: 200,
 });
+const multipartMiddleware = multipart();
 
 const middleware = module.exports;
 
@@ -283,4 +285,15 @@ middleware.checkRequired = function (fields, req, res, next) {
 	}
 
 	controllers.helpers.formatApiResponse(400, res, new Error(`[[error:required-parameters-missing, ${missing.join(' ')}]]`));
+};
+
+middleware.handleMultipart = (req, res, next) => {
+	// Applies multipart handler on applicable content-type
+	const { 'content-type': contentType } = req.headers;
+
+	if (contentType && !contentType.startsWith('multipart/form-data')) {
+		return next();
+	}
+
+	multipartMiddleware(req, res, next);
 };

--- a/src/routes/helpers.js
+++ b/src/routes/helpers.js
@@ -58,6 +58,7 @@ helpers.setupApiRoute = function (...args) {
 		middleware.registrationComplete,
 		middleware.pluginHooks,
 		middleware.logApiUsage,
+		middleware.handleMultipart,
 		...middlewares,
 	];
 


### PR DESCRIPTION
Rationale:

Currently one way form data (i.e. from ACP page) is saved is by using settings module, which takes form data and normalizes it for sending via JSON.

It ought to be easier:

``` js
import { post } from 'api';

const formEl = document.querySelector('#content form');
post('/plugins/myRoute', new FormData(formEl));
```

**However**, this submits the form with content-type `multipart/form-data` (which is what it is.) Current routes when set up via `setupApiRoute` do not have any middleware that parses this content-type.

The current workaround is to *not use the controller helper* and attach `.post()` (or similar) directly onto the router, which is perfectly fine, but misses out on necessary middlewares unless you explicitly also add them in.

This PR fixes that case.

----

Side benefit is support for form uploads. The way uploads are handled in NodeBB right now are downright scary. This will provide a path for refactoring those uploads at a later date.

----

This currently does not touch any existing invocations of the `connect-multiparty` dependency. It may in the future.