### PR TITLE
fix: crash and spurious job restarts when saving ACP settings

### DIFF
--- a/public/src/admin/settings/email.js
+++ b/public/src/admin/settings/email.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings'], function (ace, alerts) {
+define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings', 'hooks'], function (ace, alerts, Settings, hooks) {
 	const Email = {};
 	let emailEditor;
 
@@ -11,10 +11,8 @@ define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings'], function
 		configureEmailEditor();
 		handleDigestHourChange();
 
-		$(window).off('action:admin.settingsLoaded', onSettingsLoaded)
-			.on('action:admin.settingsLoaded', onSettingsLoaded);
-		$(window).off('action:admin.settingsSaved', onSettingsSaved)
-			.on('action:admin.settingsSaved', onSettingsSaved);
+		hooks.onPage('action:admin.settingsLoaded', onSettingsLoaded);
+		hooks.onPage('action:admin.settingsSaved', onSettingsSaved);
 	};
 
 	function onSettingsLoaded() {

--- a/src/cron.js
+++ b/src/cron.js
@@ -36,7 +36,8 @@ exports.addJob = async function (options) {
 		throw new Error('[cron] Invalid options');
 	}
 	if (Object.hasOwn(jobs, name)) {
-		throw new Error('[cron] Job with that name already exists');
+		jobs[name].stop();
+		delete jobs[name];
 	}
 
 	const job = new CronJob(cronTime, async function () {


### PR DESCRIPTION
## Problem

Two related bugs cause issues when saving settings in the ACP:

**1. Crash on re-registration of cron jobs**

Saving the Email settings page emits \`admin.user.restartJobs\`, which calls
\`User.startJobs()\`. That calls \`User.stopJobs()\`, which stops the digest jobs
but only removes them from the local registry in \`src/user/jobs.js\`. The
registry in \`src/cron.js\` (added in #14068) still holds the old names, so
re-adding \`digest.daily\` throws as an uncaught exception and crashes the
worker:

\`\`\`
error: uncaughtException: [cron] Job with that name already exists
    at exports.addJob (/var/www/nodebb/src/cron.js:39:9)
    at startDigestJob (/var/www/nodebb/src/user/jobs.js:45:29)
    at User.startJobs (/var/www/nodebb/src/user/jobs.js:25:9)
\`\`\`

**2. \`restartJobs\` leaking to other ACP pages**

\`admin/settings/email.js\` binds \`onSettingsSaved\` via \`$(window).on(...)\`,
which persists across SPA navigation. After visiting the Email settings page,
every subsequent ACP settings save in the same session also emits
\`admin.user.restartJobs\` — restarting digest jobs unnecessarily (and, before
fix 1, crashing the process on every save in any settings page).

## Fix

- \`src/cron.js\`: when a job is registered under an existing name, stop the old
  instance and replace it instead of throwing. This also covers \`user:reset:clean\`
  and \`user:autoApprove\`, which \`stopJobs()\` never removes from the cron registry.
  The \`cronJob:<name>\` DB records used by the ACP cron page are overwritten on
  re-registration anyway, so the display stays correct.

- \`public/src/admin/settings/email.js\`: replace \`$(window).off/.on\` with
  \`hooks.onPage\`, which automatically unregisters the listener on
  \`action:ajaxify.start\` (page navigation).