### PR TITLE
Allows you to ignore post delay settings

### DIFF
--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -76,7 +76,7 @@ module.exports = function (Topics) {
 		return topicData.tid;
 	};
 
-	Topics.post = async function (data) {
+	Topics.post = async function (data, shouldIgnoreDelays) {
 		data = await plugins.hooks.fire('filter:topic.post', data);
 		const { uid } = data;
 
@@ -113,7 +113,7 @@ module.exports = function (Topics) {
 
 		await guestHandleValid(data);
 		if (!data.fromQueue) {
-			await user.isReadyToPost(uid, data.cid);
+			await user.isReadyToPost(uid, data.cid, shouldIgnoreDelays);
 		}
 
 		const tid = await Topics.create(data);

--- a/src/user/posts.js
+++ b/src/user/posts.js
@@ -6,7 +6,7 @@ const privileges = require('../privileges');
 const groups = require('../groups');
 
 module.exports = function (User) {
-	User.isReadyToPost = async function (uid, cid) {
+	User.isReadyToPost = async function (uid, cid, shouldIgnoreDelays) {
 		await isReady(uid, cid, 'lastposttime');
 	};
 
@@ -28,7 +28,7 @@ module.exports = function (User) {
 		}
 	};
 
-	async function isReady(uid, cid, field) {
+	async function isReady(uid, cid, field, shouldIgnoreDelays) {
 		if (parseInt(uid, 10) === 0) {
 			return;
 		}
@@ -47,6 +47,10 @@ module.exports = function (User) {
 		}
 
 		await User.checkMuted(uid);
+
+		if (shouldIgnoreDelays) {
+			return;
+		}
 
 		const now = Date.now();
 		if (now - userData.joindate < meta.config.initialPostDelay * 1000) {


### PR DESCRIPTION
There is a whole category of plugins that may want to create several topics due to user action. The internal Topic.post API throws exceptions depending on many factors, permissions, etc. While permissions are such a big problem and its fine, the time interval between posts - both global and for new users is already a bit of a problem or automatic posting.
So this PR for fix this problem for my development and future plugins developers.