### PR TITLE
refactor(chats): match room notifications solely by roomId field

### DIFF
--- a/src/messaging/notifications.js
+++ b/src/messaging/notifications.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const winston = require('winston');
-const _ = require('lodash');
 
 const batch = require('../batch');
 const db = require('../database');
@@ -31,16 +30,7 @@ module.exports = function (Messaging) {
 	};
 
 	Messaging.markRoomNotificationsRead = async (uid, roomId) => {
-		const [scannedNids, fieldNids] = await Promise.all([
-			db.getSortedSetScan({
-				key: `uid:${uid}:notifications:unread`,
-				match: `chat_${roomId}_*`,
-			}),
-			// covers notifications that reference the room but use a different
-			// nid format (e.g. those created by plugins)
-			user.notifications.getUnreadByField(uid, 'roomId', [roomId]),
-		]);
-		const chatNids = _.uniq(scannedNids.concat(fieldNids));
+		const chatNids = await user.notifications.getUnreadByField(uid, 'roomId', [roomId]);
 		if (chatNids.length) {
 			await notifications.markReadMultiple(chatNids, uid);
 			await user.notifications.pushCount(uid);


### PR DESCRIPTION
Follow-up to #14450 (per @barisusakli's suggestion there).

Regular chat notifications already carry a `roomId` field, so `Messaging.markRoomNotificationsRead` no longer needs to scan the unread set for the `chat_<roomId>_*` nid pattern — matching by the `roomId` field alone covers both core and plugin-created notifications. This mirrors how `Topics.markTopicNotificationsRead` matches via the `tid` field.

Note: as discussed in #14450, `getUnreadByField` only looks at the 100 most recent unread notifications, same as the topic path. No one has hit that limit for topic notifs, and the `99` window can be tweaked later if needed.