### PR TITLE
(fix) Return relative asset URL instead of absolute asset url

### DIFF
--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -222,12 +222,13 @@ function addTags(categoryData, res, currentPage) {
 	];
 
 	if (categoryData.backgroundImage) {
-		if (!categoryData.backgroundImage.startsWith('http')) {
-			categoryData.backgroundImage = url + categoryData.backgroundImage;
+		var backgroundImage = categoryData.backgroundImage;
+		if (!backgroundImage.startsWith('http')) {
+			backgroundImage = url + backgroundImage;
 		}
 		res.locals.metaTags.push({
 			property: 'og:image',
-			content: categoryData.backgroundImage,
+			content: backgroundImage,
 			noEscape: true,
 		});
 	}

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -222,9 +222,10 @@ function addTags(categoryData, res, currentPage) {
 	];
 
 	if (categoryData.backgroundImage) {
-		var backgroundImage = categoryData.backgroundImage;
+		let {backgroundImage} = categoryData;
+		backgroundImage = utils.decodeHTMLEntities(backgroundImage);
 		if (!backgroundImage.startsWith('http')) {
-			backgroundImage = url + backgroundImage;
+			backgroundImage = url + backgroundImage.replace(new RegExp(`^${nconf.get('relative_path')}`), '');
 		}
 		res.locals.metaTags.push({
 			property: 'og:image',


### PR DESCRIPTION
My nodeBB instance is running on localhost:3000/communities
If I do a GET request to `http://localhost:3000/communities/api/category/5`. In the root of the object I get a backgroundImage Url 'http://localhost:3000/communities&#x2F;communities&#x2F;assets&#x2F;uploads&#x2F;category&#x2F'
I expect it to be `&#x2F;communities&#x2F;assets&#x2F;uploads&#x2F;category&#x2F`
So the path is doubled and the url isn't consistently escaped

All topic objects in topic have the correct relative url. So I think this is not intended and a bug.
So I propose this fix for the bug. I'm not used to the code style of this repo so I'm really open for feedback.