### PR TITLE
fix: setup env false-positive; post-queue id isolation and test cleanup

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -47,11 +47,16 @@ questions.optional = [
 ];
 
 function checkSetupFlagEnv() {
-	let setupVal = install.values;
+	// Caller may pass an initial config object (e.g. `./nodebb setup '{...}'` or install.values from tests).
+	// Treat an empty/missing object as "no automated values yet".
+	let setupVal = (install.values && typeof install.values === 'object' && Object.keys(install.values).length) ?
+		{ ...install.values } :
+		undefined;
+	const hadExplicitInstallValues = !!setupVal;
 
+	// CONFIG / NODEBB_CONFIG are path selectors only. The CLI sets process.env.CONFIG whenever
+	// config.json already exists (see src/cli/index.js), so they must NOT force automated setup.
 	const envConfMap = {
-		CONFIG: 'config',
-		NODEBB_CONFIG: 'config',
 		NODEBB_URL: 'url',
 		NODEBB_PORT: 'port',
 		NODEBB_ADMIN_USERNAME: 'admin:username',
@@ -66,39 +71,61 @@ function checkSetupFlagEnv() {
 		NODEBB_DB_SSL: 'ssl',
 	};
 
-	// Set setup values from env vars (if set)
+	// Set setup values from NODEBB_* env vars (if set)
+	const setupEnvKeys = Object.keys(envConfMap);
 	const envKeys = Object.keys(process.env);
-	if (Object.keys(envConfMap).some(key => envKeys.includes(key))) {
+	const hasSetupEnv = setupEnvKeys.some(key => envKeys.includes(key));
+	if (hasSetupEnv) {
 		winston.info('[install/checkSetupFlagEnv] checking env vars for setup info...');
 		setupVal = setupVal || {};
 
 		Object.entries(process.env).forEach(([evName, evValue]) => { // get setup values from env
-			if (evName.startsWith('NODEBB_DB_')) {
-				setupVal[`${process.env.NODEBB_DB}:${envConfMap[evName]}`] = evValue;
-			} else if (evName.startsWith('NODEBB_')) {
+			if (evName.startsWith('NODEBB_DB_') && envConfMap[evName]) {
+				const dbType = process.env.NODEBB_DB;
+				if (dbType) {
+					setupVal[`${dbType}:${envConfMap[evName]}`] = evValue;
+				}
+			} else if (envConfMap[evName]) {
 				setupVal[envConfMap[evName]] = evValue;
 			}
 		});
 
-		setupVal['admin:password:confirm'] = setupVal['admin:password'];
+		if (setupVal['admin:password'] && !setupVal['admin:password:confirm']) {
+			setupVal['admin:password:confirm'] = setupVal['admin:password'];
+		}
 	}
 
 	// try to get setup values from json, if successful this overwrites all values set by env
 	// TODO: better behaviour would be to support overrides per value, i.e. in order of priority (generic pattern):
 	//       flag, env, config file, default
+	let hadSetupFlag = false;
 	try {
 		if (nconf.get('setup')) {
 			const setupJSON = JSON.parse(nconf.get('setup'));
 			setupVal = { ...setupVal, ...setupJSON };
+			hadSetupFlag = true;
 		}
 	} catch (err) {
 		winston.error('[install/checkSetupFlagEnv] invalid json in nconf.get(\'setup\'), ignoring setup values from json');
 	}
 
+	function hasCompleteAdminCredentials(values) {
+		return !!(values &&
+			values['admin:username'] &&
+			values['admin:password'] &&
+			values['admin:password:confirm'] &&
+			values['admin:email']);
+	}
+
+	// Automated setup is only required when the operator explicitly requested it
+	// (CLI JSON arg, --setup flag, or complete NODEBB_ADMIN_* credentials).
+	// Partial env (e.g. NODEBB_URL only) or CONFIG set by the CLI must not abort interactive setup.
+	const explicitAutomated = hadSetupFlag || hadExplicitInstallValues || hasCompleteAdminCredentials(setupVal);
+
 	if (setupVal && typeof setupVal === 'object') {
-		if (setupVal['admin:username'] && setupVal['admin:password'] && setupVal['admin:password:confirm'] && setupVal['admin:email']) {
+		if (hasCompleteAdminCredentials(setupVal)) {
 			install.values = setupVal;
-		} else {
+		} else if (explicitAutomated) {
 			winston.error('[install/checkSetupFlagEnv] required values are missing for automated setup:');
 			if (!setupVal['admin:username']) {
 				winston.error('  admin:username');
@@ -113,7 +140,11 @@ function checkSetupFlagEnv() {
 				winston.error('  admin:email');
 			}
 
-			process.exit();
+			process.exit(1);
+		} else {
+			// Partial values only — fall back to interactive prompts (config/env still used as defaults).
+			winston.info('[install/checkSetupFlagEnv] incomplete automated setup values; falling back to interactive setup');
+			install.values = undefined;
 		}
 	} else if (nconf.get('database')) {
 		install.values = install.values || {};

--- a/src/posts/queue.js
+++ b/src/posts/queue.js
@@ -213,7 +213,9 @@ module.exports = function (Posts) {
 	Posts.addToQueue = async function (data) {
 		const type = getType(data);
 		const now = Date.now();
-		const id = `${type}-${now}`;
+		// Include a UUID so two items enqueued in the same millisecond get distinct ids
+		// (sorted-set members are unique; colliding ids would silently overwrite).
+		const id = `${type}-${now}-${utils.generateUUID()}`;
 		await canPost(type, data);
 
 		if (data.pid) {
@@ -386,10 +388,14 @@ module.exports = function (Posts) {
 		}
 		const keys = ids.map(id => `post:queue:${id}`);
 		const items = await db.getObjects(keys);
+		const pidStr = String(pid);
 		const toRemove = [];
 		items.forEach((item, idx) => {
-			const data = JSON.parse(item.data);
-			if (data.pid === pid) {
+			if (!item || item.data == null) {
+				return;
+			}
+			const data = typeof item.data === 'string' ? JSON.parse(item.data) : item.data;
+			if (data && data.pid != null && String(data.pid) === pidStr) {
 				toRemove.push(ids[idx]);
 			}
 		});

--- a/test/posts/queue.js
+++ b/test/posts/queue.js
@@ -26,10 +26,20 @@ describe('Post Queue', () => {
 	});
 
 	describe('addToQueue deduplication by pid', () => {
-		afterEach(async () => {
-			const queue = await posts.getQueuedPosts();
+		// Full-suite isolation: other test files may leave items in post:queue.
+		async function clearQueue() {
+			const queue = await posts.getQueuedPosts({}, { metadata: false });
 			await Promise.all(queue.map(q => posts.removeFromQueue(q.id)));
+		}
+
+		beforeEach(async () => {
+			await clearQueue();
 		});
+
+		afterEach(async () => {
+			await clearQueue();
+		});
+
 		it('should replace existing queue item when same pid is queued again', async () => {
 			const pid = 'https://example.org/post/1';
 


### PR DESCRIPTION
## Summary

Fixes issues found while setting up NodeBB locally and running the full test suite:

1. **`./nodebb setup` false automated mode** — After `config.json` exists, the CLI sets `process.env.CONFIG` (`src/cli/index.js`). `checkSetupFlagEnv()` treated that as an automated setup request and exited with missing `admin:*` fields even for a normal interactive/re-setup run.
2. **Post-queue full-suite flakiness** — Queue item ids used `${type}-${Date.now()}`, so two enqueues in the same millisecond shared a sorted-set member and overwrote each other. Related tests could also see leftover `post:queue` items from other files. Hardened `removeFromQueueByPid` PID matching and isolated tests with `beforeEach`/`afterEach` cleanup.

## Changes

| File | Change |
|------|--------|
| `src/install.js` | Do not treat `CONFIG` / `NODEBB_CONFIG` as automated-setup triggers; only hard-fail on incomplete admin credentials when setup was explicitly automated (`--setup` JSON / explicit install values / complete `NODEBB_ADMIN_*`). |
| `src/posts/queue.js` | Unique queue ids (`${type}-${now}-${uuid}`); null/string-safe PID comparison in `removeFromQueueByPid`. |
| `test/posts/queue.js` | Clear the post queue in `beforeEach` / `afterEach` for full-suite isolation. |

## Out of scope (Transifex)

`test/i18n.js` currently fails on master for missing `post-queue:edit` in non-`en-GB` locales. Per project policy, language files are managed via [Transifex](https://explore.transifex.com/nodebb/nodebb/) (not direct PRs). Maintainers can pull the `edit` key from Transifex separately; this PR intentionally omits locale JSON changes.

## Contributor checklist ([CONTRIBUTING.md](https://github.com/NodeBB/NodeBB/blob/master/.github/CONTRIBUTING.md))

- [x] Ran automated tests locally against these changes
- [x] No direct language-file edits (Transifex policy)
- [ ] **CLA**: Please sign the [Contributor License Agreement](https://cla-assistant.io/NodeBB/NodeBB?pullRequest=14418) on this PR (required before merge)

## Test plan

- [x] `./nodebb setup` with existing `config.json` completes successfully (no missing `admin:*` abort)
- [x] Explicit incomplete automated setup still errors as expected:
  `node app --setup='{"url":"http://127.0.0.1:4567","database":"redis"}'`
- [x] `test/posts/queue.js` stress-run (5×) all passing
- [x] Full mocha suite: post-queue failures resolved with these changes

### Local verification

```bash
./nodebb setup
npx mocha test/posts/queue.js
# optional full suite:
npx mocha --bail false
```