### PR TITLE
Add basic author information to topic data

### DIFF
--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -415,6 +415,12 @@ get:
                         type: string
                       userslug:
                         type: string
+                      uid:
+                        type: number
+                      fullname:
+                        type: string
+                      displayname:
+                        type: string
               - type: object
                 description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
                 properties:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -415,12 +415,15 @@ get:
                         type: string
                       userslug:
                         type: string
+                        required: false
                       uid:
                         type: number
                       fullname:
                         type: string
+                        required: false
                       displayname:
                         type: string
+                        required: false
               - type: object
                 description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
                 properties:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -410,20 +410,18 @@ get:
                     type: number
                   author:
                     type: object
+                    required: [username, uid]
                     properties:
                       username:
                         type: string
                       userslug:
                         type: string
-                        required: false
                       uid:
                         type: number
                       fullname:
                         type: string
-                        required: false
                       displayname:
                         type: string
-                        required: false
               - type: object
                 description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
                 properties:

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -408,6 +408,13 @@ get:
                     type: string
                   postIndex:
                     type: number
+                  author:
+                    type: object
+                    properties:
+                      username:
+                        type: string
+                      userslug:
+                        type: string
               - type: object
                 description: Optional properties that may or may not be present (except for `tid`, which is always present, and is only here as a hack to pass validation)
                 properties:

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -114,7 +114,8 @@ topicsController.get = async function getTopic(req, res, next) {
 
 	topicData.postIndex = postIndex;
 
-	await Promise.all([
+	const [author] = await Promise.all([
+		user.getUserFields(topicData.uid, ['username', 'userslug']),
 		buildBreadcrumbs(topicData),
 		addOldCategory(topicData, userPrivileges),
 		addTags(topicData, req, res, currentPage),
@@ -123,12 +124,12 @@ topicsController.get = async function getTopic(req, res, next) {
 		analytics.increment([`pageviews:byCid:${topicData.category.cid}`]),
 	]);
 
+	topicData.author = author;
 	topicData.pagination = pagination.create(currentPage, pageCount, req.query);
 	topicData.pagination.rel.forEach((rel) => {
 		rel.href = `${url}/topic/${topicData.slug}${rel.href}`;
 		res.locals.linkTags.push(rel);
 	});
-
 	res.render('topic', topicData);
 };
 


### PR DESCRIPTION
Related to #12192 

Adds a bit of author metadata to topicData so that themes can correctly display `DiscussionForumPosting` structured data.