### PR TITLE
fix: clear stuck loading indicator on bfcache restore

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -547,6 +547,16 @@ $(document).ready(function () {
 		}
 	});
 
+	window.addEventListener('pageshow', (ev) => {
+		// If a full-page navigation was triggered mid-ajaxify (e.g. a redirect to an
+		// external or login URL), the loading state was still running when this page
+		// was put into the back/forward cache. On restore, reload the current page so
+		// the loading indicator clears and the socket reconnects, instead of hanging.
+		if (ev.persisted && $('#content').hasClass('ajaxifying')) {
+			ajaxify.refresh();
+		}
+	});
+
 	function ajaxifyAnchors() {
 		const location = document.location || window.location;
 		const rootUrl = location.protocol + '//' + (location.hostname || location.host) + (location.port ? ':' + location.port : '');


### PR DESCRIPTION
### Problem

When a user opens a page whose request triggers a full-page navigation from *within* an in-flight ajaxify transition, then presses **Back**, the restored page shows the loading indicator (e.g. the progress bar) spinning forever — the page appears to hang.

Reproducing it needs a link click that ajaxify starts to handle but that ends up as a real browser navigation, for example:
- `onAjaxError` redirecting to `/login` (401) or to an external URL (302), or
- `handleRedirects` opening the admin control panel via `window.open(..., '_top')`.

### Root cause

`ajaxify.go` fires `action:ajaxify.start` and adds the `ajaxifying` class to `#content`, but when a full-page navigation is triggered before the request completes, `action:ajaxify.end` never fires. The browser then stores that half-loaded page in the back/forward cache. There is no `pageshow`/`persisted` handling, so on **Back** the page is restored with the loading state still set and nothing clears it.

### Fix

Add a `pageshow` handler that, on a persisted (bfcache) restore where `#content` still has the `ajaxifying` class, calls `ajaxify.refresh()`. This re-runs a normal load cycle (clearing the indicator via `action:ajaxify.end`) and reconnects the socket through `ajaxify.go`. It is gated on the stuck state, so ordinary bfcache restores keep their instant behaviour.

### Testing

`eslint public/src/ajaxify.js` passes. Verified manually that the handler is a no-op unless the page is restored from bfcache with an interrupted transition.