### PR TITLE
feat(chat): exempt privileged users from the chat reputation gate

### DIFF
--- a/public/language/en-GB/admin/settings/reputation.json
+++ b/public/language/en-GB/admin/settings/reputation.json
@@ -18,6 +18,7 @@
 	"downvotes-per-day": "Downvotes per day (set to 0 for unlimited downvotes)",
 	"downvotes-per-user-per-day": "Downvotes per user per day (set to 0 for unlimited downvotes)",
 	"min-rep-chat": "Minimum reputation to send chat messages",
+	"min-rep-chat-help": "This restriction only blocks chatting with regular users. Chatting with administrators and global moderators is always allowed, even when below the threshold.",
 	"min-rep-post-links": "Minimum reputation to post links",
 	"min-rep-flag": "Minimum reputation to flag posts",
 	"min-rep-aboutme": "Minimum reputation to add \"About me\" to user profile",

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -395,7 +395,6 @@ Messaging.canMessageUser = async (uid, toUid) => {
 		user.isPrivileged(toUid),
 		privileges.global.can('chat', uid),
 		privileges.global.can('chat:privileged', uid),
-		checkReputation(uid),
 	]);
 
 	if (!exists) {
@@ -404,6 +403,11 @@ Messaging.canMessageUser = async (uid, toUid) => {
 
 	if (!canChat && !(canChatWithPrivileged && isTargetPrivileged)) {
 		throw new Error('[[error:no-privileges]]');
+	}
+
+	// The reputation gate does not apply when messaging a privileged user (admin/mod)
+	if (!isTargetPrivileged) {
+		await checkReputation(uid);
 	}
 
 	const [settings, isAdmin, isModerator, isBlocked] = await Promise.all([
@@ -446,7 +450,6 @@ Messaging.canMessageRoom = async (uid, roomId) => {
 		Messaging.getRoomData(roomId),
 		Messaging.isUserInRoom(uid, roomId),
 		privileges.global.can(['chat', 'chat:privileged'], uid),
-		checkReputation(uid),
 		user.checkMuted(uid),
 	]);
 	if (!roomData) {
@@ -459,6 +462,11 @@ Messaging.canMessageRoom = async (uid, roomId) => {
 
 	if (!canChat.includes(true)) {
 		throw new Error('[[error:no-privileges]]');
+	}
+
+	// The reputation gate is skipped when every other participant in the room is privileged (admin/mod)
+	if (!await allOtherUsersPrivileged(uid, roomId)) {
+		await checkReputation(uid);
 	}
 
 	await plugins.hooks.fire('static:messaging.canMessageRoom', {
@@ -478,6 +486,18 @@ async function checkReputation(uid) {
 	if (!isPrivileged && meta.config['min:rep:chat'] > reputation) {
 		throw new Error(`[[error:not-enough-reputation-to-chat, ${meta.config['min:rep:chat']}]]`);
 	}
+}
+
+// Returns true when there is at least one other participant and every other
+// participant in the room is privileged (admin/mod), so the reputation gate can be skipped.
+async function allOtherUsersPrivileged(uid, roomId) {
+	const uids = await Messaging.getUidsInRoom(roomId, 0, -1);
+	const others = uids.filter(u => parseInt(u, 10) !== parseInt(uid, 10));
+	if (!others.length) {
+		return false;
+	}
+	const privileged = await Promise.all(others.map(u => user.isPrivileged(u)));
+	return privileged.every(Boolean);
 }
 
 Messaging.hasPrivateChat = async (uid, withUid) => {

--- a/src/views/admin/settings/reputation.tpl
+++ b/src/views/admin/settings/reputation.tpl
@@ -39,6 +39,7 @@
 				<div class="mb-3">
 					<label class="form-label" for="min:rep:chat">[[admin/settings/reputation:min-rep-chat]]</label>
 					<input type="number" class="form-control" placeholder="0" data-field="min:rep:chat" id="min:rep:chat">
+					<p class="form-text">[[admin/settings/reputation:min-rep-chat-help]]</p>
 				</div>
 				<div class="mb-3">
 					<label class="form-label" for="min:rep:upvote">[[admin/settings/reputation:min-rep-upvote]]</label>


### PR DESCRIPTION
### Problem

The `min:rep:chat` threshold currently blocks any user below the configured reputation from sending chat messages to **anyone** — including administrators and global moderators. There is no way to keep the spam/abuse protection of a reputation gate while still letting restricted users reach staff (for example, to ask for help or appeal).

### Change

Skip the reputation check when the chat target is privileged:

- **`canMessageUser`** — the gate is skipped when the recipient is an administrator or global moderator (`user.isPrivileged`).
- **`canMessageRoom`** — the gate is skipped only when **every** other participant in the room is privileged, so a low-rep user cannot bypass the threshold by adding a single admin to an otherwise regular group chat.

Sender-side privileged users remain exempt exactly as before. `user.checkMuted` and all other existing checks are unchanged.

A help text was also added under the **Minimum reputation to send chat messages** setting to document that the restriction only applies to chatting with regular users.

### Notes

- New language string added to `en-GB` only; other locales fall back to it.