### PR TITLE
feat: allow owners to move misplaced topics

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -14,6 +14,7 @@
     "postEditDuration": 0,
     "newbiePostEditDuration": 3600,
     "postDeleteDuration": 0,
+    "movingTopicsMaxPosts": 5,
     "enablePostHistory": 1,
     "topicBacklinks": 1,
     "postCacheSize": 20971520,

--- a/public/language/en-GB/admin/settings/post.json
+++ b/public/language/en-GB/admin/settings/post.json
@@ -27,6 +27,7 @@
 	"restrictions.post-length": "Post Length",
 	"restrictions.days-until-stale": "Days until topic is considered stale",
 	"restrictions.stale-help": "If a topic is considered \"stale\", then a warning will be shown to users who attempt to reply to that topic. (set to 0 to disable)",
+	"restrictions.move-own-topic-max-posts": "Maximum number of posts in a topic after which users are disallowed to move their own topic (set to 0 to disable)",
 	"timestamp": "Timestamp",
 	"timestamp.cut-off": "Date cut-off (in days)",
 	"timestamp.cut-off-help": "Dates &amp; times will be shown in a relative manner (e.g. \"3 hours ago\" / \"5 days ago\"), and localised into various\n\t\t\t\t\tlanguages. After a certain point, this text can be switched to display the localised date itself\n\t\t\t\t\t(e.g. 5 Nov 2016 15:30).<br /><em>(Default: <code>30</code>, or one month). Set to 0 to always display dates, leave blank to always display relative times.</em>",

--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -269,6 +269,7 @@
 	"cant-move-to-same-topic": "Can't move post to same topic!",
 	"cant-move-topic-to-same-category": "Can't move topic to the same category!",
 	"cant-move-topic-to-from-remote-categories": "You cannot move topics in or out of remote categories; consider cross-posting instead.",
+	"cant-move-topic-too-many-posts": "Cannot move a topic with more than %1 posts.",
 
 	"cannot-block-self": "You cannot block yourself!",
 	"cannot-block-privileged": "You cannot block administrators or global moderators",

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -148,6 +148,8 @@ get:
                         type: boolean
                       deletable:
                         type: boolean
+                      canMoveOwnTopic:
+                        type: boolean
                       view_deleted:
                         type: boolean
                       view_scheduled:

--- a/public/src/client/topic/move.js
+++ b/public/src/client/topic/move.js
@@ -32,7 +32,7 @@ define('forum/topic/move', [
 			dropdownEl.addClass('dropup');
 
 			const privs = ajaxify.data && ajaxify.data.privileges;
-			const isAdminOrMod = !!(privs && privs.isAdminOrMod);
+			const isAdminOrMod = !!(privs && privs.isAdminOrMod) || app.user.isAdmin || app.user.isGlobalMod;
 			categorySelector.init(dropdownEl, {
 				onSelect: onCategorySelected,
 				privilege: isAdminOrMod ? 'moderate' : 'topics:create',

--- a/public/src/client/topic/move.js
+++ b/public/src/client/topic/move.js
@@ -31,9 +31,11 @@ define('forum/topic/move', [
 			const dropdownEl = modal.find('[component="category-selector"]');
 			dropdownEl.addClass('dropup');
 
+			const privs = ajaxify.data && ajaxify.data.privileges;
+			const isAdminOrMod = !!(privs && privs.isAdminOrMod);
 			categorySelector.init(dropdownEl, {
 				onSelect: onCategorySelected,
-				privilege: 'moderate',
+				privilege: isAdminOrMod ? 'moderate' : 'topics:create',
 				localOnly: true,
 				disabledCids: Move.currentCid ? [Move.currentCid] : [],
 			});

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -298,22 +298,39 @@ topicsAPI.bump = async (caller, { tid }) => {
 };
 
 topicsAPI.move = async (caller, { tid, cid }) => {
-	const canMove = await privileges.categories.isAdminOrMod(cid, caller.uid);
-	if (!canMove) {
-		throw new Error('[[error:no-privileges]]');
+	const tids = Array.isArray(tid) ? tid : [tid];
+	const isAdminOrMod = await privileges.categories.isAdminOrMod(cid, caller.uid);
+
+	let maxOwnerPosts = 0;
+	if (!isAdminOrMod) {
+		const [canCreate, canRead] = await Promise.all([
+			privileges.categories.can('topics:create', cid, caller.uid),
+			privileges.categories.can('topics:read', cid, caller.uid),
+		]);
+		if (!canCreate || !canRead) {
+			throw new Error('[[error:no-privileges]]');
+		}
+		maxOwnerPosts = parseInt(meta.config.movingTopicsMaxPosts, 10);
+		if (Number.isNaN(maxOwnerPosts)) {
+			maxOwnerPosts = 5;
+		}
 	}
 
-	const tids = Array.isArray(tid) ? tid : [tid];
 	const uids = await user.getUidsFromSet('users:online', 0, -1);
 	const cids = [parseInt(cid, 10)];
 
 	await batch.processArray(tids, async (tids) => {
 		await Promise.all(tids.map(async (tid) => {
-			const canMove = await privileges.topics.isAdminOrMod(tid, caller.uid);
-			if (!canMove) {
-				throw new Error('[[error:no-privileges]]');
+			const topicData = await topics.getTopicFields(tid, ['tid', 'cid', 'uid', 'mainPid', 'slug', 'deleted', 'locked', 'postcount']);
+			if (!isAdminOrMod) {
+				const isOwner = parseInt(topicData.uid, 10) === parseInt(caller.uid, 10);
+				if (!isOwner || topicData.locked || topicData.deleted) {
+					throw new Error('[[error:no-privileges]]');
+				}
+				if (maxOwnerPosts > 0 && topicData.postcount > maxOwnerPosts) {
+					throw new Error(`[[error:cant-move-topic-too-many-posts, ${maxOwnerPosts}]]`);
+				}
 			}
-			const topicData = await topics.getTopicFields(tid, ['tid', 'cid', 'mainPid', 'slug', 'deleted']);
 			topicData.toCid = cid;
 			if (!cids.includes(topicData.cid)) {
 				cids.push(topicData.cid);

--- a/src/api/topics.js
+++ b/src/api/topics.js
@@ -303,10 +303,7 @@ topicsAPI.move = async (caller, { tid, cid }) => {
 
 	let maxOwnerPosts = 0;
 	if (!isAdminOrMod) {
-		const [canCreate, canRead] = await Promise.all([
-			privileges.categories.can('topics:create', cid, caller.uid),
-			privileges.categories.can('topics:read', cid, caller.uid),
-		]);
+		const [canCreate, canRead] = await privileges.categories.can(['topics:create', 'topics:read'], cid, caller.uid);
 		if (!canCreate || !canRead) {
 			throw new Error('[[error:no-privileges]]');
 		}

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -23,7 +23,7 @@ privsTopics.get = async function (tid, uid) {
 		'posts:upvote', 'posts:downvote',
 		'posts:delete', 'posts:view_deleted', 'read', 'purge',
 	];
-	const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled']);
+	const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled', 'postcount']);
 	const [userPrivileges, isAdministrator, isModerator, disabled, topicTools] = await Promise.all([
 		helpers.isAllowedTo(privs, uid, topicData.cid),
 		user.isAdministrator(uid),
@@ -43,6 +43,19 @@ privsTopics.get = async function (tid, uid) {
 	const mayReply = privsTopics.canViewDeletedScheduled(topicData, {}, false, privData['topics:schedule']);
 	const hasTools = topicTools.tools.length > 0;
 
+	let maxOwnerPosts = parseInt(meta.config.movingTopicsMaxPosts, 10);
+	if (Number.isNaN(maxOwnerPosts)) {
+		maxOwnerPosts = 5;
+	}
+	const exceedsOwnerMoveLimit = maxOwnerPosts > 0 && topicData.postcount > maxOwnerPosts;
+	const canMoveOwnTopic = !!(
+		isOwner &&
+		!isAdminOrMod &&
+		!topicData.locked &&
+		!topicData.deleted &&
+		!exceedsOwnerMoveLimit
+	);
+
 	return await plugins.hooks.fire('filter:privileges.topics.get', {
 		'topics:reply': (privData['topics:reply'] && ((!topicData.locked && mayReply) || isModerator)) || isAdministrator,
 		'topics:read': privData['topics:read'] || isAdministrator,
@@ -58,9 +71,10 @@ privsTopics.get = async function (tid, uid) {
 		read: privData.read || isAdministrator,
 		purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,
 
-		view_thread_tools: editable || deletable || hasTools,
+		view_thread_tools: editable || deletable || hasTools || canMoveOwnTopic,
 		editable: editable,
 		deletable: deletable,
+		canMoveOwnTopic: canMoveOwnTopic,
 		view_deleted: isAdminOrMod || isOwner || privData['posts:view_deleted'],
 		view_scheduled: privData['topics:schedule'] || isAdministrator,
 		isAdminOrMod: isAdminOrMod,

--- a/src/views/admin/settings/post.tpl
+++ b/src/views/admin/settings/post.tpl
@@ -112,6 +112,11 @@
 				</div>
 
 				<div class="mb-3">
+					<label class="form-label" for="movingTopicsMaxPosts">[[admin/settings/post:restrictions.move-own-topic-max-posts]]</label>
+					<input id="movingTopicsMaxPosts" type="text" class="form-control" value="5" data-field="movingTopicsMaxPosts">
+				</div>
+
+				<div class="mb-3">
 					<label class="form-label" for="topicStaleDays">[[admin/settings/post:restrictions.days-until-stale]]</label>
 					<input id="topicStaleDays" type="text" class="form-control" value="60" data-field="topicStaleDays">
 					<p class="form-text">

--- a/src/views/partials/topic/topic-menu-list.tpl
+++ b/src/views/partials/topic/topic-menu-list.tpl
@@ -46,6 +46,12 @@
 <li class="dropdown-divider"></li>
 {{{ end }}}
 
+{{{ if (privileges.canMoveOwnTopic && isNumber(cid)) }}}
+<li>
+	<a component="topic/move" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem"><i class="fa fa-fw fa-arrows text-secondary"></i> [[topic:thread-tools.move]]</a>
+</li>
+{{{ end }}}
+
 {{{ if privileges.deletable }}}
 <li {{{ if deleted }}}hidden{{{ end }}}>
 	<a component="topic/delete" href="#" class="dropdown-item rounded-1 d-flex align-items-center gap-2 {{{ if deleted }}}hidden{{{ end }}}" role="menuitem"><i class="fa fa-fw fa-trash-o text-secondary"></i> [[topic:thread-tools.delete]]</a>


### PR DESCRIPTION
## Summary
- allow topic owners to move their own topics when they have create/read access in the destination category
- add an admin setting to cap this ability by topic post count, defaulting to 5 posts
- show a clear error when the topic is too large to move

## Problem
Users sometimes open a topic in the wrong place by mistake, and once that happens they cannot move it themselves. This change lets topic owners correct that mistake in small topics without granting them moderator-level move privileges.

## Testing
- validated changed files with VS Code diagnostics
- verified the final diff only keeps English locale additions for the new strings