### PR TITLE
fix: guard against directional override characters in translator args

### DIFF
--- a/public/src/modules/translator.common.js
+++ b/public/src/modules/translator.common.js
@@ -260,7 +260,7 @@ module.exports = function (utils, load, warn) {
 				return Promise.all(argsToTranslate).then(function (translatedArgs) {
 					let out = translated;
 					translatedArgs.forEach(function (arg, i) {
-						let escaped = arg.replace(/%(?=\d)/g, '&#37;').replace(/\\,/g, '&#44;');
+						let escaped = `<bdi>${arg.replace(/%(?=\d)/g, '&#37;').replace(/\\,/g, '&#44;')}</bdi>`;
 						// fix double escaped translation keys, see https://github.com/NodeBB/NodeBB/issues/9206
 						escaped = escaped.replace(/&amp;lsqb;/g, '&lsqb;')
 							.replace(/&amp;rsqb;/g, '&rsqb;');


### PR DESCRIPTION
Encountered a remote user who had the [Right-to-Left Override](https://unicode-explorer.com/c/202E) unicode character in their display name, which caused some fun stuff to happen in the notifications dropdown:

![image](https://github.com/user-attachments/assets/6cfa8a7d-c221-404d-90ad-5b348fd7b651)

One suggested solution was to wrap those unknown strings with [the `<bdi>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi).

Considering that we don't know where these issues can crop up (usually happens when user-generated strings are used in inline text), this PR proactively wraps every translator argument with `<bdi>`.

It might be a bit overkill, though, hence the PR.

----

The most targeted fix for this would be to update the notifications dropdown translation strings to wrap arguments with `<bdi>` directly in the source string. However, this doesn't guard against future occurrences of this bug.

Another targeted fix would be to proactively scan for the RTL override character in `modifyUser` and remove it :smirk: 