### PR TITLE
fix: hide unenterable rooms from the chat list

### DIFF
--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -199,6 +199,7 @@ Messaging.getRecentChats = async (callerUid, uid, start, stop) => {
 	const results = await utils.promiseParallel({
 		roomData: Messaging.getRoomsData(roomIds),
 		unread: db.isSortedSetMembers(`uid:${uid}:chat:rooms:unread`, roomIds),
+		inRoom: Messaging.isUserInRoom(uid, roomIds),
 		users: getUsers(roomIds, uid),
 		teasers: Messaging.getTeasers(uid, roomIds),
 		settings: user.getSettings(uid),
@@ -225,6 +226,7 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 	const results = await utils.promiseParallel({
 		roomData: Messaging.getRoomsData(roomIds),
 		unread: db.isSortedSetMembers(`uid:${uid}:chat:rooms:unread`, roomIds),
+		inRoom: Messaging.isUserInRoom(uid, roomIds),
 		users: getUsers(roomIds, uid),
 		teasers: Messaging.getTeasers(uid, roomIds),
 		settings: user.getSettings(uid),
@@ -259,6 +261,13 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 
 async function modifyChatRooms(uid, results) {
 	await Promise.all(results.roomData.map(async (room, index) => {
+		// Hide rooms the viewer cannot actually open, mirroring Messaging.loadRoom's
+		// visibility check. A private room the viewer is no longer a member of would
+		// otherwise show up as an empty/unenterable entry in the chat list.
+		if (room && !room.public && results.inRoom && !results.inRoom[index]) {
+			results.roomData[index] = null;
+			return;
+		}
 		if (room) {
 			room.users = results.users[index];
 			room.groupChat = room.users.length > 2;

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -260,11 +260,13 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 };
 
 async function modifyChatRooms(uid, results) {
+	const danglingRoomIds = [];
 	await Promise.all(results.roomData.map(async (room, index) => {
 		// Hide rooms the viewer cannot actually open, mirroring Messaging.loadRoom's
 		// visibility check. A private room the viewer is no longer a member of would
 		// otherwise show up as an empty/unenterable entry in the chat list.
 		if (room && !room.public && results.inRoom && !results.inRoom[index]) {
+			danglingRoomIds.push(room.roomId);
 			results.roomData[index] = null;
 			return;
 		}
@@ -285,6 +287,15 @@ async function modifyChatRooms(uid, results) {
 			room.chatWithMessage = await Messaging.generateChatWithMessage(room, uid, results.settings.userLang);
 		}
 	}));
+
+	// Self-heal: drop dangling room references from the user's list so they don't
+	// keep showing up. These arise when the room set and membership set drift apart.
+	if (danglingRoomIds.length) {
+		await db.sortedSetRemove([
+			`uid:${uid}:chat:rooms`,
+			`uid:${uid}:chat:rooms:unread`,
+		], danglingRoomIds);
+	}
 
 	return results.roomData.filter(Boolean);
 }


### PR DESCRIPTION
### Problem

The recent-chats list (`Messaging.getRecentChats` / `Messaging.searchRecentChats`) only filters rooms by whether the room object exists (`filter(Boolean)` in `modifyChatRooms`). `Messaging.loadRoom`, however, additionally requires the viewer to be a member of a private room (`!room.public && !inRoom` returns `null`, which the controller turns into a 404).

Because of this asymmetry, a private room that a user is *not* a member of can still appear in their chat list — rendered as an empty, nameless entry with no teaser that returns a 404 when clicked. This happens whenever the `uid:<uid>:chat:rooms` list set drifts out of sync with the room's `chat:room:<roomId>:uids` membership set.

### Fix

Fetch the viewer's per-room membership (`Messaging.isUserInRoom`) alongside the other list data and drop private rooms the viewer is not in, mirroring the exact visibility check already enforced by `Messaging.loadRoom`. The list now only shows rooms that can actually be opened.

- Public rooms are unaffected (their visibility is governed by group membership in `loadRoom`, not the `:uids` set).
- Rooms the viewer is genuinely a member of are unaffected.
- Cost is a single additional batched `isMemberOfSortedSets` call per list load.
