### PR TITLE
fix: bind hooks module in admin/settings/email define() (empty email settings page)

### DIFF
--- a/public/src/admin/settings/email.js
+++ b/public/src/admin/settings/email.js
@@ -1,7 +1,7 @@
 'use strict';
 
 
-define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings', 'hooks'], function (ace, alerts, hooks) {
+define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings', 'hooks'], function (ace, alerts, settings, hooks) {
 	const Email = {};
 	let emailEditor;
 


### PR DESCRIPTION
Fixes #14351

### Problem

`public/src/admin/settings/email.js` declares **four** AMD dependencies but the factory function only takes **three** parameters:

```js
define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings', 'hooks'], function (ace, alerts, hooks) {
```

Because RequireJS binds positionally, the `hooks` parameter resolves to the **`admin/settings`** module (3rd dependency), while the real `hooks` module (4th dependency) is never bound. `Email.init()` then calls `hooks.onPage(...)`, which doesn't exist on `admin/settings`, and throws `TypeError: hooks.onPage is not a function`.

That aborts the page init chain, so `admin/settings.js`'s `Settings.prepare()` never copies saved values into the `[data-field]` inputs — the **entire admin email settings page renders empty** (SMTP host/port/user, "From" address/name, etc.), even though the values are stored correctly and email still sends.

This was introduced in v4.13.1 when the `'hooks'` dependency and `hooks` parameter were added without inserting a parameter for the existing `'admin/settings'` dependency (v4.13.0 had 3 deps / 2 params and was consistent).

### Fix

Add the missing `settings` parameter so each dependency binds to the correct module:

```js
define('admin/settings/email', ['ace/ace', 'alerts', 'admin/settings', 'hooks'], function (ace, alerts, settings, hooks) {
```

`settings` is unused, matching how `admin/settings` was an unbound dependency in v4.13.0.

### Testing

- Before: navigating to `/admin/settings/email` logs `TypeError: hooks.onPage is not a function` and all fields are blank.
- After: the page loads and all email settings fields populate from the saved configuration.
