### PR TITLE
fix: bypass self-edit reputation checks for privileged users

### DIFF
--- a/src/controllers/accounts/edit.js
+++ b/src/controllers/accounts/edit.js
@@ -19,8 +19,6 @@ editController.get = async function (req, res, next) {
 	const {
 		username,
 		userslug,
-		isSelf,
-		reputation,
 		groups: _groups,
 		groupTitleArray,
 		allowMultipleBadges,
@@ -37,8 +35,8 @@ editController.get = async function (req, res, next) {
 	userData.maximumAboutMeLength = meta.config.maximumAboutMeLength;
 	userData.allowMultipleBadges = meta.config.allowMultipleBadges === 1;
 	userData.allowAccountDelete = meta.config.allowAccountDelete === 1;
-	userData.allowAboutMe = !isSelf || !!meta.config['reputation:disabled'] || reputation >= meta.config['min:rep:aboutme'];
-	userData.allowSignature = canUseSignature && (!isSelf || !!meta.config['reputation:disabled'] || reputation >= meta.config['min:rep:signature']);
+	userData.allowAboutMe = accountHelpers.meetsMinReputation(userData, 'min:rep:aboutme');
+	userData.allowSignature = canUseSignature && accountHelpers.meetsMinReputation(userData, 'min:rep:signature');
 	userData.defaultAvatar = user.getDefaultAvatar();
 
 	userData.groups = _groups.filter(g => g && g.userTitleEnabled && !groups.isPrivilegeGroup(g.name) && g.name !== 'registered-users');

--- a/src/controllers/accounts/helpers.js
+++ b/src/controllers/accounts/helpers.js
@@ -22,6 +22,13 @@ const relative_path = nconf.get('relative_path');
 
 const helpers = module.exports;
 
+helpers.meetsMinReputation = function (userData, setting) {
+	return !userData.isSelf ||
+		userData.isAdminOrGlobalModerator ||
+		!!meta.config['reputation:disabled'] ||
+		userData.reputation >= meta.config[setting];
+};
+
 helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {}) {
 	const uid = await user.getUidByUserslug(userslug);
 	if (!uid) {
@@ -93,8 +100,8 @@ helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {})
 	userData.hasPrivateChat = results.hasPrivateChat;
 	userData.iconBackgrounds = results.iconBackgrounds;
 	userData.showHidden = results.canEdit; // remove in v1.19.0
-	userData.allowProfilePicture = !userData.isSelf || !!meta.config['reputation:disabled'] || userData.reputation >= meta.config['min:rep:profile-picture'];
-	userData.allowCoverPicture = !userData.isSelf || !!meta.config['reputation:disabled'] || userData.reputation >= meta.config['min:rep:cover-picture'];
+	userData.allowProfilePicture = helpers.meetsMinReputation(userData, 'min:rep:profile-picture');
+	userData.allowCoverPicture = helpers.meetsMinReputation(userData, 'min:rep:cover-picture');
 	userData.allowProfileImageUploads = meta.config.allowProfileImageUploads;
 	userData.allowedProfileImageExtensions = user.getAllowedProfileImageExtensions().map(ext => `.${ext}`).join(', ');
 	userData.maximumProfileImageSize = meta.config.maximumProfileImageSize;

--- a/src/user/profile.js
+++ b/src/user/profile.js
@@ -278,6 +278,9 @@ module.exports = function (User) {
 		if (!isSelf || meta.config['reputation:disabled']) {
 			return;
 		}
+		if (await User.isAdminOrGlobalMod(callerUid)) {
+			return;
+		}
 		const reputation = await User.getUserField(uid, 'reputation');
 		if (reputation < meta.config[setting]) {
 			throw new Error(`[[error:not-enough-reputation-${setting.replace(/:/g, '-')}, ${meta.config[setting]}]]`);


### PR DESCRIPTION
## Problem

Privileged users such as administrators and global moderators could edit other users' profile images, but could still be blocked from editing their own profile fields when a minimum reputation requirement was configured.

In practice, this created an inconsistent self-edit experience:

- an admin could manage another user's profile picture
- the same admin could be blocked from changing their own profile picture
- server-side reputation checks for self-edited profile fields did not consistently account for privileged self-edit permissions
- the UI could still hide or disable self-edit controls based on reputation alone

This was especially visible for settings controlled by min:rep:*, including profile picture, cover picture, about me, and signature.

## Solution

This patch aligns privileged self-edit behavior across both server-side validation and the account UI.

### Server-side

- User.checkMinReputation() now bypasses self-edit reputation checks for administrators and global moderators
- this keeps the existing reputation thresholds for regular users, while allowing privileged users to edit their own profile fields consistently

### UI

- adds a shared meetsMinReputation() helper for account pages
- uses that helper when computing access to:
  - profile picture
  - cover picture
  - about me
  - signature

This avoids the mismatch where the backend allows the action but the UI still blocks it.

## Result

Privileged users editing their own profiles now follow their edit permissions first, instead of being incorrectly blocked by minimum reputation settings.

Regular users are still governed by the configured reputation thresholds as before.
