### PR TITLE
fix: Revise package hash check in Docker entrypoint.sh

### DIFF
--- a/install/docker/entrypoint.sh
+++ b/install/docker/entrypoint.sh
@@ -103,7 +103,7 @@ build_forum() {
   local config="$1"
   local start_build="$2"
   local package_hash=$(md5sum install/package.json | head -c 32)
-  if [ "$package_hash" = "$(cat $CONFIG_DIR/install_hash.md5 || true)" ]; then
+  if [ "$package_hash" != "$(cat $CONFIG_DIR/install_hash.md5 || true)" ]; then
       echo "package.json was updated. Upgrading..."
       /usr/src/app/nodebb upgrade --config="$config" || {
           echo "Failed to build NodeBB. Exiting..."


### PR DESCRIPTION
- In the build_forum() function, the file install_hash.md5 is intended to track the content of package.json and detect changes that imply the need to run 'nodebb upgrade'.
- The check to compare the current checksum of package.json to the one saved in install_hash.md5 is reversed.  The "package.json was updated" branch is taken when the hashes are the same, not when they are different.
- When install_hash.md5 does not exist, the comparison value becomes the null string, which never matches the checksum of package.json. As a result, the code always takes the "No changes in package.json" branch and returns from the function without creating install_hash.md5.  As a result, install_hash.md5 never gets created on a new installation.
- Revised build_forum() to use "not equals" when comparing the two checksums.  This causes it to run 'nodebb upgrade' when the checksums are different, and also when install_hash.md5 does not yet exist.  If the checksum saved in install_hash.md5 matches the current package.json checksum, it proceeds to either the "Build before start" case or the "No changes" case.