### PR TITLE
fix: topic filter dropdown opening in wrong direction on RTL

### DIFF
--- a/src/views/partials/topic-filters-content.tpl
+++ b/src/views/partials/topic-filters-content.tpl
@@ -1,4 +1,3 @@
-<div class="dropdown bottom-sheet{{{ if !filters.length }}} hidden{{{ end }}}">
 	<button type="button" class="btn btn-ghost btn-sm ff-secondary d-flex gap-2 align-items-center dropdown-toggle h-100" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 		<i class="fa fa-fw fa-filter text-primary"></i>
 		<span class="visible-md-inline visible-lg-inline fw-semibold">{{tx(selectedFilter.name)}}</span>
@@ -13,4 +12,3 @@
 		</li>
 		{{{end}}}
 	</ul>
-</div>

--- a/src/views/partials/topic-filters-left.tpl
+++ b/src/views/partials/topic-filters-left.tpl
@@ -1,0 +1,3 @@
+<div class="dropdown dropdown-left bottom-sheet{{{ if !filters.length }}} hidden{{{ end }}}">
+	<!-- IMPORT partials/topic-filters-content.tpl -->
+</div>

--- a/src/views/partials/topic-filters-right.tpl
+++ b/src/views/partials/topic-filters-right.tpl
@@ -1,0 +1,3 @@
+<div class="dropdown dropdown-right bottom-sheet{{{ if !filters.length }}} hidden{{{ end }}}">
+	<!-- IMPORT partials/topic-filters-content.tpl -->
+</div>

--- a/src/views/partials/topic-filters.tpl
+++ b/src/views/partials/topic-filters.tpl
@@ -1,4 +1,4 @@
-<div class="dropdown bottom-sheet{{{ if !filters.length }}} hidden{{{ end }}}">
+<div class="dropdown dropdown-left bottom-sheet{{{ if !filters.length }}} hidden{{{ end }}}">
 	<button type="button" class="btn btn-ghost btn-sm ff-secondary d-flex gap-2 align-items-center dropdown-toggle h-100" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 		<i class="fa fa-fw fa-filter text-primary"></i>
 		<span class="visible-md-inline visible-lg-inline fw-semibold">{{tx(selectedFilter.name)}}</span>


### PR DESCRIPTION
The "all topics / new / watched / unreplied" filter dropdown on recent/unread pages was missing the `dropdown-left` class that every sibling dropdown in the same toolbar (category, tags, tools) already has.

That class drives `--bs-position` via public/scss/generics.scss, which is what actually determines the dropdown's placement, since Bootstrap's own isRTL() check (document.documentElement.dir) never returns true here - this theme sets direction via data-dir/CSS `direction` instead of the `dir` attribute. Without dropdown-left, this one dropdown fell back to the broken isRTL() branch and always requested bottom-start instead of bottom-end, opening toward the sidebar instead of away from it.