### PR TITLE
fix: let users who can approve requests join private groups directly

### DIFF
--- a/src/api/groups.js
+++ b/src/api/groups.js
@@ -171,11 +171,23 @@ groupsAPI.join = async function (caller, data) {
 			targetUid: data.uid,
 		});
 	} else if (isSelf) {
-		await groups.requestMembership(groupName, caller.uid);
-		logGroupEvent(caller, 'group-request-membership', {
-			groupName: groupName,
-			targetUid: data.uid,
-		});
+		// users who can approve membership requests for this group (owners,
+		// global moderators) would only have to approve themselves, so let
+		// them join immediately instead of queueing a pointless request
+		const canApprove = await isOwner(caller, groupName, false);
+		if (canApprove) {
+			await groups.join(groupName, data.uid);
+			logGroupEvent(caller, 'group-join', {
+				groupName: groupName,
+				targetUid: data.uid,
+			});
+		} else {
+			await groups.requestMembership(groupName, caller.uid);
+			logGroupEvent(caller, 'group-request-membership', {
+				groupName: groupName,
+				targetUid: data.uid,
+			});
+		}
 	} else {
 		throw new Error('[[error:not-allowed]]');
 	}

--- a/test/groups.js
+++ b/test/groups.js
@@ -784,6 +784,35 @@ describe('Groups', () => {
 			await apiGroups.join({ uid: adminUid }, { uid: adminUid, slug: 'global-moderators' });
 			assert(await Groups.isMember(adminUid, 'Global Moderators'));
 		});
+
+		it('should let a user who can approve membership requests join a private group immediately', async () => {
+			meta.config.allowPrivateGroups = 1;
+			const uid = await User.create({ username: utils.generateUUID().slice(0, 8) });
+			// global moderators can approve requests for non-system groups
+			await Groups.join('Global Moderators', uid);
+			const slug = await Groups.getGroupField('PrivateCanJoin', 'slug');
+			await apiGroups.join({ uid: uid }, { slug: slug, uid: uid });
+			const [isMember, isPending] = await Promise.all([
+				Groups.isMember(uid, 'PrivateCanJoin'),
+				Groups.isPending(uid, 'PrivateCanJoin'),
+			]);
+			assert.strictEqual(isMember, true);
+			assert.strictEqual(isPending, false);
+			await Groups.leave('Global Moderators', uid);
+		});
+
+		it('should place a user who cannot approve requests into the pending queue', async () => {
+			meta.config.allowPrivateGroups = 1;
+			const uid = await User.create({ username: utils.generateUUID().slice(0, 8) });
+			const slug = await Groups.getGroupField('PrivateCanJoin', 'slug');
+			await apiGroups.join({ uid: uid }, { slug: slug, uid: uid });
+			const [isMember, isPending] = await Promise.all([
+				Groups.isMember(uid, 'PrivateCanJoin'),
+				Groups.isPending(uid, 'PrivateCanJoin'),
+			]);
+			assert.strictEqual(isMember, false);
+			assert.strictEqual(isPending, true);
+		});
 	});
 
 	describe('.leave()', () => {


### PR DESCRIPTION
### Problem

When a user self-joins a **private** group (with join requests enabled), they are always placed in the pending membership queue — even when they themselves have the authority to approve that request.

This affects **group owners** and **global moderators**: they click "Join", become *pending*, and then have to go approve their own request. Pointless friction, since the approval is guaranteed.

### Fix

In the self-join branch of `groupsAPI.join`, if the caller can approve membership for the group, add them as a member immediately instead of queueing a pending request. The check reuses the existing `isOwner()` helper (group owner / `admin:groups` / global moderator on non-system groups) — the same authority that gates approving pending requests — so a user is only fast-tracked when they could have approved themselves anyway.

Users without approval authority continue through the normal request-membership flow, unchanged.

```js
} else if (isSelf) {
    const canApprove = await isOwner(caller, groupName, false);
    if (canApprove) {
        await groups.join(groupName, data.uid);
        logGroupEvent(caller, 'group-join', { groupName, targetUid: data.uid });
    } else {
        await groups.requestMembership(groupName, caller.uid);
        logGroupEvent(caller, 'group-request-membership', { groupName, targetUid: data.uid });
    }
}
```

No client changes are needed — the group page already refreshes after the join call and reflects the resulting state.

### Tests

Adds coverage in `test/groups.js`:
- a global moderator self-joining a private group becomes a member immediately (not pending);
- a regular user self-joining the same group is still placed in the pending queue.