### PR TITLE
Allow setting value of Express 'trust proxy' from config

### DIFF
--- a/src/webserver.js
+++ b/src/webserver.js
@@ -264,10 +264,12 @@ async function listen() {
 		}
 	}
 	port = parseInt(port, 10);
+	
 	const trust_proxy = nconf.get('trust_proxy');
-	if ((port !== 80 && port !== 443) || trust_proxy) {
-		winston.info('🤝 Enabling \'trust proxy\'');
-		app.set('trust proxy', trust_proxy || true);
+	if (trust_proxy == null && ![80,443].includes(port)) trust_proxy = true;
+	if (trust_proxy) {
+		winston.info(`🤝 Setting 'trust proxy' to ${JSON.stringify(trust_proxy)}`);
+		app.set('trust proxy', trust_proxy);
 	}
 
 	if ((port === 80 || port === 443) && process.env.NODE_ENV !== 'development') {

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -264,9 +264,9 @@ async function listen() {
 		}
 	}
 	port = parseInt(port, 10);
-	
-	const trust_proxy = nconf.get('trust_proxy');
-	if (trust_proxy == null && ![80,443].includes(port)) trust_proxy = true;
+
+	let trust_proxy = nconf.get('trust_proxy');
+	if (trust_proxy == null && ![80, 443].includes(port)) trust_proxy = true;
 	if (trust_proxy) {
 		winston.info(`🤝 Setting 'trust proxy' to ${JSON.stringify(trust_proxy)}`);
 		app.set('trust proxy', trust_proxy);

--- a/src/webserver.js
+++ b/src/webserver.js
@@ -264,9 +264,10 @@ async function listen() {
 		}
 	}
 	port = parseInt(port, 10);
-	if ((port !== 80 && port !== 443) || nconf.get('trust_proxy') === true) {
+	const trust_proxy = nconf.get('trust_proxy');
+	if ((port !== 80 && port !== 443) || trust_proxy) {
 		winston.info('🤝 Enabling \'trust proxy\'');
-		app.enable('trust proxy');
+		app.set('trust proxy', trust_proxy || true);
 	}
 
 	if ((port === 80 || port === 443) && process.env.NODE_ENV !== 'development') {


### PR DESCRIPTION
Pass the value of trust_proxy from the nodebb config to the Express ['trust proxy'](https://expressjs.com/en/4x/api.html#trust.proxy.options.table) setting because it may be necessary to configure this to prevent IP spoofing.

It may be a good idea to log the value as well but I don't know if winston logger can log objects.