### PR TITLE
fix: relax newbieChatMessageDelay default from 120s to 3s

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -21,7 +21,7 @@
     "chatEditDuration": 0,
     "chatDeleteDuration": 0,
     "chatMessageDelay": 2000,
-    "newbieChatMessageDelay": 120000,
+    "newbieChatMessageDelay": 3000,
     "notificationSendDelay": 60,
     "newbieReputationThreshold": 3,
     "postQueue": 1,

--- a/src/upgrades/4.11.0/relax-newbie-chat-delay-default.js
+++ b/src/upgrades/4.11.0/relax-newbie-chat-delay-default.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const db = require('../../database');
+
+module.exports = {
+	name: 'Relax newbie chat delay default',
+	timestamp: Date.UTC(2026, 4, 20),
+	method: async function () {
+		const current = await db.getObjectField('config', 'newbieChatMessageDelay');
+		if (parseInt(current, 10) === 120000) {
+			await db.setObjectField('config', 'newbieChatMessageDelay', 3000);
+		}
+	},
+};


### PR DESCRIPTION
Fixes #13092

The previous default of 120,000ms (2 minutes) between messages for new users was far too restrictive for normal chat usage. Reduced to 3,000ms (3 seconds) to still throttle spambots without blocking legitimate users sending follow-up messages.

Also added an upgrade script so existing installations with the old default value are automatically migrated.