### PR TITLE
fix: respect user pagination settings in infinite scroll (#13765)

### DIFF
--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -126,7 +126,7 @@ categoriesAPI.getTopics = async (caller, data) => {
 		throw new Error('[[error:no-privileges]]');
 	}
 
-	const infScrollTopicsPerPage = 20;
+	const infScrollTopicsPerPage = settings.topicsPerPage;
 	const sort = data.sort || data.categoryTopicSort || meta.config.categoryTopicSort || 'recently_replied';
 
 	let start = Math.max(0, parseInt(data.after || 0, 10));


### PR DESCRIPTION
- Changed hardcoded topicsPerPage value of 20 to use settings.topicsPerPage
- Allows infinite scroll to respect user's configured page size preference
- Consistent with pagination handling in other controllers (category.js, recent.js, etc)
- Validates against admin's maxTopicsPerPage setting
- Fixes issue where all users were limited to 20 topics per request regardless of settings


Fixes #13765