### PR TITLE
fix: use configured forum URL for shared links

### DIFF
--- a/public/openapi/read/admin/config.yaml
+++ b/public/openapi/read/admin/config.yaml
@@ -11,6 +11,8 @@ get:
           schema:
             type: object
             properties:
+              url:
+                type: string
               relative_path:
                 type: string
               upload_url:

--- a/public/openapi/read/config.yaml
+++ b/public/openapi/read/config.yaml
@@ -11,6 +11,8 @@ get:
           schema:
             type: object
             properties:
+              url:
+                type: string
               relative_path:
                 type: string
               upload_url:

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -261,7 +261,7 @@ define('forum/chats', [
 				const copyEl = $(this);
 				const mid = copyEl.attr('data-mid');
 				if (mid) {
-					doCopy(copyEl, `${config.url || window.location.origin}/message/${mid}`);
+					doCopy(copyEl, `${config.url}/message/${mid}`);
 				}
 			});
 

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -261,7 +261,7 @@ define('forum/chats', [
 				const copyEl = $(this);
 				const mid = copyEl.attr('data-mid');
 				if (mid) {
-					doCopy(copyEl, `${window.location.origin}/message/${mid}`);
+					doCopy(copyEl, `${config.url || window.location.origin}/message/${mid}`);
 				}
 			});
 

--- a/public/src/modules/share.js
+++ b/public/src/modules/share.js
@@ -3,7 +3,6 @@
 
 define('share', ['hooks', 'translator'], function (hooks, translator) {
 	const share = {};
-	const baseUrl = config.url || (window.location.protocol + '//' + window.location.host + config.relative_path);
 
 	share.addShareHandlers = function (name) {
 		function openShare(url, urlToPost, width, height) {
@@ -89,7 +88,7 @@ define('share', ['hooks', 'translator'], function (hooks, translator) {
 	function getPostUrl(clickedElement) {
 		const pid = clickedElement.parents('[data-pid]').attr('data-pid');
 		return pid ?
-			`${baseUrl}/post/${pid}` :
+			`${config.url}/post/${pid}` :
 			window.location.href;
 	}
 

--- a/public/src/modules/share.js
+++ b/public/src/modules/share.js
@@ -3,7 +3,7 @@
 
 define('share', ['hooks', 'translator'], function (hooks, translator) {
 	const share = {};
-	const baseUrl = window.location.protocol + '//' + window.location.host;
+	const baseUrl = config.url || (window.location.protocol + '//' + window.location.host + config.relative_path);
 
 	share.addShareHandlers = function (name) {
 		function openShare(url, urlToPost, width, height) {
@@ -89,7 +89,7 @@ define('share', ['hooks', 'translator'], function (hooks, translator) {
 	function getPostUrl(clickedElement) {
 		const pid = clickedElement.parents('[data-pid]').attr('data-pid');
 		return pid ?
-			`${baseUrl + config.relative_path}/post/${pid}` :
+			`${baseUrl}/post/${pid}` :
 			window.location.href;
 	}
 

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -26,6 +26,7 @@ const fontawesome_version = utils.getFontawesomeVersion();
 
 apiController.loadConfig = async function (req) {
 	const config = {
+		url: nconf.get('url'),
 		relative_path,
 		upload_url,
 		asset_base_url,

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -14,6 +14,7 @@ const utils = require('../utils');
 
 const apiController = module.exports;
 
+const url = nconf.get('url');
 const relative_path = nconf.get('relative_path');
 const upload_url = nconf.get('upload_url');
 const asset_base_url = nconf.get('asset_base_url');
@@ -26,7 +27,7 @@ const fontawesome_version = utils.getFontawesomeVersion();
 
 apiController.loadConfig = async function (req) {
 	const config = {
-		url: nconf.get('url'),
+		url,
 		relative_path,
 		upload_url,
 		asset_base_url,


### PR DESCRIPTION
## Summary
- expose the configured forum URL to client config
- use the configured forum URL when building copied chat message links
- use the configured forum URL for shared post links and document the new config field

## Problem
Copied chat message links were built relative to the current page origin. When the forum is served from a subdomain, that produced links against the main domain instead of the configured forum URL.

## Testing
- node --check src/controllers/api.js
- node --check public/src/client/chats.js
- node --check public/src/modules/share.js
- checked public/openapi/read/config.yaml for diagnostics in VS Code
