### PR TITLE
Fix skip to content target on topic pages

### DIFF
--- a/node_modules/nodebb-theme-harmony/templates/header.tpl
+++ b/node_modules/nodebb-theme-harmony/templates/header.tpl
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="{function.localeToHTML, userLang, defaultLang}" {{{if languageDirection}}}data-dir="{languageDirection}" style="direction: {languageDirection};"{{{end}}}>
+<head>
+	<title>{browserTitle}</title>
+	{{{each metaTags}}}{function.buildMetaTag}{{{end}}}
+	<link rel="stylesheet" type="text/css" href="{relative_path}/assets/client{{{if bootswatchSkin}}}-{bootswatchSkin}{{{end}}}{{{ if (languageDirection=="rtl") }}}-rtl{{{ end }}}.css?{config.cache-buster}" />
+	{{{each linkTags}}}{function.buildLinkTag}{{{end}}}
+
+	<script>
+		var config = JSON.parse('{{configJSON}}');
+		var app = {
+			user: JSON.parse('{{userJSON}}')
+		};
+		document.documentElement.style.setProperty('--panel-offset', `0px`);
+	</script>
+
+	{{{if useCustomHTML}}}
+	{{customHTML}}
+	{{{end}}}
+	{{{if useCustomCSS}}}
+	<style>{{customCSS}}</style>
+	{{{end}}}
+</head>
+
+<body class="{bodyClass} skin-{{{if bootswatchSkin}}}{bootswatchSkin}{{{else}}}noskin{{{end}}}">
+	<a class="visually-hidden-focusable position-absolute top-0 start-0 p-3 m-3 bg-body" style="z-index: 1021;" href="#main-content">[[global:skip-to-content]]</a>
+
+	{{{ if config.theme.topMobilebar }}}
+	<!-- IMPORT partials/mobile-header.tpl -->
+	{{{ end }}}
+
+	<div class="layout-container d-flex justify-content-between pb-4 pb-md-0">
+		<!-- IMPORT partials/sidebar-left.tpl -->
+
+		<main id="panel" class="d-flex flex-column gap-3 flex-grow-1 mt-3" style="min-width: 0;">
+			<!-- IMPORT partials/header/brand.tpl -->
+			<div class="container-lg px-md-4 d-flex flex-column gap-3 h-100 mb-5 mb-lg-0" id="content">
+			<!-- IMPORT partials/noscript/warning.tpl -->
+			<!-- IMPORT partials/noscript/message.tpl -->

--- a/node_modules/nodebb-theme-harmony/templates/topic.tpl
+++ b/node_modules/nodebb-theme-harmony/templates/topic.tpl
@@ -1,0 +1,160 @@
+<!-- IMPORT partials/breadcrumbs-json-ld.tpl -->
+{{{ if config.theme.enableBreadcrumbs }}}
+<!-- IMPORT partials/breadcrumbs.tpl -->
+{{{ end }}}
+{{{ if widgets.header.length }}}
+<div data-widget-area="header">
+{{{each widgets.header}}}
+{{widgets.header.html}}
+{{{end}}}
+</div>
+{{{ end }}}
+
+<div class="flex-fill" itemid="{url}" itemscope itemtype="https://schema.org/DiscussionForumPosting">
+	<meta itemprop="headline" content="{escape(titleRaw)}">
+	<meta itemprop="text" content="{escape(titleRaw)}">
+	<meta itemprop="url" content="{url}">
+	<meta itemprop="datePublished" content="{timestampISO}">
+	<meta itemprop="dateModified" content="{lastposttimeISO}">
+	<div itemprop="author" itemscope itemtype="https://schema.org/Person">
+		<meta itemprop="name" content="{author.username}">
+		{{{ if author.userslug }}}<meta itemprop="url" content="{config.relative_path}/user/{author.userslug}">{{{ end }}}
+	</div>
+	<div itemprop="interactionStatistic" itemscope itemtype="https://schema.org/InteractionCounter">
+		<meta itemprop="interactionType" content="https://schema.org/CommentAction">
+		<meta itemprop="userInteractionCount" content="{increment(postcount, "-1")}">
+	</div>
+	<div itemprop="interactionStatistic" itemscope itemtype="https://schema.org/InteractionCounter">
+		<meta itemprop="interactionType" content="https://schema.org/LikeAction">
+		<meta itemprop="userInteractionCount" content="{upvotes}">
+	</div>
+
+	<div class="d-flex flex-column gap-3">
+		<div class="d-flex gap-2 flex-wrap flex-column flex-md-row {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ else }}}justify-content-between{{{ end }}}">
+			<div class="d-flex flex-column gap-3 flex-md-shrink-50">
+				<h1 id="main-content" tabindex="-1" component="post/header" class="tracking-tight fw-semibold fs-3 mb-0 text-break {{{ if config.theme.centerHeaderElements }}}text-center{{{ end }}}">
+					<span class="topic-title" component="topic/title">{title}</span>
+				</h1>
+
+				<div class="topic-info d-flex gap-2 align-items-center flex-wrap {{{ if config.theme.centerHeaderElements }}}justify-content-center{{{ end }}}">
+					<span component="topic/labels" class="d-flex gap-2 {{{ if (!scheduled && (!pinned && (!locked && (!icons.length && (!oldCid || (oldCid == "-1")))))) }}}hidden{{{ end }}}">
+						<span component="topic/scheduled" class="badge border border-gray-300 text-body {{{ if !scheduled }}}hidden{{{ end }}}">
+							<i class="fa fa-clock-o"></i> [[topic:scheduled]]
+						</span>
+						<span component="topic/pinned" class=" badge border border-gray-300 text-body {{{ if (scheduled || !pinned) }}}hidden{{{ end }}}">
+							<i class="fa fa-thumb-tack"></i> {{{ if !pinExpiry }}}[[topic:pinned]]{{{ else }}}[[topic:pinned-with-expiry, {isoTimeToLocaleString(./pinExpiryISO, config.userLang)}]]{{{ end }}}
+						</span>
+						<span component="topic/locked" class="badge border border-gray-300 text-body {{{ if !locked }}}hidden{{{ end }}}">
+							<i class="fa fa-lock"></i> [[topic:locked]]
+						</span>
+						<a component="topic/moved" href="{config.relative_path}/category/{oldCid}" class="badge border border-gray-300 text-body text-decoration-none {{{ if (!oldCid || (oldCid == "-1")) }}}hidden{{{ end }}}">
+							<i class="fa fa-arrow-circle-right"></i> {{{ if privileges.isAdminOrMod }}}[[topic:moved-from, {oldCategory.name}]]{{{ else }}}[[topic:moved]]{{{ end }}}
+						</a>
+						{{{each icons}}}<span class="lh-1">{@value}</span>{{{end}}}
+					</span>
+					{buildCategoryLabel(category, "a", "border")}
+					<div data-tid="{./tid}" component="topic/tags" class="lh-1 tags tag-list d-flex flex-wrap hidden-xs hidden-empty gap-2"><!-- IMPORT partials/topic/tags.tpl --></div>
+					<div class="d-flex gap-2" component="topic/stats"><!-- IMPORT partials/topic/stats.tpl --></div>
+
+					{{{ if (!feeds:disableRSS && rssFeedUrl) }}}
+					<a class="badge border border-gray-300 text-body text-decoration-none d-flex align-items-center align-self-stretch" target="_blank" href="{rssFeedUrl}" title="[[global:rss-feed]]"><i class="fa fa-rss fa-sm text-muted lh-1"></i></a>
+					{{{ end }}}
+				</div>
+			</div>
+			<div class="flex-shrink-1 d-flex flex-wrap gap-2 align-items-start mt-2 hidden-empty {{{ if greaterthan(thumbs.length, "4") }}}thumbs-collapsed{{{ end }}}" component="topic/thumb/list"><!-- IMPORT partials/topic/thumbs.tpl --></div>
+		</div>
+
+		<div class="row mb-4 mb-lg-0">
+			<div class="topic {{{ if widgets.sidebar.length }}}col-lg-9 col-sm-12{{{ else }}}col-lg-12{{{ end }}}">
+				<!-- IMPORT partials/post_bar.tpl -->
+				{{{ if merger }}}
+				<!-- IMPORT partials/topic/merged-message.tpl -->
+				{{{ end }}}
+				{{{ if forker }}}
+				<!-- IMPORT partials/topic/forked-message.tpl -->
+				{{{ end }}}
+				{{{ if !scheduled }}}
+				<!-- IMPORT partials/topic/deleted-message.tpl -->
+				{{{ end }}}
+
+				<div class="d-flex gap-0 gap-lg-5">
+					<div class="posts-container" style="min-width: 0;">
+						<ul component="topic" class="posts timeline list-unstyled p-0 py-3" style="min-width: 0;" data-tid="{tid}" data-cid="{cid}">
+						{{{ each posts }}}
+							<li component="post" class="{{{ if (./index != 0) }}}pt-4{{{ end }}} {{{ if posts.deleted }}}deleted{{{ end }}} {{{ if posts.selfPost }}}self-post{{{ end }}} {{{ if posts.topicOwnerPost }}}topic-owner-post{{{ end }}}" <!-- IMPORT partials/data/topic.tpl -->>
+								<a component="post/anchor" data-index="{./index}" id="{increment(./index, "1")}"></a>
+								<meta itemprop="datePublished" content="{./timestampISO}">
+								{{{ if ./editedISO }}}
+								<meta itemprop="dateModified" content="{./editedISO}">
+								{{{ end }}}
+
+								<!-- IMPORT partials/topic/post.tpl -->
+							</li>
+							{{{ if (config.topicPostSort != "most_votes") }}}
+							{{{ each ./events}}}<!-- IMPORT partials/topic/event.tpl -->{{{ end }}}
+							{{{ end }}}
+						{{{ end }}}
+						</ul>
+						{{{ if browsingUsers }}}
+						<div class="visible-xs">
+							<!-- IMPORT partials/topic/browsing-users.tpl -->
+							<hr/>
+						</div>
+						{{{ end }}}
+						{{{ if config.theme.enableQuickReply }}}
+						<!-- IMPORT partials/topic/quickreply.tpl -->
+						{{{ end }}}
+						{{{ if !config.loggedIn }}}
+						<!-- IMPORT partials/topic/guest-cta.tpl -->
+						{{{ end }}}
+					</div>
+					<div class="d-flex d-none d-lg-block flex-grow-1 mt-2">
+						<div class="sticky-top" style="{{{ if config.theme.topicSidebarTools }}}top:2rem;{{{ else }}}top:6rem; {{{ end }}} z-index:1;">
+							<div class="d-flex flex-column gap-3 align-items-end">
+								{{{ if config.theme.topicSidebarTools }}}
+								<div class="topic-sidebar-tools d-flex flex-column gap-2" style="width: 170px;">
+									<!-- IMPORT partials/topic/reply-button.tpl -->
+									<!-- IMPORT partials/topic/mark-unread.tpl -->
+									<!-- IMPORT partials/topic/watch.tpl -->
+									<!-- IMPORT partials/topic/sort.tpl -->
+									<!-- IMPORT partials/topic/crosspost.tpl -->
+									<!-- IMPORT partials/topic/tools.tpl -->
+								</div>
+								{{{ end }}}
+								{{{ if config.theme.topicSidebarTools }}}<hr class="my-0" style="min-width: 170px;"/>{{{ end }}}
+								<!-- IMPORT partials/topic/navigator.tpl -->
+								{{{ if config.theme.topicSidebarTools }}}<hr class="my-0" style="min-width: 170px;" />{{{ end }}}
+								{{{ if browsingUsers }}}
+								<div class="d-flex flex-column ps-2 hidden-xs" style="min-width: 170px;">
+								<!-- IMPORT partials/topic/browsing-users.tpl -->
+								</div>
+								{{{ end }}}
+							</div>
+						</div>
+					</div>
+				</div>
+
+				{{{ if config.usePagination }}}
+				<!-- IMPORT partials/paginator.tpl -->
+				{{{ end }}}
+			</div>
+			<div data-widget-area="sidebar" class="col-lg-3 col-sm-12 {{{ if !widgets.sidebar.length }}}hidden{{{ end }}}">
+			{{{each widgets.sidebar}}}
+			{{widgets.sidebar.html}}
+			{{{end}}}
+			</div>
+		</div>
+	</div>
+</div>
+
+<div data-widget-area="footer">
+{{{each widgets.footer}}}
+{{widgets.footer.html}}
+{{{end}}}
+</div>
+
+{{{ if !config.usePagination }}}
+<noscript>
+<!-- IMPORT partials/paginator.tpl -->
+</noscript>
+{{{ end }}}


### PR DESCRIPTION
This updates the skip to content behavior on topic pages so keyboard users jump directly to the topic title/main content instead of landing before the breadcrumb navigation.
