### PR TITLE
ci: drop ARM v7 from docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,9 +26,6 @@ jobs:
           - os: ubuntu-24.04-arm
             platforms: linux/arm64
             required: true
-          - os: ubuntu-24.04-arm
-            platforms: linux/arm/v7
-            required: false
     continue-on-error: ${{ !matrix.required }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Removed optional ARM v7 (32 bit) platform from the workflow due to lack of support from Node and very limited usefulness.

As the platform had been flaky in the past, this part of the workflow was already optional and didn't cause it to fail. So this is just the next step here.