### PR TITLE
fix(chat): wire copy link/text handlers in minimized chat window

### DIFF
--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -328,6 +328,7 @@ define('chat', [
 			Chats.addTextareaResizeHandler(chatModal);
 			Chats.addTypingHandler(chatModal, roomId);
 			Chats.addIPHandler(chatModal);
+			Chats.addCopyTextLinkHandler(chatModal);
 			Chats.addTooltipHandler(chatModal);
 			Chats.addUploadHandler({
 				dragDropAreaEl: chatModal.find('.modal-content'),
@@ -431,6 +432,7 @@ define('chat', [
 				Chats.addTextareaResizeHandler(chatModal);
 				Chats.addTypingHandler(chatModal, roomId);
 				Chats.addIPHandler(chatModal);
+				Chats.addCopyTextLinkHandler(chatModal);
 				Chats.addTooltipHandler(chatModal);
 				Chats.addUploadHandler({
 					dragDropAreaEl: chatModal.find('.modal-content'),


### PR DESCRIPTION
## Problem
In the minimized/popup chat window, some buttons in the per-message "..." dropdown menu do nothing — notably **Copy link** and **Copy text**. They work fine on the full chat page.

## Root cause
These two actions are bound by `Chats.addCopyTextLinkHandler`, which is separate from `Chats.addActionHandlers` (reply/edit/delete/pin/...). The full chat page (`public/src/client/chats.js`) calls both, but the popup/minimized window (`public/src/modules/chat.js`) only called `addActionHandlers` and `addIPHandler` — never `addCopyTextLinkHandler`. So copy-link/copy-text were dead in the modal while the other actions worked.

## Fix
Add `Chats.addCopyTextLinkHandler(chatModal)` in both `Chat.initWidget` and `Chat.createModal`, mirroring the full-page wiring at `chats.js`. The same `message.tpl` partial is used in both contexts, so `data-mid` is already present on the copy items.

## Testing
Open a minimized chat popup, open a message's "..." menu, and confirm Copy link and Copy text now work. Full chat page behaviour is unchanged.