### PR TITLE
fix: #12017, unreliable forum updated messaging

### DIFF
--- a/src/socket.io/meta.js
+++ b/src/socket.io/meta.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const os = require('os');
 
 const user = require('../user');
+const meta = require('../meta');
 const topics = require('../topics');
 
 const SocketMeta = module.exports;
@@ -13,7 +15,10 @@ SocketMeta.reconnected = function (socket, data, callback) {
 		topics.pushUnreadCount(socket.uid);
 		user.notifications.pushCount(socket.uid);
 	}
-	callback();
+	callback(null, {
+		'cache-buster': meta.config['cache-buster'],
+		hostname: os.hostname(),
+	});
 };
 
 /* Rooms */

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -4,7 +4,6 @@
 const fs = require('fs');
 const util = require('util');
 const path = require('path');
-const os = require('os');
 const nconf = require('nconf');
 const express = require('express');
 const chalk = require('chalk');
@@ -85,10 +84,7 @@ exports.listen = async function () {
 	await initializeNodeBB();
 	winston.info('🎉 NodeBB Ready');
 
-	require('./socket.io').server.emit('event:nodebb.ready', {
-		'cache-buster': meta.config['cache-buster'],
-		hostname: os.hostname(),
-	});
+	require('./socket.io').server.emit('event:nodebb.ready', {});
 
 	plugins.hooks.fire('action:nodebb.ready');
 


### PR DESCRIPTION
- Removed payload from event:nodebb.ready event (ready to remove for v4 in favour of SSE)
- Send hostname/cache-buster payload in meta.reconnected method instead
