### PR TITLE
feat: add global "Manage Groups" privilege

### DIFF
--- a/public/language/en-GB/admin/manage/privileges.json
+++ b/public/language/en-GB/admin/manage/privileges.json
@@ -24,6 +24,7 @@
 	"allow-local-login": "Local Login",
 	"allow-group-creation": "Group Create",
 	"view-users-info": "View Users Info",
+	"manage-groups": "Manage Groups",
 	"find-category": "Find Category",
 	"access-category": "Access Category",
 	"access-topics": "Access Topics",

--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -364,14 +364,15 @@ async function isOwner(caller, groupName, throwOnFalse = true) {
 	if (typeof groupName !== 'string') {
 		throw new Error('[[error:invalid-group-name]]');
 	}
-	const [hasAdminPrivilege, isGlobalModerator, isOwner, group] = await Promise.all([
+	const [hasAdminPrivilege, canManageGroups, isGlobalModerator, isOwner, group] = await Promise.all([
 		privileges.admin.can('admin:groups', caller.uid),
+		privileges.global.can('group:manage', caller.uid),
 		user.isGlobalModerator(caller.uid),
 		groups.ownership.isOwner(caller.uid, groupName),
 		groups.getGroupData(groupName),
 	]);
 
-	const check = isOwner || hasAdminPrivilege || (isGlobalModerator && !group.system);
+	const check = isOwner || hasAdminPrivilege || ((isGlobalModerator || canManageGroups) && !group.system);
 	if (!check && throwOnFalse) {
 		throw new Error('[[error:no-privileges]]');
 	}

--- a/src/groups/index.js
+++ b/src/groups/index.js
@@ -154,7 +154,9 @@ Groups.get = async function (groupName, options) {
 		stop = (parseInt(options.userListCount, 10) || 4) - 1;
 	}
 
-	const [groupData, members, isMember, isPending, isInvited, isOwner, isAdmin, isGlobalMod] = await Promise.all([
+	const [
+		groupData, members, isMember, isPending, isInvited, isOwner, isAdmin, isGlobalMod, canManage,
+	] = await Promise.all([
 		Groups.getGroupData(groupName),
 		Groups.getOwnersAndMembers(groupName, options.uid, 0, stop),
 		Groups.isMember(options.uid, groupName),
@@ -163,13 +165,14 @@ Groups.get = async function (groupName, options) {
 		Groups.ownership.isOwner(options.uid, groupName),
 		privileges.admin.can('admin:groups', options.uid),
 		user.isGlobalModerator(options.uid),
+		privileges.global.can('group:manage', options.uid),
 	]);
 
 	if (!groupData) {
 		return null;
 	}
 
-	groupData.isOwner = isOwner || isAdmin || (isGlobalMod && !groupData.system);
+	groupData.isOwner = isOwner || isAdmin || ((isGlobalMod || canManage) && !groupData.system);
 	if (groupData.isOwner) {
 		([groupData.pending, groupData.invited] = await Promise.all([
 			Groups.getPending(groupName),

--- a/src/privileges/global.js
+++ b/src/privileges/global.js
@@ -34,6 +34,7 @@ const _privilegeMap = new Map([
 	['ban', { label: '[[admin/manage/privileges:ban]]', type: 'moderation' }],
 	['mute', { label: '[[admin/manage/privileges:mute]]', type: 'moderation' }],
 	['view:users:info', { label: '[[admin/manage/privileges:view-users-info]]', type: 'moderation' }],
+	['group:manage', { label: '[[admin/manage/privileges:manage-groups]]', type: 'moderation' }],
 ]);
 
 privsGlobal.init = async () => {

--- a/src/socket.io/groups.js
+++ b/src/socket.io/groups.js
@@ -120,10 +120,12 @@ async function canModifyGroup(uid, groupName) {
 		isOwner: groups.ownership.isOwner(uid, groupName),
 		system: groups.getGroupField(groupName, 'system'),
 		hasAdminPrivilege: privileges.admin.can('admin:groups', uid),
+		canManageGroups: privileges.global.can('group:manage', uid),
 		isGlobalMod: user.isGlobalModerator(uid),
 	});
 
-	if (!(results.isOwner || results.hasAdminPrivilege || (results.isGlobalMod && !results.system))) {
+	const canManage = results.isGlobalMod || results.canManageGroups;
+	if (!(results.isOwner || results.hasAdminPrivilege || (canManage && !results.system))) {
 		throw new Error('[[error:no-privileges]]');
 	}
 }

--- a/test/categories.js
+++ b/test/categories.js
@@ -734,6 +734,7 @@ describe('Categories', () => {
 					signature: false,
 					'local:login': false,
 					'group:create': false,
+					'group:manage': false,
 					'view:users': false,
 					'view:tags': false,
 					'view:groups': false,
@@ -791,6 +792,7 @@ describe('Categories', () => {
 					'groups:signature': true,
 					'groups:local:login': true,
 					'groups:group:create': false,
+					'groups:group:manage': false,
 				});
 
 				done();

--- a/test/groups.js
+++ b/test/groups.js
@@ -613,6 +613,9 @@ describe('Groups', () => {
 				apiGroups.update({ uid: managerUid }, { slug: slug, description: 'nope' }),
 				{ message: '[[error:no-privileges]]' }
 			);
+			// the manage UI (Admin tab) is gated by group.isOwner
+			const groupData = await Groups.get('managePrivGroup', { uid: managerUid });
+			assert.strictEqual(groupData.isOwner, false);
 		});
 
 		it('should allow a user with the group:manage privilege to update a non-system group', async () => {
@@ -621,6 +624,9 @@ describe('Groups', () => {
 			await apiGroups.update({ uid: managerUid }, { slug: slug, description: 'managed' });
 			const groupObj = await Groups.get('managePrivGroup', {});
 			assert.strictEqual(groupObj.description, 'managed');
+			// the privilege should also expose the manage UI for non-system groups
+			const asManager = await Groups.get('managePrivGroup', { uid: managerUid });
+			assert.strictEqual(asManager.isOwner, true);
 		});
 
 		it('should still not allow updating a system group with only the group:manage privilege', async () => {
@@ -629,6 +635,9 @@ describe('Groups', () => {
 				apiGroups.update({ uid: managerUid }, { slug: slug, description: 'nope' }),
 				{ message: '[[error:no-privileges]]' }
 			);
+			// and the manage UI must stay hidden for system groups
+			const sysGroup = await Groups.get('administrators', { uid: managerUid });
+			assert.strictEqual(sysGroup.isOwner, false);
 			await privileges.global.rescind(['groups:group:manage'], 'registered-users');
 		});
 	});

--- a/test/groups.js
+++ b/test/groups.js
@@ -599,6 +599,40 @@ describe('Groups', () => {
 		});
 	});
 
+	describe('group:manage global privilege', () => {
+		const privileges = require('../src/privileges');
+		let managerUid;
+		before(async () => {
+			managerUid = await User.create({ username: 'groupmanager' });
+			await Groups.create({ name: 'managePrivGroup', description: 'foo' });
+		});
+
+		it('should not allow a regular user to update a group', async () => {
+			const slug = await Groups.getGroupField('managePrivGroup', 'slug');
+			await assert.rejects(
+				apiGroups.update({ uid: managerUid }, { slug: slug, description: 'nope' }),
+				{ message: '[[error:no-privileges]]' }
+			);
+		});
+
+		it('should allow a user with the group:manage privilege to update a non-system group', async () => {
+			await privileges.global.give(['groups:group:manage'], 'registered-users');
+			const slug = await Groups.getGroupField('managePrivGroup', 'slug');
+			await apiGroups.update({ uid: managerUid }, { slug: slug, description: 'managed' });
+			const groupObj = await Groups.get('managePrivGroup', {});
+			assert.strictEqual(groupObj.description, 'managed');
+		});
+
+		it('should still not allow updating a system group with only the group:manage privilege', async () => {
+			const slug = await Groups.getGroupField('administrators', 'slug');
+			await assert.rejects(
+				apiGroups.update({ uid: managerUid }, { slug: slug, description: 'nope' }),
+				{ message: '[[error:no-privileges]]' }
+			);
+			await privileges.global.rescind(['groups:group:manage'], 'registered-users');
+		});
+	});
+
 	describe('.destroy()', () => {
 		before((done) => {
 			Groups.join('foobar?', 1, done);

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -91,6 +91,7 @@ describe('Middlewares', () => {
 					ban: true,
 					mute: true,
 					'view:users:info': true,
+					'group:manage': true,
 					'admin:dashboard': true,
 					'admin:categories': true,
 					'admin:privileges': true,


### PR DESCRIPTION
### Summary

Adds a new **global moderation privilege** — `group:manage` ("Manage Groups") — that lets administrators delegate group management to specific users or groups **without** granting full admin (`admin:groups`) or Global Moderator status.

Today, managing an arbitrary group requires one of:
- being a group **owner**, or
- holding the `admin:groups` **admin** privilege, or
- membership in the **Global Moderators** group.

There was no finer-grained way to let a trusted user edit/delete groups, manage membership/ownership, or change group covers. This adds one, surfaced under the **Moderation** section of the global privileges table (alongside Ban / Mute / View Users Info).

### Behaviour

- Grantable per-user or per-group from **ACP → Manage → Privileges → Global**.
- Wired into both group-management entry points:
  - `isOwner()` in `src/api/groups.js` (covers update, delete, membership add/remove, ownership grant/rescind, pending/invites).
  - `canModifyGroup()` in `src/socket.io/groups.js` (group cover update/remove).
- Gated to **non-system** groups, mirroring the existing Global Moderator rule — holders cannot touch `administrators`, `Global Moderators`, etc.
- Administrators continue to implicitly hold the privilege.

### Tests

Adds coverage in `test/groups.js` verifying that a non-admin/non-mod user:
- cannot update a group without the privilege,
- can update a non-system group once granted `groups:group:manage`,
- still cannot update a system group with only this privilege.

### Notes

- New privilege defaults to ungranted, so behaviour is unchanged on upgrade until an admin explicitly assigns it. No migration required.
- Only the `en-GB` source string (`manage-groups`) is added; other locales are handled via the translation workflow.