### PR TITLE
fix: don't expose user existence if visitor can't view users

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -161,20 +161,20 @@ middleware.privateTagListing = helpers.try(async (req, res, next) => {
 });
 
 middleware.exposeGroupName = helpers.try(async (req, res, next) => {
-	await expose('groupName', groups.getGroupNameByGroupSlug, 'slug', req, res, next);
+	await expose('groupName', groups.getGroupNameByGroupSlug, middleware.canViewGroups, 'slug', req, res, next);
 });
 
 middleware.exposeUid = helpers.try(async (req, res, next) => {
-	await expose('uid', user.getUidByUserslug, 'userslug', req, res, next);
+	await expose('uid', user.getUidByUserslug, middleware.canViewUsers, 'userslug', req, res, next);
 });
 
-async function expose(exposedField, method, field, req, res, next) {
+async function expose(exposedField, method, canViewMethod, field, req, res, next) {
 	if (!req.params.hasOwnProperty(field)) {
 		return next();
 	}
 	const value = await method(String(req.params[field]).toLowerCase());
 	if (!value) {
-		middleware.canViewUsers(req, res, () => next('route'));
+		canViewMethod(req, res, () => next('route'));
 		return;
 	}
 

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -174,7 +174,7 @@ async function expose(exposedField, method, field, req, res, next) {
 	}
 	const value = await method(String(req.params[field]).toLowerCase());
 	if (!value) {
-		next('route');
+		middleware.canViewUsers(req, res, () => next('route'));
 		return;
 	}
 


### PR DESCRIPTION
resolves #12432

This is a slightly hacky way to fix this, but I'm not entirely sure if there aren't any plugins depending on `exposeUid/exposeGroupName` short-circuiting to a 404 on lack of the relevant value (which obvious solutions would need to change), while this ensures it still goes directly to 404 if the visitor has the relevant privilege while going to notAllowed otherwise.

This way also required changes to just the middleware and not any of its consumers.

Also, this fixes the same issue for groups because the code was shared already.