### PR TITLE
fix: don't prepend relative_path to absolute URLs in getProfilePictures

### DIFF
--- a/src/socket.io/user/picture.js
+++ b/src/socket.io/user/picture.js
@@ -39,7 +39,7 @@ module.exports = function (SocketUser) {
 		userPictures.forEach((picture) => {
 			list.pictures.push({
 				type: 'uploaded',
-				url: `${nconf.get('relative_path')}${picture}`,
+				url: picture.startsWith('http') ? picture : `${nconf.get('relative_path')}${picture}`,
 				text: '[[user:uploaded-picture]]',
 			});
 		});


### PR DESCRIPTION
#14092 introduced uid:{uid}:profile:pictures and prepends relative_path to all stored URLs in getProfilePictures:                                                                                                          
   
url: `${nconf.get('relative_path')}${picture}`,                                                                                                                                                                            
                                                                                                                                                                                                                             
Upload plugins like nodebb-plugin-cloudinary store full absolute URLs (e.g. https://media-cdn.example.com/image/upload/forum/abc.jpg). With a relative_path of /forum, this produces a broken URL:                         
`/forumhttps://media-cdn.example.com/...`                                                                                                                                                                               
                                                                                                                                                
This adds the same startsWith('http') guard used elsewhere in the codebase (e.g. user/data.js:261, groups/data.js:85, controllers/accounts/helpers.js:124).                                                                

NodeBB version: v4.10.2