### PR TITLE
fix: let administrators bypass post length limits in quick reply

### DIFF
--- a/public/src/modules/quickreply.js
+++ b/public/src/modules/quickreply.js
@@ -89,11 +89,14 @@ define('quickreply', [
 				...opts.body,
 			};
 
-			const replyLen = replyMsg.length;
-			if (replyLen < parseInt(config.minimumPostLength, 10)) {
-				return alerts.error('[[error:content-too-short, ' + config.minimumPostLength + ']]');
-			} else if (replyLen > parseInt(config.maximumPostLength, 10)) {
-				return alerts.error('[[error:content-too-long, ' + config.maximumPostLength + ']]');
+			// Administrators bypass post length limits (mirrors server-side check in src/topics/create.js)
+			if (!app.user.isAdmin) {
+				const replyLen = replyMsg.length;
+				if (replyLen < parseInt(config.minimumPostLength, 10)) {
+					return alerts.error('[[error:content-too-short, ' + config.minimumPostLength + ']]');
+				} else if (replyLen > parseInt(config.maximumPostLength, 10)) {
+					return alerts.error('[[error:content-too-long, ' + config.maximumPostLength + ']]');
+				}
 			}
 
 			ready = false;


### PR DESCRIPTION
### Description

Topic/post creation on the server skips the minimum/maximum length checks for administrators (`src/topics/create.js` wraps `Topics.checkTitle`/`Topics.checkContent` in `if (!isAdmin)`). The client-side **quick reply** validation, however, enforced `minimumPostLength`/`maximumPostLength` for everyone, so an administrator was blocked by the UI before the request ever reached the server.

This change skips the client-side length check for administrators in the quick reply, mirroring the server behaviour and the existing `app.user.isAdmin` guard already used in `public/src/modules/uploadHelpers.js` for upload size limits.

### Code changes

- `public/src/modules/quickreply.js`: wrap the `content-too-short` / `content-too-long` check in `if (!app.user.isAdmin)`.

### Notes

The full composer (`nodebb-plugin-composer-default`) has the same client-side discrepancy and is addressed separately in that plugin's repository.