### PR TITLE
fix: hide current category from move topic selector

### DIFF
--- a/public/src/client/topic/move.js
+++ b/public/src/client/topic/move.js
@@ -35,6 +35,7 @@ define('forum/topic/move', [
 				onSelect: onCategorySelected,
 				privilege: 'moderate',
 				localOnly: true,
+				excludeCids: Move.currentCid ? [Move.currentCid] : [],
 			});
 
 			const dropdown = new bootstrap.Dropdown(dropdownEl.find('button'));

--- a/public/src/client/topic/move.js
+++ b/public/src/client/topic/move.js
@@ -35,7 +35,7 @@ define('forum/topic/move', [
 				onSelect: onCategorySelected,
 				privilege: 'moderate',
 				localOnly: true,
-				excludeCids: Move.currentCid ? [Move.currentCid] : [],
+				disabledCids: Move.currentCid ? [Move.currentCid] : [],
 			});
 
 			const dropdown = new bootstrap.Dropdown(dropdownEl.find('button'));

--- a/public/src/modules/categorySearch.js
+++ b/public/src/modules/categorySearch.js
@@ -88,6 +88,10 @@ define('categorySearch', ['alerts', 'bootstrap', 'api'], function (alerts, boots
 
 		function renderList(categories) {
 			const selectedCids = options.selectedCids.map(String);
+			if (Array.isArray(options.excludeCids) && options.excludeCids.length) {
+				const excludeCids = options.excludeCids.map(String);
+				categories = categories.filter(c => !excludeCids.includes(String(c.cid)));
+			}
 			categories.forEach(function (c) {
 				c.selected = selectedCids.includes(String(c.cid));
 			});

--- a/public/src/modules/categorySearch.js
+++ b/public/src/modules/categorySearch.js
@@ -88,12 +88,12 @@ define('categorySearch', ['alerts', 'bootstrap', 'api'], function (alerts, boots
 
 		function renderList(categories) {
 			const selectedCids = options.selectedCids.map(String);
-			if (Array.isArray(options.excludeCids) && options.excludeCids.length) {
-				const excludeCids = options.excludeCids.map(String);
-				categories = categories.filter(c => !excludeCids.includes(String(c.cid)));
-			}
+			const disabledCids = (options.disabledCids || []).map(String);
 			categories.forEach(function (c) {
 				c.selected = selectedCids.includes(String(c.cid));
+				if (disabledCids.includes(String(c.cid))) {
+					c.disabledClass = true;
+				}
 			});
 			app.parseAndTranslate(options.template, {
 				categoryItems: categories.slice(0, 200),


### PR DESCRIPTION
## Summary
- The category a topic currently belongs to was shown in the move-topic category selector and selecting it produced an error.
- Adds an `excludeCids` option to `categorySearch` that filters categories out of the rendered list.
- `forum/topic/move` now passes the topic's current `cid` via `excludeCids` so it cannot be picked as a destination.
