### PR TITLE
fix(chats): mark notifications with matching roomId read when opening a room

### DIFF
--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -6,7 +6,6 @@ const db = require('../database');
 const user = require('../user');
 const meta = require('../meta');
 const messaging = require('../messaging');
-const notifications = require('../notifications');
 const privileges = require('../privileges');
 const plugins = require('../plugins');
 const utils = require('../utils');
@@ -210,9 +209,7 @@ chatsAPI.mark = async (caller, data) => {
 	} else {
 		await messaging.markRead(caller.uid, roomId);
 		socketHelpers.emitToUids('event:chats.markedAsRead', { roomId: roomId }, [caller.uid]);
-		const nids = await user.notifications.getUnreadByField(caller.uid, 'roomId', [roomId]);
-		await notifications.markReadMultiple(nids, caller.uid);
-		user.notifications.pushCount(caller.uid);
+		await messaging.markRoomNotificationsRead(caller.uid, roomId);
 	}
 
 	socketHelpers.emitToUids('event:chats.mark', { roomId, state }, [caller.uid]);

--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const winston = require('winston');
+const _ = require('lodash');
 
 const batch = require('../batch');
 const db = require('../database');
@@ -30,10 +31,16 @@ module.exports = function (Messaging) {
 	};
 
 	Messaging.markRoomNotificationsRead = async (uid, roomId) => {
-		const chatNids = await db.getSortedSetScan({
-			key: `uid:${uid}:notifications:unread`,
-			match: `chat_${roomId}_*`,
-		});
+		const [scannedNids, fieldNids] = await Promise.all([
+			db.getSortedSetScan({
+				key: `uid:${uid}:notifications:unread`,
+				match: `chat_${roomId}_*`,
+			}),
+			// covers notifications that reference the room but use a different
+			// nid format (e.g. those created by plugins)
+			user.notifications.getUnreadByField(uid, 'roomId', [roomId]),
+		]);
+		const chatNids = _.uniq(scannedNids.concat(fieldNids));
 		if (chatNids.length) {
 			await notifications.markReadMultiple(chatNids, uid);
 			await user.notifications.pushCount(uid);


### PR DESCRIPTION
## Problem

When a user opens a chat room, `Messaging.markRoomNotificationsRead` only marks notifications whose `nid` matches the `chat_<roomId>_*` pattern as read. Chat-related notifications created by plugins (e.g. nodebb-plugin-reactions notifying a user that someone reacted to their chat message) use a different nid format, so they stay unread even after the user has opened the room and seen the message. The user has to click the notification itself to clear it.

Topics don't have this problem: `Topics.markTopicNotificationsRead` matches unread notifications by their `tid` field, so any notification referencing the topic — including plugin-created ones — is cleared when the topic is read. `chatsAPI.mark` also already matches by the `roomId` field.

## Change

- `Messaging.markRoomNotificationsRead` now additionally matches unread notifications by their `roomId` field (via `user.notifications.getUnreadByField`), merged with the existing nid-pattern scan so core chat notifications beyond the field-lookup window are still caught.
- `chatsAPI.mark` reuses `Messaging.markRoomNotificationsRead` instead of duplicating the same logic inline.

Any plugin that sets `roomId` on its notification data now gets its notifications cleared when the room is opened, consistent with how topic notifications behave.