### PR TITLE
socket categories refactor

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -208,6 +208,8 @@ paths:
     $ref: 'write/flags/flagId/notes.yaml'
   /flags/{flagId}/notes/{datetime}:
     $ref: 'write/flags/flagId/notes/datetime.yaml'
+  /search/categories:
+    $ref: 'write/search/categories.yaml'
   /admin/settings/{setting}:
     $ref: 'write/admin/settings/setting.yaml'
   /admin/analytics:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -112,6 +112,10 @@ paths:
     $ref: 'write/categories.yaml'
   /categories/{cid}:
     $ref: 'write/categories/cid.yaml'
+  /categories/{cid}/count:
+    $ref: 'write/categories/cid/count.yaml'
+  /categories/{cid}/posts:
+    $ref: 'write/categories/cid/posts.yaml'
   /categories/{cid}/privileges:
     $ref: 'write/categories/cid/privileges.yaml'
   /categories/{cid}/privileges/{privilege}:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -118,6 +118,8 @@ paths:
     $ref: 'write/categories/cid/posts.yaml'
   /categories/{cid}/children:
     $ref: 'write/categories/cid/children.yaml'
+  /categories/{cid}/topics:
+    $ref: 'write/categories/cid/topics.yaml'
   /categories/{cid}/watch:
     $ref: 'write/categories/cid/watch.yaml'
   /categories/{cid}/privileges:

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -116,6 +116,10 @@ paths:
     $ref: 'write/categories/cid/count.yaml'
   /categories/{cid}/posts:
     $ref: 'write/categories/cid/posts.yaml'
+  /categories/{cid}/children:
+    $ref: 'write/categories/cid/children.yaml'
+  /categories/{cid}/watch:
+    $ref: 'write/categories/cid/watch.yaml'
   /categories/{cid}/privileges:
     $ref: 'write/categories/cid/privileges.yaml'
   /categories/{cid}/privileges/{privilege}:

--- a/public/openapi/write/categories.yaml
+++ b/public/openapi/write/categories.yaml
@@ -1,3 +1,25 @@
+get:
+  tags:
+    - categories
+  summary: list categories
+  description: This operation returns a flat list of categories available to the calling user
+  responses:
+    '200':
+      description: categories successfully listed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  categories:
+                    type: array
+                    items:
+                      $ref: ../components/schemas/CategoryObject.yaml#/CategoryObject
 post:
   tags:
     - categories

--- a/public/openapi/write/categories/cid/children.yaml
+++ b/public/openapi/write/categories/cid/children.yaml
@@ -1,0 +1,36 @@
+get:
+  tags:
+    - categories
+  summary: get subcategories
+  description: |
+    This operation returns the requested category's children (aka subcategories).
+
+    It is important to note that the number of subcategories returned is dependent on the configured value for that category.
+    If a lower number is specified than there are children, then the list will be truncated to that number.
+
+    This is defined by the `subCategoriesPerPage` key in the category's hash.
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: string
+      required: true
+      description: a valid category id, `0` for global privileges, `admin` for admin privileges
+      example: 1
+  responses:
+    '200':
+      description: categories count successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  categories:
+                    type: array
+                    items:
+                      $ref: ../../../components/schemas/CategoryObject.yaml#/CategoryObject

--- a/public/openapi/write/categories/cid/count.yaml
+++ b/public/openapi/write/categories/cid/count.yaml
@@ -1,0 +1,28 @@
+get:
+  tags:
+    - categories
+  summary: get topic count
+  description: This operation returns the count of topics in a given category (excluding its subcategories)
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: string
+      required: true
+      description: a valid category id, `0` for global privileges, `admin` for admin privileges
+      example: 1
+  responses:
+    '200':
+      description: categories count successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  count:
+                    type: number

--- a/public/openapi/write/categories/cid/posts.yaml
+++ b/public/openapi/write/categories/cid/posts.yaml
@@ -1,0 +1,28 @@
+get:
+  tags:
+    - categories
+  summary: get topic posts
+  description: This operation returns a list of posts in the category, across all topics in that category (excluding its subcategories)
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: string
+      required: true
+      description: a valid category id, `0` for global privileges, `admin` for admin privileges
+      example: 1
+  responses:
+    '200':
+      description: categories posts successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  posts:
+                    $ref: ../../../components/schemas/PostsObject.yaml#/PostsObject

--- a/public/openapi/write/categories/cid/topics.yaml
+++ b/public/openapi/write/categories/cid/topics.yaml
@@ -1,0 +1,75 @@
+get:
+  tags:
+    - categories
+  summary: get topics
+  description: |
+    This operation returns a set of topics in the requested category.
+
+    The number of topics returned is defined by the "Topics per Page" (`topicsPerPage`) setting under ACP > Settings > Pagination.
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: string
+      required: true
+      description: a valid category id, `0` for global privileges, `admin` for admin privileges
+      example: 1
+    - in: query
+      name: 'query'
+      schema:
+        type: string
+      required: false
+      description: Likely unused — a URI-encoded JSON string containing values that are passed to `getCategoryTopics`.
+      example: ''
+    - in: query
+      name: 'after'
+      schema:
+        type: string
+      required: false
+      description: The index to start at when querying for the next set of topics. This parameter would be more aptly named `start`.
+      example: '0'
+    - in: query
+      name: 'sort'
+      schema:
+        type: string
+      required: false
+      description: Likely deprecated — the sorting method of topics (use `categoryTopicSort` instead.)
+      example: ''
+    - in: query
+      name: 'categoryTopicSort'
+      schema:
+        type: string
+      required: false
+      description: The sorting method of topics
+      example: 'newest_to_oldest'
+    - in: query
+      name: 'direction'
+      schema:
+        type: string
+      required: false
+      description: The sorting of returned results (if you scroll up you want the topics reversed). Set to "-1" for reversed results.
+      example: '1'
+  responses:
+    '200':
+      description: categories topics successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  topics:
+                    type: array
+                    items:
+                      $ref: ../../../components/schemas/TopicObject.yaml#/TopicObject
+                  nextStart:
+                    type: number
+                  privileges:
+                    type: object
+                    additionalProperties:
+                      type: boolean
+                      description: A set of privileges with either true or false

--- a/public/openapi/write/categories/cid/watch.yaml
+++ b/public/openapi/write/categories/cid/watch.yaml
@@ -1,0 +1,102 @@
+put:
+  tags:
+    - categories
+  summary: update watch state
+  description: |
+    This operation changes the watch state for the category.
+
+    Note that a category can be watched, not watched, or ignored:
+
+      * A category that is watched will have topics that show up in both `/unread` and `/recent`
+      * A category that is *not* watched will have topics that show up in `/recent` but not `/unread`
+      * A category that is ignored will not have topics that show up in either route.
+
+    This API call does not pertain to notifications for new topics in categories.
+    That behaviour is handled by a third-party plugin — nodebb-plugin-category-notifications
+
+    N.B. When a category's watch state is updated, all of that category's children also have their watch states updated.
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: string
+      required: true
+      description: a valid category id, `0` for global privileges, `admin` for admin privileges
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            uid:
+              type: number
+              description: This value is optional, it allows privileged uids to use this call to affect other user accounts.
+              example: 1
+            state:
+              type: string
+              enum: ['watching', 'notwatching', 'ignoring']
+              example: 'watching'
+  responses:
+    '200':
+      description: categories watch state successfully updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  modified:
+                    type: array
+                    description: A list of cids that have had their watch states modified.
+                    items:
+                      type: number
+delete:
+  tags:
+    - categories
+  summary: update watch state
+  description: |
+    Like the corresponding `PUT` method, this operation changes the watch state for the category.
+    However, it does not take a `state` parameter. It is assumed to be whatever the system default is (`categoryWatchState`).
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: string
+      required: true
+      description: a valid category id, `0` for global privileges, `admin` for admin privileges
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            uid:
+              type: number
+              description: This value is optional, it allows privileged uids to use this call to affect other user accounts.
+              example: 1
+  responses:
+    '200':
+      description: categories watch state successfully updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  modified:
+                    type: array
+                    description: A list of cids that have had their watch states modified.
+                    items:
+                      type: number

--- a/public/openapi/write/search/categories.yaml
+++ b/public/openapi/write/search/categories.yaml
@@ -1,0 +1,96 @@
+get:
+  tags:
+    - search
+  summary: find categories by keyword
+  description: |
+    This operation returns a set of categories matching the keyword search.
+
+    A number of filtering options are available, and can be passed in via query string.
+  parameters:
+    - in: query
+      name: 'search'
+      schema:
+        type: string
+      required: false
+      description: The keyword used in the category search
+      example: 'announcements'
+    - in: query
+      name: 'query'
+      schema:
+        type: string
+      required: false
+      description: Likely unused — a URI-encoded JSON string containing values that are passed to `getRecentTopicReplies`.
+      example: ''
+    - in: query
+      name: 'parentCid'
+      schema:
+        type: array
+      required: false
+      description: A list of category IDs. The values received are simply reflected back in the results. Matching cids will have "selected" set to true.
+      example: '0'
+    - in: query
+      name: 'selectedCids'
+      schema:
+        type: array
+      required: false
+      description: Likely deprecated — the sorting method of topics (use `categoryTopicSort` instead.)
+      example: ''
+    - in: query
+      name: 'categoryTopicSort'
+      schema:
+        type: string
+      required: false
+      description: The sorting method of topics
+      example: 'newest_to_oldest'
+    - in: query
+      name: 'direction'
+      schema:
+        type: string
+      required: false
+      description: The sorting of returned results (if you scroll up you want the topics reversed). Set to "-1" for reversed results.
+      example: '1'
+  responses:
+    '200':
+      description: matching categories successfully retrieved
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  categories:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        cid:
+                          type: number
+                          description: A category identifier assigned upon category creation (this value cannot be changed)
+                        name:
+                          type: string
+                          description: The category's name/title
+                        level:
+                          type: number
+                        icon:
+                          type: string
+                          description: A FontAwesome icon string
+                          example: fa-comments-o
+                        bgColor:
+                          type: string
+                          description: Theme-related, a six-character hexadecimal string representing the background colour of the category
+                        color:
+                          type: string
+                          description: Theme-related, a six-character hexadecimal string representing the foreground/text colour of the category
+                        parentCid:
+                          type: number
+                          description: The category identifier for the category that is the immediate ancestor of the current category
+                        imageClass:
+                          type: string
+                          enum: [auto, cover, contain]
+                          description: The `background-position` of the category background image, if one is set
+                        selected:
+                          type: boolean

--- a/public/src/client/account/categories.js
+++ b/public/src/client/account/categories.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('forum/account/categories', ['forum/account/header', 'alerts'], function (header, alerts) {
+define('forum/account/categories', ['forum/account/header', 'alerts', 'api'], function (header, alerts, api) {
 	const Categories = {};
 
 	Categories.init = function () {
@@ -11,36 +11,32 @@ define('forum/account/categories', ['forum/account/header', 'alerts'], function 
 			handleIgnoreWatch(category.cid);
 		});
 
-		$('[component="category/watch/all"]').find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', function () {
+		$('[component="category/watch/all"]').find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', async (e) => {
 			const cids = [];
-			const state = $(this).attr('data-state');
+			const state = e.currentTarget.getAttribute('data-state');
+			const { uid } = ajaxify.data;
 			$('[data-parent-cid="0"]').each(function (index, el) {
 				cids.push($(el).attr('data-cid'));
 			});
 
-			socket.emit('categories.setWatchState', { cid: cids, state: state, uid: ajaxify.data.uid }, function (err, modified_cids) {
-				if (err) {
-					return alerts.error(err);
-				}
-				updateDropdowns(modified_cids, state);
-			});
+			let modified_cids = await Promise.all(cids.map(async cid => api.put(`/categories/${cid}/watch`, { state, uid })));
+			modified_cids = modified_cids
+				.reduce((memo, cur) => memo.concat(cur.modified), [])
+				.filter((cid, idx, arr) => arr.indexOf(cid) === idx);
+
+			updateDropdowns(modified_cids, state);
 		});
 	};
 
 	function handleIgnoreWatch(cid) {
 		const category = $('[data-cid="' + cid + '"]');
-		category.find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', function () {
-			const $this = $(this);
-			const state = $this.attr('data-state');
+		category.find('[component="category/watching"], [component="category/ignoring"], [component="category/notwatching"]').on('click', async (e) => {
+			const state = e.currentTarget.getAttribute('data-state');
+			const { uid } = ajaxify.data;
 
-			socket.emit('categories.setWatchState', { cid: cid, state: state, uid: ajaxify.data.uid }, function (err, modified_cids) {
-				if (err) {
-					return alerts.error(err);
-				}
-				updateDropdowns(modified_cids, state);
-
-				alerts.success('[[category:' + state + '.message]]');
-			});
+			const { modified } = await api.put(`/categories/${cid}/watch`, { state, uid });
+			updateDropdowns(modified, state);
+			alerts.success('[[category:' + state + '.message]]');
 		});
 	}
 

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -123,7 +123,7 @@ define('forum/category', [
 
 		hooks.fire('action:topics.loading');
 		const params = utils.params();
-		infinitescroll.loadMore('categories.loadMore', {
+		infinitescroll.loadMore(`/categories/${ajaxify.data.cid}/topics`, {
 			cid: ajaxify.data.cid,
 			after: after,
 			direction: direction,

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -89,28 +89,22 @@ define('forum/category', [
 	}
 
 	function handleLoadMoreSubcategories() {
-		$('[component="category/load-more-subcategories"]').on('click', function () {
+		$('[component="category/load-more-subcategories"]').on('click', async function () {
 			const btn = $(this);
-			socket.emit('categories.loadMoreSubCategories', {
-				cid: ajaxify.data.cid,
-				start: ajaxify.data.nextSubCategoryStart,
-			}, function (err, data) {
-				if (err) {
-					return alerts.error(err);
-				}
-				btn.toggleClass('hidden', !data.length || data.length < ajaxify.data.subCategoriesPerPage);
-				if (!data.length) {
-					return;
-				}
-				app.parseAndTranslate('category', 'children', { children: data }, function (html) {
-					html.find('.timeago').timeago();
-					$('[component="category/subcategory/container"]').append(html);
-					ajaxify.data.nextSubCategoryStart += ajaxify.data.subCategoriesPerPage;
-					ajaxify.data.subCategoriesLeft -= data.length;
-					btn.toggleClass('hidden', ajaxify.data.subCategoriesLeft <= 0)
-						.translateText('[[category:x-more-categories, ' + ajaxify.data.subCategoriesLeft + ']]');
-				});
+			const { categories: data } = await api.get(`/categories/${ajaxify.data.cid}/children?start=${ajaxify.data.nextSubCategoryStart}`);
+			btn.toggleClass('hidden', !data.length || data.length < ajaxify.data.subCategoriesPerPage);
+			if (!data.length) {
+				return;
+			}
+			app.parseAndTranslate('category', 'children', { children: data }, function (html) {
+				html.find('.timeago').timeago();
+				$('[component="category/subcategory/container"]').append(html);
+				ajaxify.data.nextSubCategoryStart += ajaxify.data.subCategoriesPerPage;
+				ajaxify.data.subCategoriesLeft -= data.length;
+				btn.toggleClass('hidden', ajaxify.data.subCategoriesLeft <= 0)
+					.translateText('[[category:x-more-categories, ' + ajaxify.data.subCategoriesLeft + ']]');
 			});
+
 			return false;
 		});
 	}

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -69,7 +69,7 @@ define('forum/category', [
 			const $this = $(this);
 			const state = $this.attr('data-state');
 
-			socket.emit('categories.setWatchState', { cid: cid, state: state }, function (err) {
+			api.put(`/categories/${cid}/watch`, { state }, (err) => {
 				if (err) {
 					return alerts.error(err);
 				}

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -9,7 +9,8 @@ define('forum/category', [
 	'categorySelector',
 	'hooks',
 	'alerts',
-], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts) {
+	'api',
+], function (infinitescroll, share, navigator, topicList, sort, categorySelector, hooks, alerts, api) {
 	const Category = {};
 
 	$(window).on('action:ajaxify.start', function (ev, data) {
@@ -118,14 +119,9 @@ define('forum/category', [
 		navigator.scrollTop(0);
 	};
 
-	Category.toBottom = function () {
-		socket.emit('categories.getTopicCount', ajaxify.data.cid, function (err, count) {
-			if (err) {
-				return alerts.error(err);
-			}
-
-			navigator.scrollBottom(count - 1);
-		});
+	Category.toBottom = async () => {
+		const { count } = await api.get(`/categories/${ajaxify.data.category.cid}/count`);
+		navigator.scrollBottom(count - 1);
 	};
 
 	function loadTopicsAfter(after, direction, callback) {

--- a/public/src/client/infinitescroll.js
+++ b/public/src/client/infinitescroll.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('forum/infinitescroll', ['hooks', 'alerts'], function (hooks, alerts) {
+define('forum/infinitescroll', ['hooks', 'alerts', 'api'], function (hooks, alerts, api) {
 	const scroll = {};
 	let callback;
 	let previousScrollTop = 0;
@@ -72,7 +72,9 @@ define('forum/infinitescroll', ['hooks', 'alerts'], function (hooks, alerts) {
 		const hookData = { method: method, data: data };
 		hooks.fire('action:infinitescroll.loadmore', hookData);
 
-		socket.emit(hookData.method, hookData.data, function (err, data) {
+		const call = hookData.method.startsWith('/') ? api.get : socket.emit;
+
+		call(hookData.method, hookData.data, function (err, data) {
 			if (err) {
 				loadingMore = false;
 				return alerts.error(err);

--- a/public/src/sockets.js
+++ b/public/src/sockets.js
@@ -111,8 +111,8 @@ app = window.app || {};
 				alerts.alert(params);
 			});
 		});
-		socket.on('event:deprecated_call', function (data) {
-			console.warn('[socket.io] ', data.eventName, 'is now deprecated in favour of', data.replacement);
+		socket.on('event:deprecated_call', (data) => {
+			console.warn('[socket.io]', data.eventName, 'is now deprecated', data.replacement ? `in favour of ${data.replacement}` : 'with no alternative planned.');
 		});
 
 		socket.on('event:livereload', function () {

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -61,6 +61,8 @@ categoriesAPI.delete = async function (caller, { cid }) {
 	});
 };
 
+categoriesAPI.getPosts = async (caller, { cid }) => await categories.getRecentReplies(cid, caller.uid, 0, 4);
+
 categoriesAPI.getPrivileges = async (caller, { cid }) => {
 	await hasAdminPrivilege(caller.uid, 'privileges');
 

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -77,6 +77,11 @@ categoriesAPI.delete = async function (caller, { cid }) {
 	});
 };
 
+categoriesAPI.getTopicCount = async (caller, { cid }) => {
+	const count = await categories.getCategoryField(cid, 'topic_count');
+	return { count };
+};
+
 categoriesAPI.getPosts = async (caller, { cid }) => await categories.getRecentReplies(cid, caller.uid, 0, 4);
 
 categoriesAPI.getPrivileges = async (caller, { cid }) => {

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -15,6 +15,22 @@ const hasAdminPrivilege = async (uid, privilege = 'categories') => {
 	}
 };
 
+categoriesAPI.list = async (caller) => {
+	async function getCategories() {
+		const cids = await categories.getCidsByPrivilege('categories:cid', caller.uid, 'find');
+		return await categories.getCategoriesData(cids);
+	}
+
+	const [isAdmin, categoriesData] = await Promise.all([
+		user.isAdministrator(caller.uid),
+		getCategories(),
+	]);
+
+	return {
+		categories: categoriesData.filter(category => category && (!category.disabled || isAdmin)),
+	};
+};
+
 categoriesAPI.get = async function (caller, data) {
 	const [userPrivileges, category] = await Promise.all([
 		privileges.categories.get(data.cid, caller.uid),

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,6 +9,7 @@ module.exports = {
 	posts: require('./posts'),
 	chats: require('./chats'),
 	categories: require('./categories'),
+	search: require('./search'),
 	flags: require('./flags'),
 	files: require('./files'),
 	utils: require('./utils'),

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -20,6 +20,7 @@ searchApi.categories = async (caller, data) => {
 	data.states = (data.states || ['watching', 'notwatching', 'ignoring']).map(
 		state => categories.watchStates[state]
 	);
+	data.parentCid = parseInt(data.parentCid || 0, 10);
 
 	if (data.search) {
 		({ cids, matchedCids } = await findMatchedCids(caller.uid, data));

--- a/src/api/search.js
+++ b/src/api/search.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const _ = require('lodash');
+
+const categories = require('../categories');
+const privileges = require('../privileges');
+const meta = require('../meta');
+const plugins = require('../plugins');
+
+const controllersHelpers = require('../controllers/helpers');
+
+const searchApi = module.exports;
+
+searchApi.categories = async (caller, data) => {
+	// used by categorySearch module
+
+	let cids = [];
+	let matchedCids = [];
+	const privilege = data.privilege || 'topics:read';
+	data.states = (data.states || ['watching', 'notwatching', 'ignoring']).map(
+		state => categories.watchStates[state]
+	);
+
+	if (data.search) {
+		({ cids, matchedCids } = await findMatchedCids(caller.uid, data));
+	} else {
+		cids = await loadCids(caller.uid, data.parentCid);
+	}
+
+	const visibleCategories = await controllersHelpers.getVisibleCategories({
+		cids, uid: caller.uid, states: data.states, privilege, showLinks: data.showLinks, parentCid: data.parentCid,
+	});
+
+	if (Array.isArray(data.selectedCids)) {
+		data.selectedCids = data.selectedCids.map(cid => parseInt(cid, 10));
+	}
+
+	let categoriesData = categories.buildForSelectCategories(visibleCategories, ['disabledClass'], data.parentCid);
+	categoriesData = categoriesData.slice(0, 200);
+
+	categoriesData.forEach((category) => {
+		category.selected = data.selectedCids ? data.selectedCids.includes(category.cid) : false;
+		if (matchedCids.includes(category.cid)) {
+			category.match = true;
+		}
+	});
+	const result = await plugins.hooks.fire('filter:categories.categorySearch', {
+		categories: categoriesData,
+		...data,
+		uid: caller.uid,
+	});
+
+	return { categories: result.categories };
+};
+
+async function findMatchedCids(uid, data) {
+	const result = await categories.search({
+		uid: uid,
+		query: data.search,
+		qs: data.query,
+		paginate: false,
+	});
+
+	let matchedCids = result.categories.map(c => c.cid);
+	// no need to filter if all 3 states are used
+	const filterByWatchState = !Object.values(categories.watchStates)
+		.every(state => data.states.includes(state));
+
+	if (filterByWatchState) {
+		const states = await categories.getWatchState(matchedCids, uid);
+		matchedCids = matchedCids.filter((cid, index) => data.states.includes(states[index]));
+	}
+
+	const rootCids = _.uniq(_.flatten(await Promise.all(matchedCids.map(categories.getParentCids))));
+	const allChildCids = _.uniq(_.flatten(await Promise.all(matchedCids.map(categories.getChildrenCids))));
+
+	return {
+		cids: _.uniq(rootCids.concat(allChildCids).concat(matchedCids)),
+		matchedCids: matchedCids,
+	};
+}
+
+async function loadCids(uid, parentCid) {
+	let resultCids = [];
+	async function getCidsRecursive(cids) {
+		const categoryData = await categories.getCategoriesFields(cids, ['subCategoriesPerPage']);
+		const cidToData = _.zipObject(cids, categoryData);
+		await Promise.all(cids.map(async (cid) => {
+			const allChildCids = await categories.getAllCidsFromSet(`cid:${cid}:children`);
+			if (allChildCids.length) {
+				const childCids = await privileges.categories.filterCids('find', allChildCids, uid);
+				resultCids.push(...childCids.slice(0, cidToData[cid].subCategoriesPerPage));
+				await getCidsRecursive(childCids);
+			}
+		}));
+	}
+
+	const allRootCids = await categories.getAllCidsFromSet(`cid:${parentCid}:children`);
+	const rootCids = await privileges.categories.filterCids('find', allRootCids, uid);
+	const pageCids = rootCids.slice(0, meta.config.categoriesPerPage);
+	resultCids = pageCids;
+	await getCidsRecursive(pageCids);
+	return resultCids;
+}

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -51,6 +51,13 @@ Categories.getChildren = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.categories.getChildren(req, { cid, start }));
 };
 
+Categories.getTopics = async (req, res) => {
+	const { cid } = req.params;
+	const result = await api.categories.getTopics(req, { ...req.query, cid });
+
+	helpers.formatApiResponse(200, res, result);
+};
+
 Categories.setWatchState = async (req, res) => {
 	const { cid } = req.params;
 	let { uid, state } = req.body;

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const categories = require('../../categories');
+const meta = require('../../meta');
 const api = require('../../api');
 
 const helpers = require('../helpers');
@@ -42,6 +43,24 @@ Categories.getTopicCount = async (req, res) => {
 Categories.getPosts = async (req, res) => {
 	const posts = await api.categories.getPosts(req, { ...req.params });
 	helpers.formatApiResponse(200, res, posts);
+};
+
+Categories.setWatchState = async (req, res) => {
+	const { cid } = req.params;
+	let { uid, state } = req.body;
+
+	if (req.method === 'DELETE') {
+		// DELETE is always setting state to system default in acp
+		state = categories.watchStates[meta.config.categoryWatchState];
+	} else if (Object.keys(categories.watchStates).includes(state)) {
+		state = categories.watchStates[state]; // convert to integer for backend processing
+	} else {
+		throw new Error('[[error:invalid-data]]');
+	}
+
+	const { cids: modified } = await api.categories.setWatchState(req, { cid, state, uid });
+
+	helpers.formatApiResponse(200, res, { modified });
 };
 
 Categories.getPrivileges = async (req, res) => {

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -61,6 +61,7 @@ Categories.setWatchState = async (req, res) => {
 	} else if (Object.keys(categories.watchStates).includes(state)) {
 		state = categories.watchStates[state]; // convert to integer for backend processing
 	} else {
+		console.log('throwing', cid, uid, state);
 		throw new Error('[[error:invalid-data]]');
 	}
 

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -35,6 +35,10 @@ Categories.delete = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Categories.getTopicCount = async (req, res) => {
+	helpers.formatApiResponse(200, res, await api.categories.getTopicCount(req, { ...req.params }));
+};
+
 Categories.getPosts = async (req, res) => {
 	const posts = await api.categories.getPosts(req, { ...req.params });
 	helpers.formatApiResponse(200, res, posts);

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -7,6 +7,10 @@ const helpers = require('../helpers');
 
 const Categories = module.exports;
 
+Categories.list = async (req, res) => {
+	helpers.formatApiResponse(200, res, await api.categories.list(req));
+};
+
 Categories.get = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.categories.get(req, req.params));
 };

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -31,6 +31,11 @@ Categories.delete = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Categories.getPosts = async (req, res) => {
+	const posts = await api.categories.getPosts(req, { ...req.params });
+	helpers.formatApiResponse(200, res, posts);
+};
+
 Categories.getPrivileges = async (req, res) => {
 	const privilegeSet = await api.categories.getPrivileges(req, { cid: req.params.cid });
 	helpers.formatApiResponse(200, res, privilegeSet);

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -42,7 +42,7 @@ Categories.getTopicCount = async (req, res) => {
 
 Categories.getPosts = async (req, res) => {
 	const posts = await api.categories.getPosts(req, { ...req.params });
-	helpers.formatApiResponse(200, res, posts);
+	helpers.formatApiResponse(200, res, { posts });
 };
 
 Categories.getChildren = async (req, res) => {

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -45,6 +45,12 @@ Categories.getPosts = async (req, res) => {
 	helpers.formatApiResponse(200, res, posts);
 };
 
+Categories.getChildren = async (req, res) => {
+	const { cid } = req.params;
+	const { start } = req.query;
+	helpers.formatApiResponse(200, res, await api.categories.getChildren(req, { cid, start }));
+};
+
 Categories.setWatchState = async (req, res) => {
 	const { cid } = req.params;
 	let { uid, state } = req.body;

--- a/src/controllers/write/index.js
+++ b/src/controllers/write/index.js
@@ -10,6 +10,7 @@ Write.tags = require('./tags');
 Write.posts = require('./posts');
 Write.chats = require('./chats');
 Write.flags = require('./flags');
+Write.search = require('./search');
 Write.admin = require('./admin');
 Write.files = require('./files');
 Write.utilities = require('./utilities');

--- a/src/controllers/write/search.js
+++ b/src/controllers/write/search.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const api = require('../../api');
+const helpers = require('../helpers');
+
+const Search = module.exports;
+
+Search.categories = async (req, res) => {
+	helpers.formatApiResponse(200, res, await api.search.categories(req, req.query));
+};

--- a/src/middleware/assert.js
+++ b/src/middleware/assert.js
@@ -11,6 +11,7 @@ const nconf = require('nconf');
 const file = require('../file');
 const user = require('../user');
 const groups = require('../groups');
+const categories = require('../categories');
 const topics = require('../topics');
 const posts = require('../posts');
 const messaging = require('../messaging');
@@ -34,6 +35,14 @@ Assert.group = helpers.try(async (req, res, next) => {
 	const name = await groups.getGroupNameByGroupSlug(req.params.slug);
 	if (!name || !await groups.exists(name)) {
 		return controllerHelpers.formatApiResponse(404, res, new Error('[[error:no-group]]'));
+	}
+
+	next();
+});
+
+Assert.category = helpers.try(async (req, res, next) => {
+	if (!await categories.exists(req.params.cid)) {
+		return controllerHelpers.formatApiResponse(404, res, new Error('[[error:no-category]]'));
 	}
 
 	next();

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -10,6 +10,7 @@ const { setupApiRoute } = routeHelpers;
 module.exports = function () {
 	const middlewares = [middleware.ensureLoggedIn];
 
+	setupApiRoute(router, 'get', '/', [...middlewares], controllers.write.categories.list);
 	setupApiRoute(router, 'post', '/', [...middlewares, middleware.checkRequired.bind(null, ['name'])], controllers.write.categories.create);
 	setupApiRoute(router, 'get', '/:cid', [], controllers.write.categories.get);
 	setupApiRoute(router, 'put', '/:cid', [...middlewares], controllers.write.categories.update);

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -16,8 +16,9 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:cid', [...middlewares], controllers.write.categories.update);
 	setupApiRoute(router, 'delete', '/:cid', [...middlewares], controllers.write.categories.delete);
 
-	setupApiRoute(router, 'get', '/:cid/count', [...middlewares], controllers.write.categories.getTopicCount);
-	setupApiRoute(router, 'get', '/:cid/posts', [...middlewares], controllers.write.categories.getPosts);
+	setupApiRoute(router, 'get', '/:cid/count', [...middlewares, middleware.assert.category], controllers.write.categories.getTopicCount);
+	setupApiRoute(router, 'get', '/:cid/posts', [...middlewares, middleware.assert.category], controllers.write.categories.getPosts);
+	setupApiRoute(router, 'get', '/:cid/children', [...middlewares, middleware.assert.category], controllers.write.categories.getChildren);
 
 	setupApiRoute(router, 'put', '/:cid/watch', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);
 	setupApiRoute(router, 'delete', '/:cid/watch', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -15,6 +15,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:cid', [...middlewares], controllers.write.categories.update);
 	setupApiRoute(router, 'delete', '/:cid', [...middlewares], controllers.write.categories.delete);
 
+	setupApiRoute(router, 'get', '/:cid/posts', [...middlewares], controllers.write.categories.getPosts);
+
 	setupApiRoute(router, 'get', '/:cid/privileges', [...middlewares], controllers.write.categories.getPrivileges);
 	setupApiRoute(router, 'put', '/:cid/privileges/:privilege', [...middlewares, middleware.checkRequired.bind(null, ['member'])], controllers.write.categories.setPrivilege);
 	setupApiRoute(router, 'delete', '/:cid/privileges/:privilege', [...middlewares, middleware.checkRequired.bind(null, ['member'])], controllers.write.categories.setPrivilege);

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -19,6 +19,7 @@ module.exports = function () {
 	setupApiRoute(router, 'get', '/:cid/count', [...middlewares, middleware.assert.category], controllers.write.categories.getTopicCount);
 	setupApiRoute(router, 'get', '/:cid/posts', [...middlewares, middleware.assert.category], controllers.write.categories.getPosts);
 	setupApiRoute(router, 'get', '/:cid/children', [...middlewares, middleware.assert.category], controllers.write.categories.getChildren);
+	setupApiRoute(router, 'get', '/:cid/topics', [...middlewares, middleware.assert.category], controllers.write.categories.getTopics);
 
 	setupApiRoute(router, 'put', '/:cid/watch', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);
 	setupApiRoute(router, 'delete', '/:cid/watch', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -16,6 +16,7 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:cid', [...middlewares], controllers.write.categories.update);
 	setupApiRoute(router, 'delete', '/:cid', [...middlewares], controllers.write.categories.delete);
 
+	setupApiRoute(router, 'get', '/:cid/count', [...middlewares], controllers.write.categories.getTopicCount);
 	setupApiRoute(router, 'get', '/:cid/posts', [...middlewares], controllers.write.categories.getPosts);
 
 	setupApiRoute(router, 'get', '/:cid/privileges', [...middlewares], controllers.write.categories.getPrivileges);

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -19,6 +19,9 @@ module.exports = function () {
 	setupApiRoute(router, 'get', '/:cid/count', [...middlewares], controllers.write.categories.getTopicCount);
 	setupApiRoute(router, 'get', '/:cid/posts', [...middlewares], controllers.write.categories.getPosts);
 
+	setupApiRoute(router, 'put', '/:cid/watch', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);
+	setupApiRoute(router, 'delete', '/:cid/watch', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);
+
 	setupApiRoute(router, 'get', '/:cid/privileges', [...middlewares], controllers.write.categories.getPrivileges);
 	setupApiRoute(router, 'put', '/:cid/privileges/:privilege', [...middlewares, middleware.checkRequired.bind(null, ['member'])], controllers.write.categories.setPrivilege);
 	setupApiRoute(router, 'delete', '/:cid/privileges/:privilege', [...middlewares, middleware.checkRequired.bind(null, ['member'])], controllers.write.categories.setPrivilege);

--- a/src/routes/write/index.js
+++ b/src/routes/write/index.js
@@ -41,6 +41,7 @@ Write.reload = async (params) => {
 	router.use('/api/v3/posts', require('./posts')());
 	router.use('/api/v3/chats', require('./chats')());
 	router.use('/api/v3/flags', require('./flags')());
+	router.use('/api/v3/search', require('./search')());
 	router.use('/api/v3/admin', require('./admin')());
 	router.use('/api/v3/files', require('./files')());
 	router.use('/api/v3/utilities', require('./utilities')());

--- a/src/routes/write/search.js
+++ b/src/routes/write/search.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const router = require('express').Router();
+// const middleware = require('../../middleware');
+const controllers = require('../../controllers');
+const routeHelpers = require('../helpers');
+
+const { setupApiRoute } = routeHelpers;
+
+module.exports = function () {
+	// const middlewares = [];
+
+	// maybe redirect to /search/posts?
+	// setupApiRoute(router, 'post', '/', [...middlewares], controllers.write.search.TBD);
+
+	setupApiRoute(router, 'get', '/categories', [], controllers.write.search.categories);
+
+	return router;
+};

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -24,6 +24,8 @@ SocketCategories.get = async function (socket) {
 };
 
 SocketCategories.getWatchedCategories = async function (socket) {
+	sockets.warnDeprecated(socket);
+
 	const [categoriesData, ignoredCids] = await Promise.all([
 		categories.getCategoriesByPrivilege('cid:0:children', socket.uid, 'find'),
 		user.getIgnoredCategories(socket.uid),
@@ -81,7 +83,9 @@ SocketCategories.loadMore = async function (socket, data) {
 };
 
 SocketCategories.getTopicCount = async function (socket, cid) {
-	return await categories.getCategoryField(cid, 'topic_count');
+	sockets.warnDeprecated(socket, 'GET /api/v3/categories/:cid');
+	const { count } = await api.categories.getTopicCount(socket, { cid });
+	return count;
 };
 
 SocketCategories.getCategoriesByPrivilege = async function (socket, privilege) {

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -84,19 +84,26 @@ SocketCategories.loadMore = async function (socket, data) {
 
 SocketCategories.getTopicCount = async function (socket, cid) {
 	sockets.warnDeprecated(socket, 'GET /api/v3/categories/:cid');
+
 	const { count } = await api.categories.getTopicCount(socket, { cid });
 	return count;
 };
 
 SocketCategories.getCategoriesByPrivilege = async function (socket, privilege) {
+	sockets.warnDeprecated(socket);
+
 	return await categories.getCategoriesByPrivilege('categories:cid', socket.uid, privilege);
 };
 
 SocketCategories.getMoveCategories = async function (socket, data) {
+	sockets.warnDeprecated(socket);
+
 	return await SocketCategories.getSelectCategories(socket, data);
 };
 
 SocketCategories.getSelectCategories = async function (socket) {
+	sockets.warnDeprecated(socket);
+
 	const [isAdmin, categoriesData] = await Promise.all([
 		user.isAdministrator(socket.uid),
 		categories.buildForSelect(socket.uid, 'find', ['disabled', 'link']),
@@ -114,10 +121,14 @@ SocketCategories.setWatchState = async function (socket, data) {
 };
 
 SocketCategories.watch = async function (socket, data) {
+	sockets.warnDeprecated(socket);
+
 	return await ignoreOrWatch(user.watchCategory, socket, data);
 };
 
 SocketCategories.ignore = async function (socket, data) {
+	sockets.warnDeprecated(socket);
+
 	return await ignoreOrWatch(user.ignoreCategory, socket, data);
 };
 
@@ -146,6 +157,8 @@ async function ignoreOrWatch(fn, socket, data) {
 }
 
 SocketCategories.isModerator = async function (socket, cid) {
+	sockets.warnDeprecated(socket);
+
 	return await user.isModerator(socket.uid, cid);
 };
 

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -167,20 +167,14 @@ SocketCategories.isModerator = async function (socket, cid) {
 };
 
 SocketCategories.loadMoreSubCategories = async function (socket, data) {
+	sockets.warnDeprecated(socket, `GET /api/v3/categories/:cid/children`);
+
 	if (!data || !data.cid || !(parseInt(data.start, 10) >= 0)) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	const allowed = await privileges.categories.can('read', data.cid, socket.uid);
-	if (!allowed) {
-		throw new Error('[[error:no-privileges]]');
-	}
-	const category = await categories.getCategoryData(data.cid);
-	await categories.getChildrenTree(category, socket.uid);
-	const allCategories = [];
-	categories.flattenCategories(allCategories, category.children);
-	await categories.getRecentTopicReplies(allCategories, socket.uid);
-	const start = parseInt(data.start, 10);
-	return category.children.slice(start, start + category.subCategoriesPerPage);
+
+	const { categories: children } = await api.categories.getChildren(socket, data);
+	return children;
 };
 
 require('../promisify')(SocketCategories);

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -18,15 +18,9 @@ SocketCategories.getRecentReplies = async function (socket, cid) {
 };
 
 SocketCategories.get = async function (socket) {
-	async function getCategories() {
-		const cids = await categories.getCidsByPrivilege('categories:cid', socket.uid, 'find');
-		return await categories.getCategoriesData(cids);
-	}
-	const [isAdmin, categoriesData] = await Promise.all([
-		user.isAdministrator(socket.uid),
-		getCategories(),
-	]);
-	return categoriesData.filter(category => category && (!category.disabled || isAdmin));
+	sockets.warnDeprecated(socket, 'GET /api/v3/categories');
+	const { categories } = await api.categories.list(socket);
+	return categories;
 };
 
 SocketCategories.getWatchedCategories = async function (socket) {

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -112,12 +112,16 @@ SocketCategories.getSelectCategories = async function (socket) {
 };
 
 SocketCategories.setWatchState = async function (socket, data) {
+	sockets.warnDeprecated(socket, 'PUT/DELETE /api/v3/categories/:cid/watch');
+
 	if (!data || !data.cid || !data.state) {
 		throw new Error('[[error:invalid-data]]');
 	}
-	return await ignoreOrWatch(async (uid, cids) => {
-		await user.setCategoryWatchState(uid, cids, categories.watchStates[data.state]);
-	}, socket, data);
+
+	data.state = categories.watchStates[data.state];
+
+	await api.categories.setWatchState(socket, data);
+	return data.cid;
 };
 
 SocketCategories.watch = async function (socket, data) {

--- a/src/socket.io/categories.js
+++ b/src/socket.io/categories.js
@@ -4,13 +4,17 @@ const categories = require('../categories');
 const privileges = require('../privileges');
 const user = require('../user');
 const topics = require('../topics');
+const api = require('../api');
+
+const sockets = require('.');
 
 const SocketCategories = module.exports;
 
 require('./categories/search')(SocketCategories);
 
 SocketCategories.getRecentReplies = async function (socket, cid) {
-	return await categories.getRecentReplies(cid, socket.uid, 0, 4);
+	sockets.warnDeprecated(socket, 'GET /api/v3/categories/:cid/posts');
+	return await api.categories.getPosts(socket, { cid });
 };
 
 SocketCategories.get = async function (socket) {

--- a/src/socket.io/categories/search.js
+++ b/src/socket.io/categories/search.js
@@ -1,101 +1,13 @@
 'use strict';
 
-const _ = require('lodash');
-
-const meta = require('../../meta');
-const categories = require('../../categories');
-const privileges = require('../../privileges');
-const controllersHelpers = require('../../controllers/helpers');
-const plugins = require('../../plugins');
+const sockets = require('..');
+const api = require('../../api');
 
 module.exports = function (SocketCategories) {
-	// used by categorySearch module
 	SocketCategories.categorySearch = async function (socket, data) {
-		let cids = [];
-		let matchedCids = [];
-		const privilege = data.privilege || 'topics:read';
-		data.states = (data.states || ['watching', 'notwatching', 'ignoring']).map(
-			state => categories.watchStates[state]
-		);
+		sockets.warnDeprecated(socket, 'GET /api/v3/search/categories');
 
-		if (data.search) {
-			({ cids, matchedCids } = await findMatchedCids(socket.uid, data));
-		} else {
-			cids = await loadCids(socket.uid, data.parentCid);
-		}
-
-		const visibleCategories = await controllersHelpers.getVisibleCategories({
-			cids, uid: socket.uid, states: data.states, privilege, showLinks: data.showLinks, parentCid: data.parentCid,
-		});
-
-		if (Array.isArray(data.selectedCids)) {
-			data.selectedCids = data.selectedCids.map(cid => parseInt(cid, 10));
-		}
-
-		let categoriesData = categories.buildForSelectCategories(visibleCategories, ['disabledClass'], data.parentCid);
-		categoriesData = categoriesData.slice(0, 200);
-
-		categoriesData.forEach((category) => {
-			category.selected = data.selectedCids ? data.selectedCids.includes(category.cid) : false;
-			if (matchedCids.includes(category.cid)) {
-				category.match = true;
-			}
-		});
-		const result = await plugins.hooks.fire('filter:categories.categorySearch', {
-			categories: categoriesData,
-			...data,
-			uid: socket.uid,
-		});
-		return result.categories;
+		const { categories } = await api.search.categories(socket, data);
+		return categories;
 	};
-
-	async function findMatchedCids(uid, data) {
-		const result = await categories.search({
-			uid: uid,
-			query: data.search,
-			qs: data.query,
-			paginate: false,
-		});
-
-		let matchedCids = result.categories.map(c => c.cid);
-		// no need to filter if all 3 states are used
-		const filterByWatchState = !Object.values(categories.watchStates)
-			.every(state => data.states.includes(state));
-
-		if (filterByWatchState) {
-			const states = await categories.getWatchState(matchedCids, uid);
-			matchedCids = matchedCids.filter((cid, index) => data.states.includes(states[index]));
-		}
-
-		const rootCids = _.uniq(_.flatten(await Promise.all(matchedCids.map(categories.getParentCids))));
-		const allChildCids = _.uniq(_.flatten(await Promise.all(matchedCids.map(categories.getChildrenCids))));
-
-		return {
-			cids: _.uniq(rootCids.concat(allChildCids).concat(matchedCids)),
-			matchedCids: matchedCids,
-		};
-	}
-
-	async function loadCids(uid, parentCid) {
-		let resultCids = [];
-		async function getCidsRecursive(cids) {
-			const categoryData = await categories.getCategoriesFields(cids, ['subCategoriesPerPage']);
-			const cidToData = _.zipObject(cids, categoryData);
-			await Promise.all(cids.map(async (cid) => {
-				const allChildCids = await categories.getAllCidsFromSet(`cid:${cid}:children`);
-				if (allChildCids.length) {
-					const childCids = await privileges.categories.filterCids('find', allChildCids, uid);
-					resultCids.push(...childCids.slice(0, cidToData[cid].subCategoriesPerPage));
-					await getCidsRecursive(childCids);
-				}
-			}));
-		}
-
-		const allRootCids = await categories.getAllCidsFromSet(`cid:${parentCid}:children`);
-		const rootCids = await privileges.categories.filterCids('find', allRootCids, uid);
-		const pageCids = rootCids.slice(0, meta.config.categoriesPerPage);
-		resultCids = pageCids;
-		await getCidsRecursive(pageCids);
-		return resultCids;
-	}
 };

--- a/src/socket.io/index.js
+++ b/src/socket.io/index.js
@@ -333,5 +333,9 @@ Sockets.warnDeprecated = (socket, replacement) => {
 			replacement: replacement,
 		});
 	}
-	winston.warn(`[deprecated]\n ${new Error('-').stack.split('\n').slice(2, 5).join('\n')}\n     use ${replacement}`);
+	winston.warn([
+		'[deprecated]',
+		`${new Error('-').stack.split('\n').slice(2, 5).join('\n')}`,
+		`      ${replacement ? `use ${replacement}` : 'there is no replacement for this call.'}`,
+	].join('\n'));
 };


### PR DESCRIPTION
- refactor(socket.io): deprecate categories.getRecentReplies in favour of api.categories.getPosts
- refactor(socket.io): deprecate categories.get in favour of api.categories.list
- refactor(socket.io): deprecate categories.getTopicCount in favour of api.categories.getTopicCount
- chore(socket.io): deprecate categories.(isModerator|ignore|watch|getSelectCategories|getMoveCategories|getCategoriesByPrivilege)
- refactor(socket.io): deprecate categories.setWatchState in favour of api.categories.setWatchState
- refactor(socket.io): deprecate categories.loadMoreSubCategories in favour of api.categories.getChildren
