### PR TITLE
fix: ensure legacy_object_live view is created if missing

### DIFF
--- a/src/database/postgres.js
+++ b/src/database/postgres.js
@@ -83,9 +83,13 @@ SELECT EXISTS(SELECT *
 		EXISTS(SELECT *
 				FROM "information_schema"."routines"
 			   WHERE "routine_schema" = 'public'
-				 AND "routine_name" = 'nodebb_get_sorted_set_members_withscores') d`);
+				 AND "routine_name" = 'nodebb_get_sorted_set_members_withscores') d,
+       EXISTS(SELECT *
+                FROM "information_schema"."views"
+               WHERE "table_schema" = 'public'
+                 AND "table_name" = 'legacy_object_live') e`);
 
-	if (res.rows[0].a && res.rows[0].b && res.rows[0].c && res.rows[0].d) {
+	if (res.rows[0].a && res.rows[0].b && res.rows[0].c && res.rows[0].d && res.rows[0].e) {
 		return;
 	}
 
@@ -265,6 +269,14 @@ SELECT "data"->>'_key',
 				await client.query(`DROP TABLE "objects" CASCADE`);
 				await client.query(`DROP FUNCTION "fun__objects__expireAt"() CASCADE`);
 			}
+			await client.query(`
+CREATE VIEW "legacy_object_live" AS
+SELECT "_key", "type"
+  FROM "legacy_object"
+ WHERE "expireAt" IS NULL
+    OR "expireAt" > CURRENT_TIMESTAMP`);
+		} else if (!res.rows[0].e) {
+			// If the tables exist but the view is missing, create only the view
 			await client.query(`
 CREATE VIEW "legacy_object_live" AS
 SELECT "_key", "type"


### PR DESCRIPTION
Update the PostgreSQL database initialization logic to explicitly check
for the existence of the 'legacy_object_live' view. Previously, if
the migration functions already existed, the upgrade process would
return early even if the view was missing, causing 'relation does not exist'
errors.

Assisted-By: Gemma 4 26B A4B
