### PR TITLE
fix(docker): preserve persisted package.json on container recreation

### DIFF
--- a/install/docker/entrypoint.sh
+++ b/install/docker/entrypoint.sh
@@ -53,12 +53,14 @@ copy_or_link_files() {
       ;;
   esac
 
-  # Check if source and destination files are the same
-  if [ "$(realpath "$src_dir/package.json")" != "$(realpath "$dest_dir/package.json")" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
+  # Only seed the persisted files if they don't exist yet. Overwriting them would discard
+  # plugins installed at runtime (`npm install <plugin> --save`); `nodebb upgrade` merges in
+  # new base dependencies via packageInstall.updatePackageFile() while preserving plugins.
+  if [ ! -f "$dest_dir/package.json" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
     cp "$src_dir/package.json" "$dest_dir/package.json"
   fi
 
-  if [ "$(realpath "$src_dir/$lock_file")" != "$(realpath "$dest_dir/$lock_file")" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
+  if [ ! -f "$dest_dir/$lock_file" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
     cp "$src_dir/$lock_file" "$dest_dir/$lock_file"
   fi
 


### PR DESCRIPTION
### Problem

Running NodeBB via the bundled `docker-compose.yml`, every plugin installed through the ACP is
lost on a container rebuild:

```bash
git pull && docker compose down && docker compose up -d --build
```

The forum comes back up with `plugin is active but not installed` for each one, and the only way
to recover is `docker exec` into the container and reinstalling them by hand. This happens on
every NodeBB upgrade.

### Cause

`copy_or_link_files()` guards the copy of `package.json` into `$CONFIG_DIR` with a `realpath`
comparison:

```bash
if [ "$(realpath "$src_dir/package.json")" != "$(realpath "$dest_dir/package.json")" ] || [ "$OVERRIDE_UPDATE_LOCK" = true ]; then
    cp "$src_dir/package.json" "$dest_dir/package.json"
fi
```

The comparison is meant to detect "already symlinked, nothing to do". That holds for a container
**restart**, but not for a container **recreation**. After `down` + `up --build`,
`/usr/src/app/package.json` is a real file from the image again, while `/opt/config/package.json`
is the persisted file containing the user's plugins (ACP installs run
`npm install <plugin> --save`, see `src/plugins/install.js`). The two realpaths differ, the
condition passes, and the persisted file is overwritten with the pristine copy — dropping every
plugin entry. The subsequent `install_dependencies` then has nothing to reinstall, while the
database still lists the plugins as active.

Notably this bypasses NodeBB's own protection. `packageInstall.updatePackageFile()`
(`src/cli/package-install.js`) exists precisely for this: it *merges* `install/package.json` over
the current one while preserving any dependency matching `pluginNamePattern`. `build_forum()`
does eventually reach it via `nodebb upgrade`, but by then the plugin entries are already gone,
so there is nothing left to preserve.

### Fix

Seed the persisted files only when they don't exist yet, and let the existing upgrade path bring
new base dependencies in. `nodebb upgrade` already runs `updatePackageFile()` →
`preserveExtraneousPlugins()` → `installAll()` (`src/cli/upgrade.js`), which covers the version
bump case while keeping plugins intact. `OVERRIDE_UPDATE_LOCK=true` remains as the escape hatch
to force a reset.

### Testing

Reproduced and verified against the bundled `docker-compose.yml` (MongoDB), installing
`nodebb-plugin-imgur@5.0.0` with the same command the ACP issues
(`npm install <pkg> --save --ignore-scripts`) and activating it.

**Before the change** — after `docker compose down && docker compose up -d --build`:

- `"nodebb-plugin-imgur": "^5.0.0"` was gone from `$CONFIG_DIR/package.json`
- `node_modules/nodebb-plugin-imgur` was gone
- log: `warn: [plugins] "nodebb-plugin-imgur" is active but not installed.`

**After the change** — same rebuild:

- the entry survives in `$CONFIG_DIR/package.json`
- `install_dependencies` restores `node_modules/nodebb-plugin-imgur` automatically
- no `active but not installed` warning; `./nodebb plugins` reports
  `nodebb-plugin-imgur@5.0.0 (installed, enabled)`; forum serves HTTP 200

**Version-bump path** — simulated by adding a dependency to `install/package.json` and
rebuilding. `build_forum()` detected the hash change and ran `nodebb upgrade`; the new base
dependency was merged into `$CONFIG_DIR/package.json` and installed into `node_modules`, while
the plugin entry was preserved. So not copying the file no longer risks stale base dependencies —
`updatePackageFile()` covers that path.

### Relationship to #13735 / #13749

#13735 was closed by #13749, which added `NODEBB_ADDITIONAL_PLUGINS`. That works, but it treats
the symptom — it asks users to maintain a second, parallel list of their plugins in the compose
file, and it is currently undocumented. `plugins:autoinstall` (#11485) doesn't help either, since
`src/install.js` only consults it during `install.setup`, which a rebuild never re-runs.

This change fixes the underlying clobbering, so plugins installed through the ACP persist with no
extra configuration. `NODEBB_ADDITIONAL_PLUGINS` remains useful for declaratively pinning plugins
in immutable/Kubernetes-style deployments.
