### PR TITLE
fix: update account controllers to look up `uid:<uid>:(posts|topics)` zsets directly instead of iterating through local cids

### DIFF
--- a/src/controllers/accounts/posts.js
+++ b/src/controllers/accounts/posts.js
@@ -31,8 +31,7 @@ const templateToData = {
 		noItemsFoundKey: '[[user:has-no-posts]]',
 		crumb: '[[global:posts]]',
 		getSets: async function (callerUid, userData) {
-			const cids = await categories.getCidsByPrivilege('categories:cid', callerUid, 'topics:read');
-			return cids.map(c => `cid:${c}:uid:${userData.uid}:pids`);
+			return `uid:${userData.uid}:posts`;
 		},
 	},
 	'account/upvoted': {
@@ -143,8 +142,7 @@ const templateToData = {
 		noItemsFoundKey: '[[user:has-no-topics]]',
 		crumb: '[[global:topics]]',
 		getSets: async function (callerUid, userData) {
-			const cids = await categories.getCidsByPrivilege('categories:cid', callerUid, 'topics:read');
-			return cids.map(c => `cid:${c}:uid:${userData.uid}:tids`);
+			return `uid:${userData.uid}:topics`;
 		},
 	},
 	'account/shares': {


### PR DESCRIPTION
I am not entirely sure _why_ the cids are iterated through, hence the PR. However, since the controller logic was added 7(!!) years ago, ~~I think it may pre-date the uid-specific post/topic sets~~

Code archaeology:

* a39f0ef592d721bd2246bd578b85c96474dd78b4 changes controller from reading `set` (which expands to `uid:<uid>:<set>` to iterating over cids.
* It looks to be part of a larger user module refactor (a51ec591ee91012d6f091382572069e1495ab402). Unsure why this was done but there was probably a reason :smirk: 

lmk if I am on the wrong track here.