### PR TITLE
fix(activitypub): don't double-encode non-ASCII handles in webfinger query

### DIFF
--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -114,7 +114,9 @@ Helpers.query = async (id) => {
 		return cached;
 	}
 
-	const query = new URLSearchParams({ resource: uri });
+	// Build the resource from the raw id; URL serialization percent-encodes non-ASCII
+	// characters, which URLSearchParams would then encode a second time
+	const query = new URLSearchParams({ resource: isUri ? uri.href : `acct:${username}@${hostname}` });
 
 	// Make a webfinger query to retrieve routing information
 	let response;


### PR DESCRIPTION
## Problem

`Helpers.query` builds the webfinger `resource` parameter by passing the `URL` object to `URLSearchParams`:

```js
const uri = isUri ? new URL(id) : new URL(`acct:${id}`);
...
const query = new URLSearchParams({ resource: uri });
```

WHATWG URL serialization percent-encodes non-ASCII characters in the path, and `URLSearchParams` then encodes the `%` signs a second time. The remote server decodes once and looks up a literal `user-%C3%B6...` handle, so webfinger returns **404** for any user whose slug contains non-ASCII characters.

Minimal repro (no server needed):

```js
const uri = new URL('acct:burak-öztürk@dokuzeylul.net');
console.log(uri.href);
// acct:burak-%C3%B6zt%C3%BCrk@dokuzeylul.net   <- already percent-encoded
console.log(new URLSearchParams({ resource: uri }).toString());
// resource=acct%3Aburak-%25C3%25B6zt%25C3%25BCrk%40dokuzeylul.net   <- %25 = double-encoded
```

The receiving instance sees `resource=acct:burak-%C3%B6ztürk@…` after a single decode and responds 404 (verified against a live NodeBB 4.13.2 instance, which answers the correctly single-encoded query with 200).

## Impact

`actors.assert()` performs a webfinger backreference check (`query(\`${actor.preferredUsername}@${domain}\`)`) and drops the actor when it fails. As a result, **federated posts from any user with non-ASCII characters in their username render as guests** on the receiving instance, because the remote user is never persisted. We hit this in production federating three Turkish university forums — every affected account had ö/ü/ğ/ş/ç/ı in its slug; ASCII-only accounts federated fine.

## Fix

Build the `resource` string from the raw handle (`acct:${username}@${hostname}`) for webfinger handles, and from `uri.href` for URIs, so `URLSearchParams` performs the only encoding pass. Behavior for ASCII handles and URI ids is unchanged.

Deployed on our three NodeBB 4.13.2 instances; previously-guest-attributed remote users assert and render correctly after the fix.