### PR TITLE
fix: show confirm dialog when plugin suggest returns null version

### DIFF
--- a/public/src/admin/extend/plugins.js
+++ b/public/src/admin/extend/plugins.js
@@ -111,9 +111,7 @@ define('admin/extend/plugins', [
 					return;
 				}
 
-				if (payload.version !== 'latest') {
-					Plugins.toggleInstall(pluginID, payload.version);
-				} else if (payload.version === 'latest') {
+				if (payload.version === null || payload.version === 'latest') {
 					confirmInstall(pluginID, function (confirm) {
 						if (confirm) {
 							Plugins.toggleInstall(pluginID, 'latest');
@@ -122,7 +120,7 @@ define('admin/extend/plugins', [
 						}
 					});
 				} else {
-					btn.removeAttr('disabled');
+					Plugins.toggleInstall(pluginID, payload.version);
 				}
 			});
 		});

--- a/public/src/admin/extend/plugins.js
+++ b/public/src/admin/extend/plugins.js
@@ -119,8 +119,10 @@ define('admin/extend/plugins', [
 							btn.removeAttr('disabled');
 						}
 					});
-				} else {
+				} else if (payload.version) {
 					Plugins.toggleInstall(pluginID, payload.version);
+				} else {
+					btn.removeAttr('disabled');
 				}
 			});
 		});

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -83,7 +83,7 @@ module.exports = function (Plugins) {
 		if (!response.ok) {
 			throw new Error(`[[error:cant-connect-to-nbbpm]]`);
 		}
-		if (body && body.code === 'ok' && (version === 'latest' || body.payload.valid.includes(version))) {
+		if (body && body.code === 'ok' && (!version || version === 'latest' || body.payload.valid.includes(version))) {
 			return;
 		}
 

--- a/src/plugins/install.js
+++ b/src/plugins/install.js
@@ -83,7 +83,7 @@ module.exports = function (Plugins) {
 		if (!response.ok) {
 			throw new Error(`[[error:cant-connect-to-nbbpm]]`);
 		}
-		if (body && body.code === 'ok' && (!version || version === 'latest' || body.payload.valid.includes(version))) {
+		if (body && body.code === 'ok' && (version === 'latest' || body.payload.valid.includes(version))) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

When the `suggest` API returns `null` for the plugin version (i.e. `code: "no-match"` — no recommended version for the current NodeBB release), the frontend incorrectly skips the confirmation dialog and silently calls `toggleInstall` with `version=null`. This causes `checkWhitelist` to throw `plugin-not-whitelisted` even for whitelisted plugins, and bypasses the intended user warning about unsupported plugins.

## Root cause

In `public/src/admin/extend/plugins.js`, the condition `payload.version !== 'latest'` is `true` when `payload.version` is `null`, so it falls into the "install directly" branch instead of showing the confirmation dialog.

## Fix

Check for `null` explicitly alongside `'latest'`, and show `confirmInstall` in both cases. This ensures the user sees a warning before installing a plugin with no recommended version for their NodeBB release.

## Test plan

- Trigger a plugin install where `suggest` returns `{ version: null, code: "no-match" }`
- Verify a confirmation dialog is shown instead of an immediate `plugin-not-whitelisted` error
- Confirm that installing a plugin with a specific suggested version still works without a dialog