### PR TITLE
fix: copy FA fonts to build directory instead of serving them directly

### DIFF
--- a/public/scss/fontawesome/loader.scss
+++ b/public/scss/fontawesome/loader.scss
@@ -1,4 +1,4 @@
-$fa-font-path: "./vendor/fontawesome/webfonts";
+$fa-font-path: "./fontawesome/webfonts";
 @import "fontawesome";
 @import "v4-shims";
 @import "nodebb-shims";

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,7 +9,6 @@ const meta = require('../meta');
 const controllers = require('../controllers');
 const controllerHelpers = require('../controllers/helpers');
 const plugins = require('../plugins');
-const utils = require('../utils');
 
 const authRoutes = require('./authentication');
 const writeRoutes = require('./write');
@@ -173,7 +172,6 @@ function addCoreRoutes(app, router, middleware, mounts) {
 	const statics = [
 		{ route: '/assets', path: path.join(__dirname, '../../build/public') },
 		{ route: '/assets', path: path.join(__dirname, '../../public') },
-		{ route: '/assets/vendor/fontawesome/webfonts', path: path.join(utils.getFontawesomePath(), 'webfonts') },
 	];
 	const staticOptions = {
 		maxAge: app.enabled('cache') ? 5184000000 : 0,


### PR DESCRIPTION


Serving fonts directly from NodeBB works fine, but if the user set up a proxy to serve files directly that doesn't have a fallback to NodeBB itself (e.g. following the sample Caddy configuration from NodeBB documentation) the fonts paths led to nonexistent files.

This PR makes the CSS build step copy these fonts to build/public/fontawesome/webfonts. The performance impact appears to be negligible in my (fairly basic) testing.

Note that since the files are not vendored anymore I removed vendor from the path. This happened across NodeBB, including the SCSS font path variable, so unless someone relied on a hard-coded path for some reason that eludes me, this shouldn't be breaking in any way (I honestly don't see a use case and would consider these font files as internal, and not public API - especially now with npm and pro support making it possible for them to change in a dependency update). If retaining current paths is preferred I can obviously restore them.