### PR TITLE
fix: extract all pages when stripping metadata

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -103,7 +103,7 @@ image.size = async function (path) {
 };
 
 image.stripEXIF = async function (path) {
-	if (!meta.config.stripEXIFData || path.endsWith('.gif') || path.endsWith('.svg')) {
+	if (!meta.config.stripEXIFData || path.endsWith('.svg')) {
 		return;
 	}
 	try {

--- a/src/image.js
+++ b/src/image.js
@@ -115,7 +115,7 @@ image.stripEXIF = async function (path) {
 		}
 		const buffer = await fs.promises.readFile(path);
 		const sharp = requireSharp();
-		await sharp(buffer, { failOnError: true }).rotate().toFile(path);
+		await sharp(buffer, { failOnError: true, pages: -1 }).rotate().toFile(path);
 	} catch (err) {
 		winston.error(err.stack);
 	}


### PR DESCRIPTION
fixes #12207

For formats that support multiple frames or pages (GIF, WebP, TIFF, HEIF, PDF) sharp by default only uses the first frame. To process all frames, `pages: -1` argument is needed.

This PR also removes the bypass for GIF files, since while GIF files don't support EXIF metadata, they do support XMP (likely no geolocation, often just a comment. But still - I'd assume stripping metadata means stipping metadata, not just literally EXIF)
