### PR TITLE
fix: support substring matching in ACP user search

### DIFF
--- a/src/controllers/admin/users.js
+++ b/src/controllers/admin/users.js
@@ -139,6 +139,11 @@ usersController.search = async function (req, res) {
 				return [];
 			}
 			query = String(query).toLowerCase();
+
+			if (!query.startsWith('*')) {
+				query = `*${query}`;
+			}
+
 			if (!query.endsWith('*')) {
 				query += '*';
 			}


### PR DESCRIPTION
**Fixes:** #14056 

**Problem:**
ACP user search only returned results when the query matched the beginning of a username/email.
Example: searching for `kamal` would not find `fardinkamal`.

**Root cause:**
The findUids function in `usersController.search` built the glob pattern as "query*", which translates to:
- MongoDB: ^query (regex anchored to start → prefix match only)
- Redis: ZSCAN with query* glob → prefix match only

**Fix:**
Wrap the query with wildcards so the pattern becomes "*query*":
- MongoDB: buildMatchQuery("*query*") → unanchored regex query → true substring match
- Redis: ZSCAN with *query* → substring glob match

⚠️ Performance note:
This change trades performance for correctness.
The original prefix pattern `query*` on Redis could exit the ZSCAN early once past the lexicographic range.
With *query*, Redis must scan the entire sorted set — O(N) in the number of users.

On MongoDB, the $regex query without a leading anchor also cannot use an index and does a full collection scan.

**Testing:**
- User with username `fardinkamal`: searching `kamal` now returns the user
- Prefix searches (fardin) continue to work as before