### PR TITLE
feat: password check hook

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -102,6 +102,8 @@ authenticationController.register = async function (req, res) {
 
 		user.isPasswordValid(userData.password);
 
+		await plugins.hooks.fire('filter:password.check', { password: userData.password, uid: 0, username: userData.username, currentPassword: null });
+
 		res.locals.processLogin = true; // set it to false in plugin if you wish to just register only
 		await plugins.hooks.fire('filter:register.check', { req: req, res: res, userData: userData });
 

--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -102,7 +102,7 @@ authenticationController.register = async function (req, res) {
 
 		user.isPasswordValid(userData.password);
 
-		await plugins.hooks.fire('filter:password.check', { password: userData.password, uid: 0, username: userData.username, currentPassword: null });
+		await plugins.hooks.fire('filter:password.check', { password: userData.password, uid: 0, userData: userData });
 
 		res.locals.processLogin = true; // set it to false in plugin if you wish to just register only
 		await plugins.hooks.fire('filter:register.check', { req: req, res: res, userData: userData });

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -295,10 +295,9 @@ module.exports = function (User) {
 			throw new Error('[[error:invalid-uid]]');
 		}
 		User.isPasswordValid(data.newPassword);
-		const [isAdmin, hasPassword, username] = await Promise.all([
+		const [isAdmin, hasPassword] = await Promise.all([
 			User.isAdministrator(uid),
 			User.hasPassword(uid),
-			User.getUserField(uid, 'username'),
 		]);
 
 		if (meta.config['password:disableEdit'] && !isAdmin) {
@@ -311,7 +310,7 @@ module.exports = function (User) {
 			throw new Error('[[user:change_password_error_privileges]]');
 		}
 
-		await plugins.hooks.fire('filter:password.check', { password: data.newPassword, uid, username, currentPassword: data.currentPassword });
+		await plugins.hooks.fire('filter:password.check', { password: data.newPassword, uid: data.uid });
 
 		if (isSelf && hasPassword) {
 			const correct = await User.isPasswordCorrect(data.uid, data.currentPassword, data.ip);

--- a/src/user/reset.js
+++ b/src/user/reset.js
@@ -96,7 +96,7 @@ UserReset.commit = async function (code, password) {
 		['password', 'passwordExpiry', 'password:shaWrapped', 'username']
 	);
 
-	await plugins.hooks.fire('filter:password.check', { password: password, uid, username: userData.username, currentPassword: userData.password });
+	await plugins.hooks.fire('filter:password.check', { password: password, uid });
 
 	const ok = await Password.compare(password, userData.password, !!parseInt(userData['password:shaWrapped'], 10));
 	if (ok) {

--- a/src/user/reset.js
+++ b/src/user/reset.js
@@ -12,6 +12,7 @@ const db = require('../database');
 const meta = require('../meta');
 const emailer = require('../emailer');
 const Password = require('../password');
+const plugins = require('../plugins');
 
 const UserReset = module.exports;
 
@@ -92,8 +93,11 @@ UserReset.commit = async function (code, password) {
 	}
 	const userData = await db.getObjectFields(
 		`user:${uid}`,
-		['password', 'passwordExpiry', 'password:shaWrapped']
+		['password', 'passwordExpiry', 'password:shaWrapped', 'username']
 	);
+
+	await plugins.hooks.fire('filter:password.check', { password: password, uid, username: userData.username, currentPassword: userData.password });
+
 	const ok = await Password.compare(password, userData.password, !!parseInt(userData['password:shaWrapped'], 10));
 	if (ok) {
 		throw new Error('[[error:reset-same-password]]');


### PR DESCRIPTION
Unusual Discord reference: https://discord.com/channels/1038154494678151239/1038154495131123774/1133784963347656774

Hopefully includes all and only relevant information that might be useful to plugins - uid and username are included for plugins which might want to make additional checks relating to them (e.g. some lookup by username). Both are included since at time of registration `uid` is not yet known and would be useless.

Additionally, `uid` set to 0 allows to differentiate between registration and password change/reset, though for most cases that probably won't be necessary.

I'm not sure if I should also add the email to this hook, since it can be null even for existing users - it should be simple enough to add though.

Also, I think I got all places where password validation happens on the server (registration, change, reset), but please let me know if I missed something (e.g. some API method or something).