### PR TITLE
Fix Email Invite Modal

### DIFF
--- a/public/src/modules/accounts/invite.js
+++ b/public/src/modules/accounts/invite.js
@@ -11,7 +11,7 @@ define('accounts/invite', ['api', 'benchpress', 'modals', 'alerts'], function (a
 		$('[component="user/invite"]').on('click', function (e) {
 			e.preventDefault();
 			api.get(`/api/v3/users/${app.user.uid}/invites/groups`, {}).then((groups) => {
-				Benchpress.render('modals/invite', { groups }, function (html) {
+				return Benchpress.render('modals/invite', { groups }).then(function (html) {
 					modals.dialog({
 						message: html,
 						title: `[[${isACP() ? 'admin/manage/users:invite' : 'users:invite'}]]`,


### PR DESCRIPTION
Was trying out this forum app, the invite by email modal didn't show up when I clicked the button. the AI agent that was getting it going in my self-hosted setup was able to identify and fix this issue, it then built a version with this diff and I tested, seemed to have fixed the issue.

Notes from the AI agent:
  - Regression from: fa77f1e ("fix: modals need benchpress.render", 2026-06-24), which changed this call from Benchpress.parse to Benchpress.render. parse(template, data, callback) invokes the callback;
  render(template, data, block) treats the 3rd arg as a block name, so the function is ignored, render resolves to '', and modals.dialog is never called.
  - Affects: v4.14.2 (latest) and master. Both the ACP "Invite by Email" and the front-end /users invite use this handler.
  - Fix: use the promise form (matches how handleUserCreate and other modals already call Benchpress.render). The added return keeps the render chained to the existing .catch(alerts.error).