### PR TITLE
refactor tests psql fix

### DIFF
--- a/src/database/postgres.js
+++ b/src/database/postgres.js
@@ -83,9 +83,13 @@ SELECT EXISTS(SELECT *
 		EXISTS(SELECT *
 				FROM "information_schema"."routines"
 			   WHERE "routine_schema" = 'public'
-				 AND "routine_name" = 'nodebb_get_sorted_set_members_withscores') d`);
+				 AND "routine_name" = 'nodebb_get_sorted_set_members_withscores') d,
+       EXISTS(SELECT *
+                FROM "information_schema"."views"
+               WHERE "table_schema" = 'public'
+                 AND "table_name" = 'legacy_object_live') e`);
 
-	if (res.rows[0].a && res.rows[0].b && res.rows[0].c && res.rows[0].d) {
+	if (res.rows[0].a && res.rows[0].b && res.rows[0].c && res.rows[0].d && res.rows[0].e) {
 		return;
 	}
 
@@ -265,6 +269,14 @@ SELECT "data"->>'_key',
 				await client.query(`DROP TABLE "objects" CASCADE`);
 				await client.query(`DROP FUNCTION "fun__objects__expireAt"() CASCADE`);
 			}
+			await client.query(`
+CREATE VIEW "legacy_object_live" AS
+SELECT "_key", "type"
+  FROM "legacy_object"
+ WHERE "expireAt" IS NULL
+    OR "expireAt" > CURRENT_TIMESTAMP`);
+		} else if (!res.rows[0].e) {
+			// If the tables exist but the view is missing, create only the view
 			await client.query(`
 CREATE VIEW "legacy_object_live" AS
 SELECT "_key", "type"


### PR DESCRIPTION
- **refactor: break out test/api.js into separate files**
- **refactor: schema backreference tests so they run in one it block instead of being dynamically generated**
- **docs: add 'id' and 'core' to values sent by ACP>Settings>Navigation in enabled, ensured that 'enabled.enabled' is always boolean**
- **fix: break out all IIFEs inside test/api/schema.js into separate internal functions, for organizational purposes**
- **fix: add 'dropdownContent' to enabled as well**
- **fix: debug logs**
- **chore: lint**
- **test: replaced hardcoded 5s timeout with export file existance polling**
- **refactor: replace hand-rolled compare() function with sturdier ajv dependency**
- **fix: remove parts of test/api.js that have been moved to other files**
- **fix: ensure legacy_object_live view is created if missing**
