### PR TITLE
fix(minifier): wait for in-flight requests before killing children

### DIFF
--- a/src/meta/minifier.js
+++ b/src/meta/minifier.js
@@ -19,6 +19,7 @@ const pool = [];
 const free = [];
 
 let maxThreads = 0;
+let pendingRequests = 0;
 
 Object.defineProperty(Minifier, 'maxThreads', {
 	get: function () {
@@ -37,13 +38,29 @@ Object.defineProperty(Minifier, 'maxThreads', {
 Minifier.maxThreads = Math.max(1, os.cpus().length - 1);
 
 Minifier.killAll = function () {
+	if (pendingRequests > 0) {
+		return new Promise((resolve) => {
+			const checkInterval = setInterval(() => {
+				if (pendingRequests <= 0) {
+					clearInterval(checkInterval);
+					doKillAll();
+					resolve();
+				}
+			}, 50);
+		});
+	}
+	doKillAll();
+	return Promise.resolve();
+};
+
+function doKillAll() {
 	pool.forEach((child) => {
 		child.kill('SIGTERM');
 	});
 
 	pool.length = 0;
 	free.length = 0;
-};
+}
 
 function getChild() {
 	while (free.length) {
@@ -96,12 +113,16 @@ function forkAction(action) {
 	return new Promise((resolve, reject) => {
 		const proc = getChild();
 
+		pendingRequests += 1;
+
 		if (!proc.connected || proc.killed) {
+			pendingRequests -= 1;
 			return reject(new Error('Child process is not connected or has been killed'));
 		}
 		const onMessage = (message) => {
 			cleanup();
 			freeChild(proc);
+			pendingRequests -= 1;
 
 			if (message.type === 'error') {
 				return reject(new Error(message.message));
@@ -114,6 +135,7 @@ function forkAction(action) {
 		const onError = (err) => {
 			cleanup();
 			freeChild(proc);
+			pendingRequests -= 1;
 			reject(err);
 		};
 

--- a/test/mocks/databasemock.js
+++ b/test/mocks/databasemock.js
@@ -183,6 +183,11 @@ before(async function () {
 			await setupMockDefaults();
 		});
 	});
+	// Attach a global afterAll that waits for pending minifier requests
+	// (e.g., from harmony theme's buildSkins scheduled via setTimeout)
+	this.test.parent.afterAll(async () => {
+		await require('../../src/meta/minifier').killAll();
+	});
 });
 
 async function setupMockDefaults() {


### PR DESCRIPTION
The harmony theme schedules CSS skin building via setTimeout in its
init() function, spawning minifier child processes. When tests exit,
these workers may still be processing and try to send IPC responses
after the main process terminates, causing EPIPE errors.

- Track pending forked requests with a counter
- killAll() now polls until all in-flight requests complete before
  terminating children (returns a Promise for this)
- Add global test afterAll hook that awaits killAll() to ensure
  pending minifier work finishes before test process exits

Assisted-by: unsloth/Qwen3.6-35B-A3B-GGUF
Signed-off-by: Julian Lam <julian@nodebb.org>
