### PR TITLE
Allows more file extensions

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -42,7 +42,7 @@
     "registrationApprovalType": "normal",
     "allowAccountDelete": 1,
     "privateUploads": 0,
-    "allowedFileExtensions": "png,jpg,bmp,txt",
+    "allowedFileExtensions": "png,jpg,bmp,txt,webp,webm,mp4,gif",
     "uploadRateLimitThreshold": 10,
     "uploadRateLimitCooldown": 60,
     "allowUserHomePage": 1,


### PR DESCRIPTION
For #12206 

Maybe we should have some more extensions as well? Like apng despite it is already been superseded by webp, so it is a dead in the water. I can think of zip/gz/rar maybe fit here but we want to have a safe bet first