### PR TITLE
Rescinding of a flag report

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -211,6 +211,7 @@
 	"post-flagged-too-many-times": "This post has been flagged by others already",
 	"user-flagged-too-many-times": "This user has been flagged by others already",
 	"cant-flag-privileged": "You are not allowed to flag the profiles or content of privileged users (moderators/global moderators/admins)",
+	"cant-locate-flag-report": "Cannot locate flag report",
 	"self-vote": "You cannot vote on your own post",
 	"too-many-upvotes-today": "You can only upvote %1 times a day",
 	"too-many-upvotes-today-user": "You can only upvote a user %1 times a day",

--- a/public/language/en-GB/flags.json
+++ b/public/language/en-GB/flags.json
@@ -1,5 +1,6 @@
 {
 	"state": "State",
+	"report": "Report",
 	"reports": "Reports",
 	"first-reported": "First Reported",
 	"no-flags": "Hooray! No flags found.",
@@ -8,6 +9,8 @@
 	"update": "Update",
 	"updated": "Updated",
 	"resolved": "Resolved",
+	"report-added": "Added",
+	"report-rescinded": "Rescinded",
 	"target-purged": "The content this flag referred to has been purged and is no longer available.",
 	"target-aboutme-empty": "This user has no &quot;About Me&quot; set.",
 

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -192,6 +192,8 @@ paths:
     $ref: 'write/flags.yaml'
   /flags/{flagId}:
     $ref: 'write/flags/flagId.yaml'
+  /flags/{flagId}/report:
+    $ref: 'write/flags/flagId/report.yaml'
   /flags/{flagId}/notes:
     $ref: 'write/flags/flagId/notes.yaml'
   /flags/{flagId}/notes/{datetime}:

--- a/public/openapi/write/flags/flagId/report.yaml
+++ b/public/openapi/write/flags/flagId/report.yaml
@@ -1,0 +1,26 @@
+delete:
+  tags:
+    - flags
+  summary: rescind a flag report
+  description: This operation rescinds the report made for a given flag.
+  parameters:
+    - in: path
+      name: flagId
+      schema:
+        type: number
+      required: true
+      description: a valid flag id
+      example: 2
+  responses:
+    '200':
+      description: Flag report rescinded
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/src/api/flags.js
+++ b/src/api/flags.js
@@ -49,6 +49,16 @@ flagsApi.update = async (caller, data) => {
 
 flagsApi.delete = async (_, { flagId }) => await flags.purge([flagId]);
 
+flagsApi.rescind = async ({ uid }, { flagId }) => {
+	const { type, targetId } = await flags.get(flagId);
+	const exists = await flags.exists(type, targetId, uid);
+	if (!exists) {
+		throw new Error('[[error:no-flag]]');
+	}
+
+	await flags.rescindReport(type, targetId, uid);
+};
+
 flagsApi.appendNote = async (caller, data) => {
 	const allowed = await user.isPrivileged(caller.uid);
 	if (!allowed) {

--- a/src/controllers/errors.js
+++ b/src/controllers/errors.js
@@ -48,6 +48,12 @@ exports.handleErrors = async function handleErrors(err, req, res, next) { // esl
 			res.status(403).type('text/plain').send(err.message);
 		},
 	};
+
+	const notFoundHandler = () => {
+		const controllers = require('.');
+		controllers['404'].handle404(req, res);
+	};
+
 	const defaultHandler = async function () {
 		if (res.headersSent) {
 			return;
@@ -87,6 +93,8 @@ exports.handleErrors = async function handleErrors(err, req, res, next) { // esl
 	try {
 		if (data.cases.hasOwnProperty(err.code)) {
 			data.cases[err.code](err, req, res, defaultHandler);
+		} else if (err.message.startsWith('[[error:no-') && err.message !== '[[error:no-privileges]]') {
+			notFoundHandler();
 		} else {
 			await defaultHandler();
 		}

--- a/src/controllers/write/flags.js
+++ b/src/controllers/write/flags.js
@@ -32,6 +32,11 @@ Flags.delete = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Flags.rescind = async (req, res) => {
+	await api.flags.rescind(req, { flagId: req.params.flagId });
+	helpers.formatApiResponse(200, res);
+};
+
 Flags.appendNote = async (req, res) => {
 	const { note, datetime } = req.body;
 	const payload = await api.flags.appendNote(req, {

--- a/src/controllers/write/flags.js
+++ b/src/controllers/write/flags.js
@@ -13,7 +13,7 @@ Flags.create = async (req, res) => {
 };
 
 Flags.get = async (req, res) => {
-	helpers.formatApiResponse(200, res, await api.flags.get(req, req.params.flagId));
+	helpers.formatApiResponse(200, res, await api.flags.get(req, req.params));
 };
 
 Flags.update = async (req, res) => {

--- a/src/flags.js
+++ b/src/flags.js
@@ -545,6 +545,7 @@ Flags.getReports = async function (flagId) {
 	return reports;
 };
 
+// Not meant to be called directly, call Flags.create() instead.
 Flags.addReport = async function (flagId, type, id, uid, reason, timestamp) {
 	await db.sortedSetAddBulk([
 		[`flags:byReporter:${uid}`, timestamp, flagId],

--- a/src/flags.js
+++ b/src/flags.js
@@ -109,7 +109,7 @@ Flags.get = async function (flagId) {
 		Flags.getReports(flagId),
 	]);
 	if (!base) {
-		return;
+		throw new Error('[[error:no-flag]]');
 	}
 	const flagObj = {
 		state: 'open',

--- a/src/flags.js
+++ b/src/flags.js
@@ -417,7 +417,10 @@ Flags.create = async function (type, id, uid, reason, timestamp, forceFlag = fal
 		const flagId = await Flags.getFlagIdByTarget(type, id);
 		await Promise.all([
 			Flags.addReport(flagId, type, id, uid, reason, timestamp),
-			Flags.update(flagId, uid, { state: 'open' }),
+			Flags.update(flagId, uid, {
+				state: 'open',
+				report: 'added',
+			}),
 		]);
 
 		return await Flags.get(flagId);
@@ -551,6 +554,45 @@ Flags.addReport = async function (flagId, type, id, uid, reason, timestamp) {
 	]);
 
 	plugins.hooks.fire('action:flags.addReport', { flagId, type, id, uid, reason, timestamp });
+};
+
+Flags.rescindReport = async (type, id, uid) => {
+	const exists = await Flags.exists(type, id, uid);
+	if (!exists) {
+		return true;
+	}
+
+	const flagId = await db.sortedSetScore('flags:hash', [type, id, uid].join(':'));
+	const reports = await db.getSortedSetMembers(`flag:${flagId}:reports`);
+	let reason;
+	reports.forEach((payload) => {
+		if (!reason) {
+			const [payloadUid, payloadReason] = payload.split(';');
+			if (parseInt(payloadUid, 10) === parseInt(uid, 10)) {
+				reason = payloadReason;
+			}
+		}
+	});
+
+	if (!reason) {
+		throw new Error('[[error:cant-locate-flag-report]]');
+	}
+
+	await db.sortedSetRemoveBulk([
+		[`flags:byReporter:${uid}`, flagId],
+		[`flag:${flagId}:reports`, [uid, reason].join(';')],
+
+		['flags:hash', [type, id, uid].join(':')],
+	]);
+
+	// If there are no more reports, consider the flag resolved
+	const reportCount = await db.sortedSetCard(`flag:${flagId}:reports`);
+	if (reportCount < 1) {
+		await Flags.update(flagId, uid, {
+			state: 'resolved',
+			report: 'rescinded',
+		});
+	}
 };
 
 Flags.exists = async function (type, id, uid) {
@@ -765,6 +807,9 @@ Flags.getHistory = async function (flagId) {
 		const changeset = entry.value[1];
 		if (changeset.hasOwnProperty('state')) {
 			changeset.state = changeset.state === undefined ? '' : `[[flags:state-${changeset.state}]]`;
+		}
+		if (changeset.hasOwnProperty('report')) {
+			changeset.report = `[[flags:report-${changeset.report}]]`;
 		}
 
 		return {

--- a/src/routes/write/flags.js
+++ b/src/routes/write/flags.js
@@ -12,6 +12,7 @@ module.exports = function () {
 
 	setupApiRoute(router, 'post', '/', [...middlewares], controllers.write.flags.create);
 
+	// Note: access control provided by middleware.assert.flag
 	setupApiRoute(router, 'get', '/:flagId', [...middlewares, middleware.assert.flag], controllers.write.flags.get);
 	setupApiRoute(router, 'put', '/:flagId', [...middlewares, middleware.assert.flag], controllers.write.flags.update);
 	setupApiRoute(router, 'delete', '/:flagId', [...middlewares, middleware.assert.flag], controllers.write.flags.delete);

--- a/src/routes/write/flags.js
+++ b/src/routes/write/flags.js
@@ -17,6 +17,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:flagId', [...middlewares, middleware.assert.flag], controllers.write.flags.update);
 	setupApiRoute(router, 'delete', '/:flagId', [...middlewares, middleware.assert.flag], controllers.write.flags.delete);
 
+	setupApiRoute(router, 'delete', '/:flagId/report', middlewares, controllers.write.flags.rescind);
+
 	setupApiRoute(router, 'post', '/:flagId/notes', [...middlewares, middleware.assert.flag], controllers.write.flags.appendNote);
 	setupApiRoute(router, 'delete', '/:flagId/notes/:datetime', [...middlewares, middleware.assert.flag], controllers.write.flags.deleteNote);
 

--- a/test/flags.js
+++ b/test/flags.js
@@ -126,6 +126,10 @@ describe('Flags', () => {
 			({ flagId } = await Flags.create('post', postData.pid, adminUid, utils.generateUUID()));
 		});
 
+		after(async () => {
+			Flags.purge([flagId]);
+		});
+
 		it('should add a report to an existing flag', async () => {
 			await Flags.addReport(flagId, 'post', postData.pid, uid3, utils.generateUUID(), Date.now());
 
@@ -155,6 +159,10 @@ describe('Flags', () => {
 				content: utils.generateUUID(),
 			}));
 			({ flagId } = await Flags.create('post', postData.pid, adminUid, utils.generateUUID()));
+		});
+
+		after(async () => {
+			Flags.purge([flagId]);
 		});
 
 		it('should remove a report from an existing flag', async () => {
@@ -986,7 +994,7 @@ describe('Flags', () => {
 			it('should update a flag\'s properties', async () => {
 				const { response } = await request({
 					method: 'put',
-					uri: `${nconf.get('url')}/api/v3/flags/2`,
+					uri: `${nconf.get('url')}/api/v3/flags/4`,
 					jar,
 					headers: {
 						'x-csrf-token': csrfToken,
@@ -1008,7 +1016,7 @@ describe('Flags', () => {
 			it('should remove a flag\'s report', async () => {
 				const response = await request({
 					method: 'delete',
-					uri: `${nconf.get('url')}/api/v3/flags/2/report`,
+					uri: `${nconf.get('url')}/api/v3/flags/4/report`,
 					jar,
 					headers: {
 						'x-csrf-token': csrfToken,
@@ -1024,7 +1032,7 @@ describe('Flags', () => {
 			it('should append a note to the flag', async () => {
 				const { response } = await request({
 					method: 'post',
-					uri: `${nconf.get('url')}/api/v3/flags/2/notes`,
+					uri: `${nconf.get('url')}/api/v3/flags/4/notes`,
 					jar,
 					headers: {
 						'x-csrf-token': csrfToken,
@@ -1052,7 +1060,7 @@ describe('Flags', () => {
 			it('should delete a note from a flag', async () => {
 				const { response } = await request({
 					method: 'delete',
-					uri: `${nconf.get('url')}/api/v3/flags/2/notes/1626446956652`,
+					uri: `${nconf.get('url')}/api/v3/flags/4/notes/1626446956652`,
 					jar,
 					headers: {
 						'x-csrf-token': csrfToken,

--- a/test/flags.js
+++ b/test/flags.js
@@ -19,6 +19,7 @@ const User = require('../src/user');
 const Groups = require('../src/groups');
 const Meta = require('../src/meta');
 const Privileges = require('../src/privileges');
+const plugins = require('../src/plugins');
 const utils = require('../src/utils');
 const api = require('../src/api');
 
@@ -31,6 +32,13 @@ describe('Flags', () => {
 	let csrfToken;
 	let category;
 	before(async () => {
+		const dummyEmailerHook = async (data) => {};
+		// Attach an emailer hook so related requests do not error
+		plugins.hooks.register('flags-test', {
+			hook: 'filter:email.send',
+			method: dummyEmailerHook,
+		});
+
 		// Create some stuff to flag
 		uid1 = await User.create({ username: 'testUser', password: 'abcdef', email: 'b@c.com' });
 
@@ -59,6 +67,10 @@ describe('Flags', () => {
 		const login = await helpers.loginUser('moderator', 'abcdef');
 		jar = login.jar;
 		csrfToken = login.csrf_token;
+	});
+
+	after(() => {
+		plugins.hooks.unregister('flags-test', 'filter:email.send');
 	});
 
 	describe('.create()', () => {
@@ -96,6 +108,71 @@ describe('Flags', () => {
 				assert.ok(isMember);
 				done();
 			});
+		});
+	});
+
+	describe('.addReport()', () => {
+		let flagId;
+		let postData;
+
+		before(async () => {
+			// Create a topic and flag it
+			({ postData } = await Topics.post({
+				cid: category.cid,
+				uid: uid1,
+				title: utils.generateUUID(),
+				content: utils.generateUUID(),
+			}));
+			({ flagId } = await Flags.create('post', postData.pid, adminUid, utils.generateUUID()));
+		});
+
+		it('should add a report to an existing flag', async () => {
+			await Flags.addReport(flagId, 'post', postData.pid, uid3, utils.generateUUID(), Date.now());
+
+			const reports = await db.getSortedSetMembers(`flag:${flagId}:reports`);
+			assert.strictEqual(reports.length, 2);
+		});
+
+		it('should add an additional report even if same user calls it again', async () => {
+			// This isn't exposed to the end user, but is possible via direct method call
+			await Flags.addReport(flagId, 'post', postData.pid, uid3, utils.generateUUID(), Date.now());
+
+			const reports = await db.getSortedSetMembers(`flag:${flagId}:reports`);
+			assert.strictEqual(reports.length, 3);
+		});
+	});
+
+	describe('.rescindReport()', () => {
+		let flagId;
+		let postData;
+
+		before(async () => {
+			// Create a topic and flag it
+			({ postData } = await Topics.post({
+				cid: category.cid,
+				uid: uid1,
+				title: utils.generateUUID(),
+				content: utils.generateUUID(),
+			}));
+			({ flagId } = await Flags.create('post', postData.pid, adminUid, utils.generateUUID()));
+		});
+
+		it('should remove a report from an existing flag', async () => {
+			await Flags.create('post', postData.pid, uid3, utils.generateUUID());
+			await Flags.rescindReport('post', postData.pid, uid3);
+			const reports = await Flags.getReports(flagId);
+
+			assert.strictEqual(reports.length, 1);
+			assert(reports.every(({ reporter }) => reporter.uid !== uid3));
+		});
+
+		it('should automatically mark the flag resolved if there are no reports remaining after removal', async () => {
+			await Flags.rescindReport('post', postData.pid, adminUid);
+			const reports = await Flags.getReports(flagId);
+			const { state } = await Flags.get(flagId);
+
+			assert.strictEqual(reports.length, 0);
+			assert.strictEqual(state, 'resolved');
 		});
 	});
 

--- a/test/flags.js
+++ b/test/flags.js
@@ -1004,6 +1004,22 @@ describe('Flags', () => {
 			});
 		});
 
+		describe('.rescind()', () => {
+			it('should remove a flag\'s report', async () => {
+				const response = await request({
+					method: 'delete',
+					uri: `${nconf.get('url')}/api/v3/flags/2/report`,
+					jar,
+					headers: {
+						'x-csrf-token': csrfToken,
+					},
+					resolveWithFullResponse: true,
+				});
+
+				assert.strictEqual(response.statusCode, 200);
+			});
+		});
+
 		describe('.appendNote()', () => {
 			it('should append a note to the flag', async () => {
 				const { response } = await request({


### PR DESCRIPTION
- feat: backend methods for rescinding a report, supplemental adds and removing a report now adds to the flag history
- test: added test cases for .addReport and .rescindReport()
- fix: incorrect data passed to api.flags.get
- feat: flag rescinding logic + api method
