### PR TITLE
Remove chat notification queue, re-implement for email notifications only

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -22,7 +22,7 @@
     "chatDeleteDuration": 0,
     "chatMessageDelay": 2000,
     "newbieChatMessageDelay": 120000,
-    "notificationSendDelay": 10,
+    "notificationSendDelay": 60,
     "newbiePostDelayThreshold": 3,
     "postQueue": 0,
     "postQueueReputationThreshold": 0,

--- a/public/language/en-GB/email.json
+++ b/public/language/en-GB/email.json
@@ -45,7 +45,7 @@
 	"digest.title.week": "Your Weekly Digest",
 	"digest.title.month": "Your Monthly Digest",
 
-	"notif.chat.subject": "New chat message received from %1",
+	"notif.chat.subject": "New chat message received in \"%1\"",
 	"notif.chat.public-chat-subject": "New message from %1 in room %2",
 	"notif.chat.cta": "Click here to continue the conversation",
 	"notif.chat.unsub.info": "This chat notification was sent to you due to your subscription settings.",

--- a/public/language/en-GB/notifications.json
+++ b/public/language/en-GB/notifications.json
@@ -26,6 +26,9 @@
 
 
 	"new_message_from": "New message from <strong>%1</strong>",
+	"new_messages_from": "%1 new messages from <strong>%2</strong>",
+	"new_message_in": "New message in <strong>%1</strong>",
+	"new_messages_in": "%1 new messages in <strong>%2</strong>",
 	"user_posted_in_public_room": "<strong>%1</strong> wrote in <strong class=\"text-nowrap\"><i class=\"fa %2\"></i>%3</strong>",
 	"user_posted_in_public_room_dual": "<strong>%1</strong> and <strong>%2</strong> wrote in <strong class=\"text-nowrap\"><i class=\"fa %3\"></i>%4</strong>",
 	"user_posted_in_public_room_triple": "<strong>%1</strong>, <strong>%2</strong> and <strong>%3</strong> wrote in <strong class=\"text-nowrap\"><i class=\"fa %4\"></i>%5</strong>",

--- a/src/cache/ttl.js
+++ b/src/cache/ttl.js
@@ -30,6 +30,14 @@ module.exports = function (opts) {
 		});
 	});
 
+	cache.has = (key) => {
+		if (!cache.enabled) {
+			return false;
+		}
+
+		return ttlCache.has(key);
+	};
+
 	cache.set = function (key, value, ttl) {
 		if (!cache.enabled) {
 			return;

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -201,7 +201,7 @@ Messaging.getRecentChats = async (callerUid, uid, start, stop) => {
 	await Promise.all(results.roomData.map(async (room, index) => {
 		if (room) {
 			room.users = results.users[index];
-			room.groupChat = room.hasOwnProperty('groupChat') ? room.groupChat : room.users.length > 2;
+			room.groupChat = room.users.length > 2;
 			room.unread = results.unread[index];
 			room.teaser = results.teasers[index];
 

--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -8,12 +8,8 @@ const notifications = require('../notifications');
 const user = require('../user');
 const io = require('../socket.io');
 const plugins = require('../plugins');
-const meta = require('../meta');
 
 module.exports = function (Messaging) {
-	// Only used to notify a user of a new chat message
-	Messaging.notifyQueue = {};
-
 	Messaging.setUserNotificationSetting = async (uid, roomId, value) => {
 		if (parseInt(value, 10) === -1) {
 			// go back to default
@@ -73,26 +69,11 @@ module.exports = function (Messaging) {
 			Messaging.pushUnreadCount(uids, unreadData);
 		}
 
-		// Delayed notifications
-		let queueObj = Messaging.notifyQueue[`${fromUid}:${roomId}`];
-		if (queueObj) {
-			queueObj.message.content += `\n${messageObj.content}`;
-			clearTimeout(queueObj.timeout);
-		} else {
-			queueObj = {
-				message: messageObj,
-			};
-			Messaging.notifyQueue[`${fromUid}:${roomId}`] = queueObj;
+		try {
+			await sendNotification(fromUid, roomId, messageObj);
+		} catch (err) {
+			winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
 		}
-
-		queueObj.timeout = setTimeout(async () => {
-			try {
-				await sendNotification(fromUid, roomId, queueObj.message);
-				delete Messaging.notifyQueue[`${fromUid}:${roomId}`];
-			} catch (err) {
-				winston.error(`[messaging/notifications] Unabled to send notification\n${err.stack}`);
-			}
-		}, meta.config.notificationSendDelay * 1000);
 	};
 
 	async function sendNotification(fromUid, roomId, messageObj) {
@@ -121,21 +102,22 @@ module.exports = function (Messaging) {
 		if (uidsToNotify.length) {
 			const { displayname } = messageObj.fromUser;
 			const isGroupChat = await Messaging.isGroupChat(roomId);
+			const roomName = roomData.roomName || `[[modules:chat.room-id, ${roomId}]]`;
 			const notifData = {
 				type: isGroupChat ? 'new-group-chat' : 'new-chat',
-				subject: `[[email:notif.chat.subject, ${displayname}]]`,
-				bodyShort: `[[notifications:new_message_from, ${displayname}]]`,
+				subject: `[[email:notif.chat.subject, ${roomName}]]`,
+				bodyShort: isGroupChat || roomData.roomName ? `[[notifications:new_message_in, ${roomName}]]` : `[[notifications:new_message_from, ${displayname}]]`,
 				bodyLong: messageObj.content,
-				nid: `chat_${roomId}_${fromUid}`,
+				nid: `chat_${roomId}_${fromUid}_${Date.now()}`,
+				mergeId: `new-chat|${roomId}`, // as roomId is the differentiator, no distinction between direct vs. group req'd.
 				from: fromUid,
-				roomId: roomId,
+				roomId,
+				roomName,
 				path: `/chats/${messageObj.roomId}`,
 			};
 			if (roomData.public) {
 				const icon = Messaging.getRoomIcon(roomData);
-				const roomName = roomData.roomName || `[[modules:chat.room-id, ${roomId}]]`;
 				notifData.type = 'new-public-chat';
-				notifData.roomName = roomName;
 				notifData.roomIcon = icon;
 				notifData.subject = `[[email:notif.chat.public-chat-subject, ${displayname}, ${roomName}]]`;
 				notifData.bodyShort = `[[notifications:user_posted_in_public_room, ${displayname}, ${icon}, ${roomName}]]`;

--- a/src/messaging/rooms.js
+++ b/src/messaging/rooms.js
@@ -48,9 +48,7 @@ module.exports = function (Messaging) {
 				db.parseIntFields(data, intFields, fields);
 				data.roomName = validator.escape(String(data.roomName || ''));
 				data.public = parseInt(data.public, 10) === 1;
-				if (data.hasOwnProperty('groupChat')) {
-					data.groupChat = parseInt(data.groupChat, 10) === 1;
-				}
+				data.groupChat = data.userCount > 2;
 
 				if (!fields.length || fields.includes('notificationSetting')) {
 					data.notificationSetting = data.notificationSetting ||
@@ -287,7 +285,8 @@ module.exports = function (Messaging) {
 	};
 
 	Messaging.isGroupChat = async function (roomId) {
-		return (await Messaging.getRoomData(roomId)).groupChat;
+		const count = await Messaging.getUserCountInRoom(roomId);
+		return count > 2;
 	};
 
 	async function updateUserCount(roomIds) {
@@ -523,7 +522,7 @@ module.exports = function (Messaging) {
 		room.isOwner = isOwner;
 		room.users = users;
 		room.canReply = canReply;
-		room.groupChat = room.hasOwnProperty('groupChat') ? room.groupChat : users.length > 2;
+		room.groupChat = users.length > 2;
 		room.icon = Messaging.getRoomIcon(room);
 		room.usernames = Messaging.generateUsernames(room, uid);
 		room.chatWithMessage = await Messaging.generateChatWithMessage(room, uid, settings.userLang);

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 const async = require('async');
 const winston = require('winston');
 const cron = require('cron').CronJob;
@@ -15,8 +16,16 @@ const batch = require('./batch');
 const plugins = require('./plugins');
 const utils = require('./utils');
 const emailer = require('./emailer');
+const ttlCache = require('./cache/ttl');
 
 const Notifications = module.exports;
+
+// ttlcache for email-only chat notifications
+const notificationCache = ttlCache({
+	ttl: (meta.config.notificationSendDelay || 60) * 1000,
+	noDisposeOnSet: true,
+	dispose: sendEmail,
+});
 
 Notifications.baseTypes = [
 	'notificationType_upvote',
@@ -191,36 +200,6 @@ async function pushToUids(uids, notification) {
 		}
 	}
 
-	async function sendEmail(uids) {
-		// Update CTA messaging (as not all notification types need custom text)
-		if (['new-reply', 'new-chat'].includes(notification.type)) {
-			notification['cta-type'] = notification.type;
-		}
-		let body = notification.bodyLong || '';
-		if (meta.config.removeEmailNotificationImages) {
-			body = body.replace(/<img[^>]*>/, '');
-		}
-		body = posts.relativeToAbsolute(body, posts.urlRegex);
-		body = posts.relativeToAbsolute(body, posts.imgRegex);
-		let errorLogged = false;
-		await async.eachLimit(uids, 3, async (uid) => {
-			await emailer.send('notification', uid, {
-				path: notification.path,
-				notification_url: notification.path.startsWith('http') ? notification.path : nconf.get('url') + notification.path,
-				subject: utils.stripHTMLTags(notification.subject || '[[notifications:new_notification]]'),
-				intro: utils.stripHTMLTags(notification.bodyShort),
-				body: body,
-				notification: notification,
-				showUnsubscribe: true,
-			}).catch((err) => {
-				if (!errorLogged) {
-					winston.error(`[emailer.send] ${err.stack}`);
-					errorLogged = true;
-				}
-			});
-		});
-	}
-
 	async function getUidsBySettings(uids) {
 		const uidsToNotify = [];
 		const uidsToEmail = [];
@@ -251,15 +230,59 @@ async function pushToUids(uids, notification) {
 	if (notification.type) {
 		results = await getUidsBySettings(data.uids);
 	}
-	await Promise.all([
-		sendNotification(results.uidsToNotify),
-		sendEmail(results.uidsToEmail),
-	]);
+	await sendNotification(results.uidsToNotify);
+	const delayNotificationTypes = ['new-chat', 'new-group-chat', 'new-public-chat'];
+	if (delayNotificationTypes.includes(notification.type)) {
+		const cacheKey = `${notification.mergeId}|${results.uidsToEmail.join(',')}`;
+		if (notificationCache.has(cacheKey)) {
+			const payload = notificationCache.get(cacheKey);
+			notification.bodyLong = [payload.notification.bodyLong, notification.bodyLong].join('\n');
+		}
+		notificationCache.set(cacheKey, { uids: results.uidsToEmail, notification });
+	} else {
+		await sendEmail({ uids: results.uidsToEmail, notification });
+	}
+
 	plugins.hooks.fire('action:notification.pushed', {
-		notification: notification,
+		notification,
 		uids: results.uidsToNotify,
 		uidsNotified: results.uidsToNotify,
 		uidsEmailed: results.uidsToEmail,
+	});
+}
+
+async function sendEmail({ uids, notification }, mergeId, reason) {
+	// Only act on cache item expiry
+	if (reason && reason !== 'stale') {
+		return;
+	}
+
+	// Update CTA messaging (as not all notification types need custom text)
+	if (['new-reply', 'new-chat'].includes(notification.type)) {
+		notification['cta-type'] = notification.type;
+	}
+	let body = notification.bodyLong || '';
+	if (meta.config.removeEmailNotificationImages) {
+		body = body.replace(/<img[^>]*>/, '');
+	}
+	body = posts.relativeToAbsolute(body, posts.urlRegex);
+	body = posts.relativeToAbsolute(body, posts.imgRegex);
+	let errorLogged = false;
+	await async.eachLimit(uids, 3, async (uid) => {
+		await emailer.send('notification', uid, {
+			path: notification.path,
+			notification_url: notification.path.startsWith('http') ? notification.path : nconf.get('url') + notification.path,
+			subject: utils.stripHTMLTags(notification.subject || '[[notifications:new_notification]]'),
+			intro: utils.stripHTMLTags(notification.bodyShort),
+			body: body,
+			notification: notification,
+			showUnsubscribe: true,
+		}).catch((err) => {
+			if (!errorLogged) {
+				winston.error(`[emailer.send] ${err.stack}`);
+				errorLogged = true;
+			}
+		});
 	});
 }
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -373,6 +373,7 @@ Notifications.merge = async function (notifications) {
 		'notifications:user_posted_to',
 		'notifications:user_flagged_post_in',
 		'notifications:user_flagged_user',
+		'new-chat',
 		'notifications:user_posted_in_public_room',
 		'new_register',
 		'post-queue',
@@ -416,6 +417,15 @@ Notifications.merge = async function (notifications) {
 			}
 			const notifObj = notifications[modifyIndex];
 			switch (mergeId) {
+				case 'new-chat': {
+					const { roomId, roomName, type, user } = set[0];
+					const isGroupChat = type === 'new-group-chat';
+					notifObj.bodyShort = isGroupChat || (roomName !== `[[modules:chat.room-id, ${roomId}]]`) ?
+						`[[notifications:new_messages_in, ${set.length}, ${roomName}]]` :
+						`[[notifications:new_messages_from, ${set.length}, ${user.displayname}]]`;
+					break;
+				}
+
 				case 'notifications:user_posted_in_public_room': {
 					const usernames = _.uniq(set.map(notifObj => notifObj && notifObj.user && notifObj.user.displayname));
 					if (usernames.length === 2 || usernames.length === 3) {

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -435,8 +435,8 @@ describe('Messaging Library', () => {
 			const data = await User.notifications.get(mocks.users.herp.uid);
 			assert(data.unread[0]);
 			const notification = data.unread[0];
-			assert.strictEqual(notification.bodyShort, 'New message from <strong>foo</strong>');
-			assert.strictEqual(notification.nid, `chat_${roomId}_${mocks.users.foo.uid}`);
+			assert.strictEqual(notification.bodyShort, `New message in <strong>Room ${roomId}</strong>`);
+			assert(notification.nid.startsWith(`chat_${roomId}_${mocks.users.foo.uid}_`));
 			assert.strictEqual(notification.path, `${nconf.get('relative_path')}/chats/${roomId}`);
 		});
 


### PR DESCRIPTION
## Tasks
* [x] refactor: remove chat message notification queue, implement merge IDs for chat message notifications, so they can be grouped together
* [x] Re-implement in email logic

## Non-breaking changes

1. Chat notification IDs now contain the timestamp of the message so as to not automatically overwrite old notifications in the same room. The formula is `chat_{roomId}_{uid}_{timestamp}`
2. Notifications' short text to users are no longer a simple "New message from {username}", it will change depending on the context:
    * In a private group chat or public chat room setting, the notification will read "New message in {room name}" or "*X* new messages in {room name}"
    * If a private chat room has been named, the name will be used, instead of the messaging user.
    * Otherwise, the short text will remain unchanged.