### PR TITLE
fix(activitypub): use absolute avatar/cover URLs as-is in user actor

### DIFF
--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -416,21 +416,29 @@ Mocks.actors.user = async (uid) => {
 	if (picture) {
 		picture = utils.decodeHTMLEntities(picture);
 		const imagePath = await user.getLocalAvatarPath(uid);
-		picture = {
-			type: 'Image',
-			mediaType: mime.getType(imagePath),
-			url: picture.startsWith('http') ? picture : `${nconf.get('url')}${picture}`,
-		};
+		try {
+			picture = {
+				type: 'Image',
+				mediaType: mime.getType(imagePath),
+				url: new URL(picture, nconf.get('url')).href,
+			};
+		} catch {
+			picture = undefined;
+		}
 	}
 
 	if (cover) {
 		cover = utils.decodeHTMLEntities(cover);
 		const imagePath = await user.getLocalCoverPath(uid);
-		cover = {
-			type: 'Image',
-			mediaType: mime.getType(imagePath),
-			url: cover.startsWith('http') ? cover : `${nconf.get('url')}${cover}`,
-		};
+		try {
+			cover = {
+				type: 'Image',
+				mediaType: mime.getType(imagePath),
+				url: new URL(cover, nconf.get('url')).href,
+			};
+		} catch {
+			cover = undefined;
+		}
 	}
 
 	const attachment = [];

--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -419,7 +419,7 @@ Mocks.actors.user = async (uid) => {
 		picture = {
 			type: 'Image',
 			mediaType: mime.getType(imagePath),
-			url: `${nconf.get('url')}${picture}`,
+			url: picture.startsWith('http') ? picture : `${nconf.get('url')}${picture}`,
 		};
 	}
 
@@ -429,7 +429,7 @@ Mocks.actors.user = async (uid) => {
 		cover = {
 			type: 'Image',
 			mediaType: mime.getType(imagePath),
-			url: `${nconf.get('url')}${cover}`,
+			url: cover.startsWith('http') ? cover : `${nconf.get('url')}${cover}`,
 		};
 	}
 

--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -416,11 +416,15 @@ Mocks.actors.user = async (uid) => {
 	if (picture) {
 		picture = utils.decodeHTMLEntities(picture);
 		const imagePath = await user.getLocalAvatarPath(uid);
+		// Absolute (remote/SSO) avatars are used as-is; relative paths get the forum url prefixed
+		// (string concat, so subfolder installs keep their relative_path). new URL validates the
+		// result and unsets the field on malformed values.
+		const url = /^https?:\/\//i.test(picture) ? picture : `${nconf.get('url')}${picture}`;
 		try {
 			picture = {
 				type: 'Image',
 				mediaType: mime.getType(imagePath),
-				url: new URL(picture, nconf.get('url')).href,
+				url: new URL(url).href,
 			};
 		} catch {
 			picture = undefined;
@@ -430,11 +434,12 @@ Mocks.actors.user = async (uid) => {
 	if (cover) {
 		cover = utils.decodeHTMLEntities(cover);
 		const imagePath = await user.getLocalCoverPath(uid);
+		const url = /^https?:\/\//i.test(cover) ? cover : `${nconf.get('url')}${cover}`;
 		try {
 			cover = {
 				type: 'Image',
 				mediaType: mime.getType(imagePath),
-				url: new URL(cover, nconf.get('url')).href,
+				url: new URL(url).href,
 			};
 		} catch {
 			cover = undefined;

--- a/test/activitypub/mocks.js
+++ b/test/activitypub/mocks.js
@@ -336,6 +336,15 @@ describe('Mocking', () => {
 
 					assert.strictEqual(actor.icon.url, `${nconf.get('url')}${relativeAvatar}`);
 				});
+
+				it('should unset the avatar when the stored value is a malformed url', async () => {
+					const uid = await user.create({ username: utils.generateUUID().slice(0, 8) });
+					await user.setUserField(uid, 'picture', 'https://');
+
+					const actor = await activitypub.mocks.actors.user(uid);
+
+					assert.strictEqual(actor.icon, undefined);
+				});
 			});
 		});
 	});

--- a/test/activitypub/mocks.js
+++ b/test/activitypub/mocks.js
@@ -314,5 +314,29 @@ describe('Mocking', () => {
 				});
 			});
 		});
+
+		describe('Actors', () => {
+			describe('.user()', () => {
+				it('should not double-prefix an absolute (remote/SSO) avatar url', async () => {
+					const uid = await user.create({ username: utils.generateUUID().slice(0, 8) });
+					const externalAvatar = 'https://example.org/avatar/abc123.png';
+					await user.setUserField(uid, 'picture', externalAvatar);
+
+					const actor = await activitypub.mocks.actors.user(uid);
+
+					assert.strictEqual(actor.icon.url, externalAvatar);
+				});
+
+				it('should prefix a relative avatar path with the forum url', async () => {
+					const uid = await user.create({ username: utils.generateUUID().slice(0, 8) });
+					const relativeAvatar = '/assets/uploads/profile/test.png';
+					await user.setUserField(uid, 'picture', relativeAvatar);
+
+					const actor = await activitypub.mocks.actors.user(uid);
+
+					assert.strictEqual(actor.icon.url, `${nconf.get('url')}${relativeAvatar}`);
+				});
+			});
+		});
 	});
 });


### PR DESCRIPTION
### What / Why

`activitypub.mocks.actors.user()` builds the actor `icon` (avatar) and `image` (cover) URLs by **unconditionally** prepending the forum URL to the stored value:

```js
url: `${nconf.get('url')}${picture}`,
```

This is correct for locally-uploaded avatars, whose `picture` field is a relative path (`/assets/uploads/...`). But when a user's avatar is an **absolute URL** — e.g. a Google avatar set via SSO login (`nodebb-plugin-sso-google`), where `picture` is `https://lh3.googleusercontent.com/...` — the result is a malformed, double-scheme URL:

```
https://forum.example.com + https://lh3.googleusercontent.com/a/...
= https://forum.example.comhttps://lh3.googleusercontent.com/a/...
```

Remote instances then store this broken URL and cannot load the avatar, so federated posts from SSO users fall back to the letter/placeholder avatar.

### Reproduction

1. On instance A, sign in a user via Google SSO (their `picture` becomes an absolute `lh3.googleusercontent.com` URL).
2. That user posts in a category that instance B follows over ActivityPub.
3. On instance B the post shows, but the author's avatar is broken — the fetched actor's `icon.url` is `https://A-domainhttps://lh3.googleusercontent.com/...`.

### Fix

Only prepend the base URL when the stored value is a **relative path**, using the same `startsWith('http')` convention already used elsewhere in the codebase (e.g. `src/socket.io/user/picture.js`, `src/coverPhoto.js`):

```js
url: picture.startsWith('http') ? picture : `${nconf.get('url')}${picture}`,
```

Applied to both the avatar (`icon`) and cover (`image`).

### Tests

Added `Mocking > Outbound > Actors > .user()` tests in `test/activitypub/mocks.js` covering both an absolute avatar URL (used as-is) and a relative avatar path (prefixed with the forum URL).

I have read and agree to the NodeBB Contributor License Agreement.
