### PR TITLE
feat: add playsinline video attribute

### DIFF
--- a/src/posts/parse.js
+++ b/src/posts/parse.js
@@ -22,7 +22,7 @@ let sanitizeConfig = {
 		a: ['href', 'name', 'hreflang', 'media', 'rel', 'target', 'type'],
 		img: ['alt', 'height', 'ismap', 'src', 'usemap', 'width', 'srcset'],
 		iframe: ['height', 'name', 'src', 'width'],
-		video: ['autoplay', 'controls', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width'],
+		video: ['autoplay', 'playsinline', 'controls', 'height', 'loop', 'muted', 'poster', 'preload', 'src', 'width'],
 		audio: ['autoplay', 'controls', 'loop', 'muted', 'preload', 'src'],
 		source: ['type', 'src', 'srcset', 'sizes', 'media', 'height', 'width'],
 		embed: ['height', 'src', 'type', 'width'],


### PR DESCRIPTION
The `playsinline` attribute is needed for preventing running videos fullscreen.

See:
https://css-tricks.com/what-does-playsinline-mean-in-web-video/
https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari#3030250