### PR TITLE
fix(mongo): Improve replica set connection resilience

### DIFF
--- a/src/database/mongo.js
+++ b/src/database/mongo.js
@@ -60,7 +60,11 @@ mongoModule.questions = [
 ];
 
 mongoModule.init = async function (opts) {
-	client = await connection.connect(opts || nconf.get('mongo'));
+	const mongoOpts = { ...(opts || nconf.get('mongo')) };
+	if (mongoOpts.uri && mongoOpts.uri.includes('replicaSet=') && !mongoOpts.uri.includes('directConnection=')) {
+		mongoOpts.uri = `${mongoOpts.uri}${mongoOpts.uri.includes('?') ? '&' : '?'}directConnection=false`;
+	}
+	client = await connection.connect(mongoOpts);
 	mongoModule.client = client.db();
 };
 


### PR DESCRIPTION
## Summary

This commit fixes an issue where NodeBB fails to start if a MongoDB replica set member is unavailable. The MongoDB driver connection URI is modified to explicitly include 'directConnection=false' for replica set configurations. This ensures the driver uses the correct mode for topology discovery, improving resilience in environments like Kubernetes.

## Changes

- **src/database/mongo.js**: In `mongoModule.init`, modify the MongoDB connection options to explicitly set `directConnection=false` in the URI for replica set connections. This improves connection stability in environments like Kubernetes where a replica set member might be temporarily unavailable.

## Related Issue

Closes #13823

