### PR TITLE
fix(docker): support all previously used env variables correctly

### DIFF
--- a/install/docker/entrypoint.sh
+++ b/install/docker/entrypoint.sh
@@ -53,11 +53,11 @@ copy_or_link_files() {
   esac
 
   # Check if source and destination files are the same
-  if [ "$(realpath "$src_dir/package.json")" != "$(realpath "$dest_dir/package.json")" ]; then
+  if [ "$(realpath "$src_dir/package.json")" != "$(realpath "$dest_dir/package.json")" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
     cp "$src_dir/package.json" "$dest_dir/package.json"
   fi
 
-  if [ "$(realpath "$src_dir/$lock_file")" != "$(realpath "$dest_dir/$lock_file")" ]; then
+  if [ "$(realpath "$src_dir/$lock_file")" != "$(realpath "$dest_dir/$lock_file")" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
     cp "$src_dir/$lock_file" "$dest_dir/$lock_file"
   fi
 

--- a/install/docker/entrypoint.sh
+++ b/install/docker/entrypoint.sh
@@ -7,6 +7,7 @@ set_defaults() {
   export CONFIG_DIR="${CONFIG_DIR:-/opt/config}"
   export CONFIG="$CONFIG_DIR/config.json"
   export NODEBB_INIT_VERB="${NODEBB_INIT_VERB:-install}"
+  export NODEBB_BUILD_VERB="${NODEBB_BUILD_VERB:-build}"
   export START_BUILD="${START_BUILD:-${FORCE_BUILD_BEFORE_START:-false}}"
   export SETUP="${SETUP:-}"
   export PACKAGE_MANAGER="${PACKAGE_MANAGER:-npm}"
@@ -102,7 +103,7 @@ build_forum() {
   local config="$1"
   local start_build="$2"
   local package_hash=$(md5sum install/package.json | head -c 32)
-  if [ package_hash = "$(cat $CONFIG_DIR/install_hash.md5)" ]; then
+  if [ "$package_hash" = "$(cat $CONFIG_DIR/install_hash.md5 || true)" ]; then
       echo "package.json was updated. Upgrading..."
       /usr/src/app/nodebb upgrade --config="$config" || {
           echo "Failed to build NodeBB. Exiting..."


### PR DESCRIPTION
`NODEBB_BUILD_VERB` was not set (breaking usage of `FORCE_BUILD_BEFORE_START`) and `OVERRIDE_UPDATE_LOCK` ended up not doing anything... Restored original functionality.