### PR TITLE
fix: handle Follow.object as plain URI string in inbox handler

### DIFF
--- a/src/activitypub/inbox.js
+++ b/src/activitypub/inbox.js
@@ -488,7 +488,7 @@ inbox.follow = async (req) => {
 	const { actor, object, id: followId } = req.body;
 
 	// Sanity checks
-	const { type, id } = await helpers.resolveLocalId(object.id);
+	const { type, id } = await helpers.resolveLocalId(object.id || object);
 	if (type === 'application') {
 		return activitypub.relays.handshake(req.body);
 	} else if (!['category', 'user'].includes(type)) {


### PR DESCRIPTION
## Summary

The Follow handler in `src/activitypub/inbox.js` line 491 accesses `object.id` without handling
the case where `object` is a plain URI string. Per the ActivityPub spec, `Follow.object` can be
either a string URI or an object with an `id` property. Most implementations (Mastodon, Lemmy,
PieFed, Flipboard) send plain URI strings.

When `object` is a string, `object.id` is `undefined`, `resolveLocalId` returns
`{ type: null, id: null }`, and the Follow is silently rejected.

## Fix

Use the same `object.id || object` pattern already used elsewhere in the inbox handler:
- Line 264 (delete handler)
- Line 405 (announce handler)

## Note

NodeBB's own outgoing Follow activities in `src/activitypub/out.js` also use a plain URI string
for `object`, so this is consistent with NodeBB's own output format.
