### PR TITLE
fix: don't show bookmark alert when there is nothing to return to

### DIFF
--- a/public/src/client/topic.js
+++ b/public/src/client/topic.js
@@ -157,7 +157,7 @@ define('forum/topic', [
 		updateUserBookmark(postIndex);
 		if (navigator.shouldScrollToPost(postIndex)) {
 			return navigator.scrollToPostIndex(postIndex - 1, true, 0);
-		} else if (bookmark && (
+		} else if (bookmark && parseInt(bookmark, 10) > postIndex && (
 			!config.usePagination ||
 			(config.usePagination && ajaxify.data.pagination.currentPage === 1)
 		) && ajaxify.data.postcount > ajaxify.data.bookmarkThreshold) {
@@ -524,6 +524,7 @@ define('forum/topic', [
 
 		if (
 			ajaxify.data.postcount > ajaxify.data.bookmarkThreshold &&
+			index > ajaxify.data.bookmarkThreshold &&
 			(
 				!currentBookmark ||
 				parseInt(index, 10) > parseInt(currentBookmark, 10) ||


### PR DESCRIPTION
## Problem

The "click here to return to the last read post" alert appears in topics the user never read past the first post, and clicking it just scrolls to the first post — where the user already is.

## Cause

Two client-side issues in `public/src/client/topic.js`:

1. **A bookmark is saved just for opening a topic (guest/localStorage path).** `updateUserBookmark` stores the bookmark in localStorage without checking the index against `bookmarkThreshold` (the server-side handler `SocketTopics.bookmark` does check `data.index > meta.config.bookmarkThreshold`). So a guest (or a user before logging in) who merely opens a topic at post 1 gets `topic:<tid>:bookmark = 1` saved. On the next visit the alert pops up pointing at post 1.

2. **The alert doesn't check that the bookmark is ahead of the current position.** `handleBookmark` shows the alert whenever a bookmark exists, even when `postIndex` is already at/past it, so clicking it goes nowhere useful.

## Fix

- Only save the localStorage bookmark when the index is past `bookmarkThreshold`, mirroring the server-side check.
- Only show the alert when the bookmark points ahead of the current post index. This also neutralizes stale `bookmark = 1` entries already saved in visitors' browsers.

## How to reproduce

1. As a guest, open a topic with more than `bookmarkThreshold` (5) posts and leave without scrolling.
2. Open the same topic again — the "return to last read post" alert appears; clicking it scrolls to post 1, where you already are.