### PR TITLE
fix: preserve markdown links in translator escape

### DIFF
--- a/public/src/modules/translator.common.js
+++ b/public/src/modules/translator.common.js
@@ -463,9 +463,58 @@ module.exports = function (utils, load, warn) {
 		 * @returns {string}
 		 */
 		Translator.escape = function escape(text) {
-			return typeof text === 'string' ?
-				text.replace(/\[\[/g, '&lsqb;&lsqb;').replace(/\]\]/g, '&rsqb;&rsqb;') :
-				text;
+			if (typeof text !== 'string') {
+				return text;
+			}
+
+			const len = text.length;
+			let cursor = 0;
+			let lastBreak = 0;
+			let out = '';
+
+			while (cursor < len) {
+				if (text.slice(cursor, cursor + 2) !== '[[') {
+					cursor += 1;
+					continue;
+				}
+
+				const tokenStart = cursor;
+				let tokenEnd = -1;
+				let level = 1;
+				cursor += 2;
+
+				while (cursor < len && tokenEnd === -1) {
+					const sub = text.slice(cursor, cursor + 2);
+					if (sub === '[[') {
+						level += 1;
+						cursor += 2;
+					} else if (sub === ']]') {
+						level -= 1;
+						cursor += 2;
+						if (level === 0) {
+							tokenEnd = cursor;
+						}
+					} else {
+						cursor += 1;
+					}
+				}
+
+				out += text.slice(lastBreak, tokenStart);
+
+				if (tokenEnd === -1) {
+					out += '&lsqb;&lsqb;';
+					lastBreak = tokenStart + 2;
+					cursor = lastBreak;
+				} else {
+					out += text.slice(tokenStart, tokenEnd)
+						.replace(/\[\[/g, '&lsqb;&lsqb;')
+						.replace(/\]\]/g, '&rsqb;&rsqb;');
+					lastBreak = tokenEnd;
+				}
+			}
+
+			out += text.slice(lastBreak);
+			return out;
 		};
 
 		/**

--- a/test/translator.js
+++ b/test/translator.js
@@ -351,22 +351,21 @@ describe('Translator static methods', () => {
 			done();
 		});
 
-		// TODO: fixing this causes other issues with escaping tx strings
-		// it('should not escape markdown links', (done) => {
-		// 	assert.strictEqual(
-		// 		Translator.escape('[link text [test]](https://example.org)'),
-		// 		'[link text [test]](https://example.org)'
-		// 	);
-		// 	done();
-		// });
+		it('should not escape markdown links', (done) => {
+			assert.strictEqual(
+				Translator.escape('[link text [test]](https://example.org)'),
+				'[link text [test]](https://example.org)'
+			);
+			done();
+		});
 
 		// TODO: fixing this causes other issues with escaping tx strings
 		// it('should not unescape markdown links', (done) => {
-		// 	assert.strictEqual(
-		// 		Translator.unescape('&lsqblink text &lsqbtest&rsqb;&rsqb;(https://example.org)'),
-		// 		'&lsqblink text &lsqbtest&rsqb;&rsqb;(https://example.org)'
-		// 	);
-		// 	done();
+		//  assert.strictEqual(
+		//      Translator.unescape('&lsqblink text &lsqbtest&rsqb;&rsqb;(https://example.org)'),
+		//      '&lsqblink text &lsqbtest&rsqb;&rsqb;(https://example.org)'
+		//  );
+		//  done();
 		// });
 	});
 


### PR DESCRIPTION
## Problem

`Translator.escape` escaped every `]]` sequence, even when it was not part of a NodeBB translation token. That broke markdown links whose label ended with a closing bracket, such as `[link text [test]](https://example.org)`, by converting the label's closing brackets to entities.

Fixes #13887.

## Solution

I changed `Translator.escape` to scan for balanced `[[...]]` translation tokens and only escape bracket pairs inside those matched tokens. Standalone `]]` sequences are now left alone, while existing translation-pattern escaping still works, including nested translation tokens.

I also enabled the existing markdown-link regression test for this edge case.

## Testing

- `npx eslint public/src/modules/translator.common.js test/translator.js`
- Ran a focused Node assertion script covering existing translation escape behavior, the markdown-link regression, and nested translation tokens
- `npx mocha test/translator.js` currently needs a local NodeBB `config.json`/database setup and failed before running tests in this checkout