### PR TITLE
refactor: upgrade HTTP signature logic to RFC 9421 standard

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -35,6 +35,7 @@
         "@fortawesome/fontawesome-free": "7.3.1",
         "@isaacs/ttlcache": "2.1.5",
         "@json2csv/node": "7.0.7",
+		"@misskey-dev/node-http-message-signatures": "^0.0.10",
         "@nodebb/spider-detector": "2.0.3",
         "@popperjs/core": "2.11.8",
         "@textcomplete/contenteditable": "0.1.13",

--- a/src/activitypub/index.js
+++ b/src/activitypub/index.js
@@ -2,11 +2,8 @@
 
 const nconf = require('nconf');
 const winston = require('winston');
-const { createHash, getHashes, sign, verify } = require('crypto');
+const { createHash } = require('crypto');
 const { cpus } = require('os');
-const { promisify } = require('util');
-const signAsync = promisify(sign);
-const verifyAsync = promisify(verify);
 
 const request = require('../request');
 const db = require('../database');
@@ -19,8 +16,6 @@ const utils = require('../utils');
 const ttl = require('../cache/ttl');
 const lru = require('../cache/lru');
 const batch = require('../batch');
-const crypto = require('crypto');
-
 const requestCache = ttl({
 	name: 'ap-request-cache',
 	max: 5000,
@@ -70,6 +65,8 @@ ActivityPub._constants = Object.freeze({
 });
 ActivityPub._cache = requestCache;
 ActivityPub._sent = new Map(); // used only in local tests
+
+const signatures = require('./signatures');
 
 ActivityPub.helpers = require('./helpers');
 ActivityPub.inbox = require('./inbox');
@@ -292,101 +289,22 @@ ActivityPub.fetchPublicKey = async (uri, ip) => {
 };
 
 ActivityPub.sign = async ({ key, keyId }, url, digest) => {
-	// Returns string for use in 'Signature' header
-	const { host, pathname } = new URL(url);
-	const date = new Date().toUTCString();
-
-	let headers = '(request-target) host date';
-	let signed_string = `(request-target): ${digest ? 'post' : 'get'} ${pathname}\nhost: ${host}\ndate: ${date}`;
-
-	// Calculate payload hash if payload present
-	if (digest) {
-		headers += ' digest';
-		signed_string += `\ndigest: ${digest}`;
-	}
-
-	// Sign string using private key
-	let signature = await signAsync('sha256', Buffer.from(signed_string), key);
-	signature = signature.toString('base64');
-
-	// Construct signature header
-	return {
-		date,
-		...(digest && { digest }),
-		signature: `keyId="${keyId}",headers="${headers}",signature="${signature}",algorithm="hs2019"`,
-	};
+	// Determines HTTP method based on digest presence
+	const method = digest ? 'POST' : 'GET';
+	return await signatures.sign({ key, keyId }, url, method, digest);
 };
 
 ActivityPub.verify = async (req) => {
 	ActivityPub.helpers.log('[activitypub/verify] Starting signature verification...');
-	if (!req.headers.hasOwnProperty('signature')) {
-		ActivityPub.helpers.log('[activitypub/verify]   Failed, no signature header.');
-		return false;
+
+	const isValid = await signatures.verify(req, ActivityPub.fetchPublicKey);
+	if (!isValid) {
+		ActivityPub.helpers.log('[activitypub/verify] Signature verification failed.');
+	} else {
+		ActivityPub.helpers.log('[activitypub/verify] Signature verification succeeded.');
 	}
 
-	// Verify the signature string via public key
-	try {
-		// Break the signature apart
-		let { keyId, headers, signature, algorithm, created, expires } = req.headers.signature.split(',').reduce((memo, cur) => {
-			const split = cur.split('="');
-			const key = split.shift();
-			const value = split.join('="');
-			memo[key] = value.slice(0, -1);
-			return memo;
-		}, {});
-
-		const acceptableHashes = getHashes();
-		if (algorithm === 'hs2019' || !acceptableHashes.includes(algorithm)) {
-			algorithm = 'sha256';
-		}
-
-		// Verify Digest header matches request body
-		if (headers.includes('digest')) {
-			const receivedDigest = req.headers.digest;
-			const bodyData = req.rawBody || (typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
-			const bodyDigest = `SHA-256=${createHash('sha256').update(bodyData).digest('base64')}`;
-			if (receivedDigest !== bodyDigest) {
-				ActivityPub.helpers.log('[activitypub/verify]   Failed, digest mismatch.');
-				return false;
-			}
-		}
-
-		// Re-construct signature string
-		const signed_string = headers.split(' ').reduce((memo, cur) => {
-			switch (cur) {
-				case '(request-target)': {
-					memo.push(`${cur}: ${String(req.method).toLowerCase()} ${req.baseUrl}${req.path}`);
-					break;
-				}
-
-				case '(created)': {
-					memo.push(`${cur}: ${created}`);
-					break;
-				}
-
-				case '(expires)': {
-					memo.push(`${cur}: ${expires}`);
-					break;
-				}
-
-				default: {
-					memo.push(`${cur}: ${req.headers[cur]}`);
-					break;
-				}
-			}
-
-			return memo;
-		}, []).join('\n');
-
-		// Retrieve public key from remote instance
-		ActivityPub.helpers.log(`[activitypub/verify] Retrieving pubkey for ${keyId}`);
-		const publicKeyPem = await ActivityPub.fetchPublicKey(keyId, req.ip);
-
-		return await verifyAsync('sha256', Buffer.from(signed_string), publicKeyPem, Buffer.from(signature, 'base64'));
-	} catch (e) {
-		ActivityPub.helpers.log('[activitypub/verify]   Failed, key retrieval or verification failure.');
-		return false;
-	}
+	return isValid;
 };
 
 ActivityPub.get = async (type, id, uri, options) => {
@@ -540,7 +458,7 @@ ActivityPub.send = async (type, id, targets, payload) => {
 			await Promise.all(inboxBatch.map(async (uri) => {
 				const ok = await ActivityPub._sendMessage(uri, keyData, payload, digest);
 				if (!ok) {
-					const queueId = crypto.createHash('sha256').update(`${type}:${id}:${uri}`).digest('hex');
+					const queueId = createHash('sha256').update(`${type}:${id}:${uri}`).digest('hex');
 					const nextTryOn = Date.now() + oneMinute;
 					retryQueueAdd.push(['ap:retry:queue', nextTryOn, queueId]);
 					retryQueuedSet.push([`ap:retry:queue:${queueId}`, {

--- a/src/activitypub/index.js
+++ b/src/activitypub/index.js
@@ -81,7 +81,7 @@ ActivityPub.relays = require('./relays');
 ActivityPub.out = require('./out');
 ActivityPub.jobs = require('./jobs');
 ActivityPub.analytics = require('./analytics');
-ActivityPub. signatures = require('./signatures');
+ActivityPub.signatures = require('./signatures');
 
 ActivityPub.resolveId = async (uid, id) => {
 	try {

--- a/src/activitypub/index.js
+++ b/src/activitypub/index.js
@@ -66,7 +66,6 @@ ActivityPub._constants = Object.freeze({
 ActivityPub._cache = requestCache;
 ActivityPub._sent = new Map(); // used only in local tests
 
-const signatures = require('./signatures');
 
 ActivityPub.helpers = require('./helpers');
 ActivityPub.inbox = require('./inbox');
@@ -82,6 +81,7 @@ ActivityPub.relays = require('./relays');
 ActivityPub.out = require('./out');
 ActivityPub.jobs = require('./jobs');
 ActivityPub.analytics = require('./analytics');
+ActivityPub. signatures = require('./signatures');
 
 ActivityPub.resolveId = async (uid, id) => {
 	try {
@@ -291,13 +291,13 @@ ActivityPub.fetchPublicKey = async (uri, ip) => {
 ActivityPub.sign = async ({ key, keyId }, url, digest) => {
 	// Determines HTTP method based on digest presence
 	const method = digest ? 'POST' : 'GET';
-	return await signatures.sign({ key, keyId }, url, method, digest);
+	return await ActivityPub.signatures.sign({ key, keyId }, url, method, digest);
 };
 
 ActivityPub.verify = async (req) => {
 	ActivityPub.helpers.log('[activitypub/verify] Starting signature verification...');
 
-	const isValid = await signatures.verify(req, ActivityPub.fetchPublicKey);
+	const isValid = await ActivityPub.signatures.verify(req, ActivityPub.fetchPublicKey);
 	if (!isValid) {
 		ActivityPub.helpers.log('[activitypub/verify] Signature verification failed.');
 	} else {

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -12,7 +12,6 @@ const {
 	parseDraftRequest,
 	parseRFC9421Request,
 	verifyRFC9421Signature,
-	parseAndImportPublicKey,
 } = require('@misskey-dev/node-http-message-signatures');
 
 const Signatures = module.exports;
@@ -125,14 +124,25 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 	}
 };
 
+function getRequestUrl(req) {
+	const relativePath = nconf.get('relative_path') || '';
+	let requestPath = req.originalUrl || req.url || req.path || '/';
+
+	if (relativePath && !requestPath.startsWith(relativePath)) {
+		requestPath = `${relativePath}${requestPath.startsWith('/') ? '' : '/'}${requestPath}`;
+	}
+
+	const origin = nconf.get('url_parsed') ? nconf.get('url_parsed').origin : nconf.get('url');
+	return new URL(requestPath, origin).href;
+}
+
 async function tryVerifyDraft(req, fetchPublicKeyFn) {
 	try {
 		if (!req.headers.signature) {
 			return false;
 		}
 
-		// Build absolute URL required by the library parser
-		const fullUrl = new URL(req.originalUrl || req.url, nconf.get('url')).href;
+		const fullUrl = getRequestUrl(req);
 		const requestObj = {
 			method: req.method,
 			url: fullUrl,
@@ -151,7 +161,6 @@ async function tryVerifyDraft(req, fetchPublicKeyFn) {
 			throw new Error(`Public key not found for keyId: ${parsed.value.keyId}`);
 		}
 
-		// Pass parsed.value, the public key, and winston as the errorLogger
 		const result = await verifyDraftSignature(
 			parsed.value,
 			publicKeyPem,
@@ -171,8 +180,7 @@ async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
 			return false;
 		}
 
-		// Build absolute URL required by the library parser
-		const fullUrl = new URL(req.originalUrl || req.url, nconf.get('url')).href;
+		const fullUrl = getRequestUrl(req);
 		const requestObj = {
 			method: req.method,
 			url: fullUrl,
@@ -193,11 +201,11 @@ async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
 			throw new Error(`Public key not found for keyId: ${keyId}`);
 		}
 
-		// Import public key into CryptoKey format required by library
-		const publicKey = await parseAndImportPublicKey(publicKeyPem);
-
-		// Pass the top-level `parsed` object to verifyRFC9421Signature
-		const result = await verifyRFC9421Signature(parsed, publicKey);
+		const result = await verifyRFC9421Signature(
+			parsed,
+			publicKeyPem,
+			msg => winston.warn(`[activitypub/signatures] verifyRFC9421Signature error: ${msg}`)
+		);
 
 		return !!result;
 	} catch (err) {

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -1,0 +1,206 @@
+'use strict';
+
+const nconf = require('nconf');
+const winston = require('winston');
+const { createHash } = require('crypto');
+const {
+	genDraftSignature,
+	genDraftSignatureHeader,
+	genDraftSigningString,
+	importPrivateKey,
+	verifyDraftSignature,
+	parseDraftRequest,
+	parseRFC9421Request,
+	verifyRFC9421Signature,
+	parseAndImportPublicKey,
+} = require('@misskey-dev/node-http-message-signatures');
+
+const Signatures = module.exports;
+
+Signatures.calculateDigest = (body) => {
+	if (!body) return null;
+	const bodyData = typeof body === 'string' || Buffer.isBuffer(body) ?
+		body :
+		JSON.stringify(body);
+
+	const hash = createHash('sha256').update(bodyData).digest('base64');
+	return `SHA-256=${hash}`;
+};
+
+Signatures.sign = async ({ key, keyId }, url, method = 'GET', digest = null) => {
+	const parsedUrl = new URL(url);
+	const date = new Date().toUTCString();
+
+	// Headers required for signing
+	const headersToSign = {
+		date,
+		host: parsedUrl.host,
+	};
+
+	if (digest) {
+		headersToSign.digest = digest;
+	}
+
+	try {
+		// Import private key
+		const privateKey = await importPrivateKey(key, ['sign']);
+
+		// Determine signed headers list
+		const signedHeaders = digest ?
+			['(request-target)', 'host', 'date', 'digest'] :
+			['(request-target)', 'host', 'date'];
+
+		// Build signing string
+		const signingString = genDraftSigningString(
+			{ method, url: parsedUrl.href, headers: headersToSign },
+			signedHeaders,
+			{ keyId },
+		);
+
+		// Sign
+		const signature = await genDraftSignature(privateKey, signingString);
+
+		// Construct signature header
+		const signatureHeader = genDraftSignatureHeader(signedHeaders, keyId, signature, getDraftAlgoString(privateKey));
+
+		return {
+			date,
+			...(digest && { digest }),
+			signature: signatureHeader,
+		};
+	} catch (err) {
+		winston.error(`[activitypub/signatures] Sign error: ${err.message}`);
+		throw err;
+	}
+};
+
+function getDraftAlgoString(key) {
+	const { name } = key.algorithm;
+	if (name === 'RSA') {
+		return 'rsa-sha256';
+	}
+	if (name === 'EC') {
+		return 'ecdsa-p256-sha256';
+	}
+	return 'rsa-sha256';
+}
+
+Signatures.verify = async (req, fetchPublicKeyFn) => {
+	try {
+		const { headers } = req;
+
+		// 1. Check if signature header exists (either RFC 9421 or draft format)
+		const hasSignature = headers.hasOwnProperty('signature') || headers.hasOwnProperty('signature-input');
+		if (!hasSignature) {
+			return false;
+		}
+
+		// 2. Digest check for requests with body (POST/PUT)
+		if (headers.digest) {
+			const bodyData = req.rawBody || (typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
+			if (!bodyData) return false;
+
+			const computedDigest = Signatures.calculateDigest(bodyData);
+			if (headers.digest !== computedDigest) {
+				winston.warn('[activitypub/signatures] Digest mismatch during request verification');
+				return false;
+			}
+		}
+
+		// 3. Try draft signature verification first (legacy Cavage/hs2019)
+		const draftVerified = await tryVerifyDraft(req, fetchPublicKeyFn);
+		if (draftVerified) {
+			return true;
+		}
+
+		// 4. Try RFC 9421 signature verification
+		const rfcVerified = await tryVerifyRFC9421(req, fetchPublicKeyFn);
+		if (rfcVerified) {
+			return true;
+		}
+
+		// Neither verification method succeeded
+		return false;
+	} catch (err) {
+		winston.warn(`[activitypub/signatures] Verification failed: ${err.message}`);
+		return false;
+	}
+};
+
+async function tryVerifyDraft(req, fetchPublicKeyFn) {
+	try {
+		if (!req.headers.signature) {
+			return false;
+		}
+
+		// Build absolute URL required by the library parser
+		const fullUrl = new URL(req.originalUrl || req.url, nconf.get('url')).href;
+		const requestObj = {
+			method: req.method,
+			url: fullUrl,
+			headers: req.headers,
+		};
+
+		// Parse the draft request
+		const parsed = parseDraftRequest(requestObj);
+		if (!parsed || !parsed.value || !parsed.value.keyId) {
+			return false;
+		}
+
+		// Fetch public key PEM
+		const publicKeyPem = await fetchPublicKeyFn(parsed.value.keyId, req.ip);
+		if (!publicKeyPem) {
+			throw new Error(`Public key not found for keyId: ${parsed.value.keyId}`);
+		}
+
+		// Import public key into CryptoKey format required by library
+		const publicKey = await parseAndImportPublicKey(publicKeyPem);
+
+		// Verify signature using imported public key object
+		const result = await verifyDraftSignature(parsed.value, publicKey);
+
+		return !!result;
+	} catch (err) {
+		winston.debug(`[activitypub/signatures] Draft verification failed: ${err.message}`);
+		return false;
+	}
+}
+
+async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
+	try {
+		if (!req.headers['signature-input'] || !req.headers.signature) {
+			return false;
+		}
+
+		// Build absolute URL required by the library parser
+		const fullUrl = new URL(req.originalUrl || req.url, nconf.get('url')).href;
+		const requestObj = {
+			method: req.method,
+			url: fullUrl,
+			headers: req.headers,
+		};
+
+		// Parse RFC 9421 request signature
+		const parsed = parseRFC9421Request(requestObj);
+		if (!parsed || !parsed.value || !parsed.value.keyId) {
+			return false;
+		}
+
+		// Fetch public key PEM
+		const publicKeyPem = await fetchPublicKeyFn(parsed.value.keyId, req.ip);
+		if (!publicKeyPem) {
+			throw new Error(`Public key not found for keyId: ${parsed.value.keyId}`);
+		}
+
+		// Import public key into CryptoKey format required by library
+		const publicKey = await parseAndImportPublicKey(publicKeyPem);
+
+		// Verify RFC 9421 signature using imported public key object
+		const result = await verifyRFC9421Signature(parsed.value, publicKey);
+
+		return !!result;
+	} catch (err) {
+		winston.debug(`[activitypub/signatures] RFC 9421 verification failed: ${err.message}`);
+		return false;
+	}
+}

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -17,6 +17,17 @@ const {
 
 const Signatures = module.exports;
 
+// Calculates RFC 9530 Digest header string for request payloads.
+Signatures.calculateDigest = (body) => {
+	if (!body) return null;
+	const bodyData = typeof body === 'string' || Buffer.isBuffer(body) ?
+		body :
+		JSON.stringify(body);
+
+	const hash = createHash('sha256').update(bodyData).digest('base64');
+	return `SHA-256=${hash}`;
+};
+
 Signatures.sign = async ({ key, keyId }, url, method = 'GET', digest = null) => {
 	const parsedUrl = new URL(url);
 	const date = new Date().toUTCString();
@@ -90,7 +101,7 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 			const bodyData = req.rawBody || (typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
 			if (!bodyData) return false;
 
-			const computedDigest = calculateDigest(bodyData);
+			const computedDigest = Signatures.calculateDigest(bodyData);
 			if (headers.digest !== computedDigest) {
 				winston.warn('[activitypub/signatures] Digest mismatch during request verification');
 				return false;
@@ -112,16 +123,6 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 		winston.warn(`[activitypub/signatures] Verification failed: ${err.message}`);
 		return false;
 	}
-};
-
-function calculateDigest(body) {
-	if (!body) return null;
-	const bodyData = typeof body === 'string' || Buffer.isBuffer(body) ?
-		body :
-		JSON.stringify(body);
-
-	const hash = createHash('sha256').update(bodyData).digest('base64');
-	return `SHA-256=${hash}`;
 };
 
 async function tryVerifyDraft(req, fetchPublicKeyFn) {
@@ -150,11 +151,12 @@ async function tryVerifyDraft(req, fetchPublicKeyFn) {
 			throw new Error(`Public key not found for keyId: ${parsed.value.keyId}`);
 		}
 
-		// Import public key into CryptoKey format required by library
-		const publicKey = await parseAndImportPublicKey(publicKeyPem);
-
-		// Verify signature using imported public key object
-		const result = await verifyDraftSignature(parsed.value, publicKey);
+		// Pass parsed.value, the public key, and winston as the errorLogger
+		const result = await verifyDraftSignature(
+			parsed.value,
+			publicKeyPem,
+			msg => winston.warn(`[activitypub/signatures] verifyDraftSignature error: ${msg}`)
+		);
 
 		return !!result;
 	} catch (err) {
@@ -179,21 +181,23 @@ async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
 
 		// Parse RFC 9421 request signature
 		const parsed = parseRFC9421Request(requestObj);
-		if (!parsed || !parsed.value || !parsed.value.keyId) {
+		const keyId = parsed?.value?.keyId || parsed?.keyId;
+
+		if (!parsed || !keyId) {
 			return false;
 		}
 
 		// Fetch public key PEM
-		const publicKeyPem = await fetchPublicKeyFn(parsed.value.keyId, req.ip);
+		const publicKeyPem = await fetchPublicKeyFn(keyId, req.ip);
 		if (!publicKeyPem) {
-			throw new Error(`Public key not found for keyId: ${parsed.value.keyId}`);
+			throw new Error(`Public key not found for keyId: ${keyId}`);
 		}
 
 		// Import public key into CryptoKey format required by library
 		const publicKey = await parseAndImportPublicKey(publicKeyPem);
 
-		// Verify RFC 9421 signature using imported public key object
-		const result = await verifyRFC9421Signature(parsed.value, publicKey);
+		// Pass the top-level `parsed` object to verifyRFC9421Signature
+		const result = await verifyRFC9421Signature(parsed, publicKey);
 
 		return !!result;
 	} catch (err) {

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -17,16 +17,6 @@ const {
 
 const Signatures = module.exports;
 
-Signatures.calculateDigest = (body) => {
-	if (!body) return null;
-	const bodyData = typeof body === 'string' || Buffer.isBuffer(body) ?
-		body :
-		JSON.stringify(body);
-
-	const hash = createHash('sha256').update(bodyData).digest('base64');
-	return `SHA-256=${hash}`;
-};
-
 Signatures.sign = async ({ key, keyId }, url, method = 'GET', digest = null) => {
 	const parsedUrl = new URL(url);
 	const date = new Date().toUTCString();
@@ -100,7 +90,7 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 			const bodyData = req.rawBody || (typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
 			if (!bodyData) return false;
 
-			const computedDigest = Signatures.calculateDigest(bodyData);
+			const computedDigest = calculateDigest(bodyData);
 			if (headers.digest !== computedDigest) {
 				winston.warn('[activitypub/signatures] Digest mismatch during request verification');
 				return false;
@@ -125,6 +115,16 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 		winston.warn(`[activitypub/signatures] Verification failed: ${err.message}`);
 		return false;
 	}
+};
+
+function calculateDigest(body) {
+	if (!body) return null;
+	const bodyData = typeof body === 'string' || Buffer.isBuffer(body) ?
+		body :
+		JSON.stringify(body);
+
+	const hash = createHash('sha256').update(bodyData).digest('base64');
+	return `SHA-256=${hash}`;
 };
 
 async function tryVerifyDraft(req, fetchPublicKeyFn) {

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -79,13 +79,13 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 	try {
 		const { headers } = req;
 
-		// 1. Check if signature header exists (either RFC 9421 or draft format)
+		// Check if signature header exists (either RFC 9421 or draft format)
 		const hasSignature = headers.hasOwnProperty('signature') || headers.hasOwnProperty('signature-input');
 		if (!hasSignature) {
 			return false;
 		}
 
-		// 2. Digest check for requests with body (POST/PUT)
+		// Digest check for requests with body (POST/PUT)
 		if (headers.digest) {
 			const bodyData = req.rawBody || (typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
 			if (!bodyData) return false;
@@ -97,19 +97,16 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 			}
 		}
 
-		// 3. Try draft signature verification first (legacy Cavage/hs2019)
-		const draftVerified = await tryVerifyDraft(req, fetchPublicKeyFn);
-		if (draftVerified) {
-			return true;
-		}
-
-		// 4. Try RFC 9421 signature verification
 		const rfcVerified = await tryVerifyRFC9421(req, fetchPublicKeyFn);
 		if (rfcVerified) {
 			return true;
 		}
 
-		// Neither verification method succeeded
+		const draftVerified = await tryVerifyDraft(req, fetchPublicKeyFn);
+		if (draftVerified) {
+			return true;
+		}
+
 		return false;
 	} catch (err) {
 		winston.warn(`[activitypub/signatures] Verification failed: ${err.message}`);

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -137,6 +137,7 @@ module.exports = function (User) {
 			`uid:${uid}:sessions`,
 			`uid:${uid}:shares`,
 			`uid:${uid}:profile:pictures`,
+			`uid:${uid}:keys`,
 			`invitation:uid:${uid}`,
 		];
 

--- a/test/activitypub/signatures.js
+++ b/test/activitypub/signatures.js
@@ -112,6 +112,7 @@ describe('http signature signing and verification', () => {
 			const req = {
 				...mockReqBase,
 				...{
+					url: path,
 					path,
 					headers: { ...signature, host },
 				},
@@ -135,6 +136,7 @@ describe('http signature signing and verification', () => {
 				...mockReqBase,
 				...{
 					method: 'POST',
+					url: path,
 					path,
 					body: payload,
 					headers: { ...signature, host },


### PR DESCRIPTION
The prior implementation was a bespoke HTTP signatures implementation following the now-outdated cavage-12 standard. ActivtiyPub development is moving away from cavage-12 and toward the now standardized RFC 9421.

Instead of rolling our own again, this PR will introduce integration with misskey-dev/node-http-message-signatures, as recommended by httpsig.org
