### PR TITLE
fix(activitypub): recognize non-ASCII webfinger handles

### DIFF
--- a/public/src/modules/search.js
+++ b/public/src/modules/search.js
@@ -26,7 +26,7 @@ define('search', [
 
 		const quickSearchContainer = searchFields.find('#quick-search-container');
 		const toggleVisibility = searchFields.hasClass('hidden');
-		const webfingerRegex = /^(@|acct:)?[\w-]+@.+$/; // should match src/activitypub/helpers.js
+		const webfingerRegex = /^(@|acct:)?[\p{L}\p{N}\p{M}_.-]+@.+$/u;
 
 		if (toggleVisibility) {
 			searchFields.off('focusout').on('focusout', function dismissSearch() {

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -19,7 +19,8 @@ const ttl = require('../cache/ttl');
 const user = require('../user');
 const activitypub = require('.');
 
-const webfingerRegex = /^(@|acct:)?[\w-.]+@.+$/;
+// \w only matches ASCII, so match unicode letters/numbers/marks explicitly to support non-ASCII handles
+const webfingerRegex = /^(@|acct:)?[\p{L}\p{N}\p{M}_.-]+@.+$/u;
 const webfingerCache = ttl({
 	name: 'ap-webfinger-cache',
 	max: 5000,


### PR DESCRIPTION
## Problem

`webfingerRegex` in `src/activitypub/helpers.js` uses `\w`, which in JS regexes only matches ASCII `[A-Za-z0-9_]`:

```js
const webfingerRegex = /^(@|acct:)?[\w-.]+@.+$/;
```

So `Helpers.isWebfinger()` returns `false` for any handle whose user portion contains non-ASCII characters — e.g. Turkish slugs like `pelin-mirioğlu@dokuzeylul.net` or `burak-öztürk@dokuzeylul.net`, which NodeBB itself generates (slugify preserves unicode letters, and the webfinger endpoint serves these handles just fine).

## Impact

Every call site that classifies input via `isWebfinger()` silently ignores such handles:

- `src/user/search.js` — searching for a remote user by handle never attempts remote resolution
- `src/categories/search.js` — same for remote categories
- `src/activitypub/actors.js` (`Actors.qualify`) — the handle falls through the webfinger translation, fails the `isUri` check, and is **cached in `failedWebfingerCache` as a webfinger failure**, so `actors.assert()` returns `false`

Verified against a live NodeBB 4.13.2 instance (stock vs. patched, same process, same handle):

```
mode: STOCK regex
isWebfinger(pelin-mirioğlu@dokuzeylul.net): false
actors.assert([pelin-mirioğlu@dokuzeylul.net]): false

mode: FIXED regex
isWebfinger(pelin-mirioğlu@dokuzeylul.net): "pelin-mirioğlu@dokuzeylul.net"
actors.assert([pelin-mirioğlu@dokuzeylul.net]): ["https://dokuzeylul.net/uid/323"]
```

## Fix

Match unicode letters/numbers/combining marks explicitly:

```js
const webfingerRegex = /^(@|acct:)?[\p{L}\p{N}\p{M}_.-]+@.+$/u;
```

`\p{M}` is needed because slugs can contain combining marks (e.g. `i̇i̇bf` — Turkish İ lowercased to `i` + U+0307). Everything the old regex accepted is still accepted; strings with spaces, URIs, and malformed handles are still rejected.

## Related

Independent from #14465 (double-encoding of the webfinger `resource` query param), but both surfaced while debugging the same production issue: federation between three Turkish university forums, where most usernames contain ö/ü/ğ/ş/ç/ı. With only #14465 applied, server-initiated federation works, but user-typed handle lookups still dead-end on this regex.