### PR TITLE
fix: don't prompt for plugin upgrades when stdin is not a TTY

### DIFF
--- a/src/cli/upgrade-plugins.js
+++ b/src/cli/upgrade-plugins.js
@@ -120,6 +120,25 @@ async function checkPlugins() {
 	return upgradable;
 }
 
+async function getUpgradeConfirmation(unattended) {
+	if (unattended) {
+		return true;
+	}
+	if (!process.stdin.isTTY) {
+		return false;
+	}
+	prompt.message = '';
+	prompt.delimiter = '';
+
+	prompt.start();
+	const result = await prompt.get({
+		name: 'upgrade',
+		description: '\nProceed with upgrade (y|n)?',
+		type: 'string',
+	});
+	return ['y', 'Y', 'yes', 'YES'].includes(result.upgrade);
+}
+
 async function upgradePlugins(unattended = false) {
 	try {
 		const found = await checkPlugins();
@@ -132,20 +151,8 @@ async function upgradePlugins(unattended = false) {
 			console.log(chalk.green('\nAll packages up-to-date!'));
 			return;
 		}
-		let result = { upgrade: 'y' };
-		if (!unattended) {
-			prompt.message = '';
-			prompt.delimiter = '';
 
-			prompt.start();
-			result = await prompt.get({
-				name: 'upgrade',
-				description: '\nProceed with upgrade (y|n)?',
-				type: 'string',
-			});
-		}
-
-		if (['y', 'Y', 'yes', 'YES'].includes(result.upgrade)) {
+		if (await getUpgradeConfirmation(unattended)) {
 			console.log('\nUpgrading packages...');
 			const args = packageManagerInstallArgs.concat(found.map(suggestObj => `${suggestObj.name}@${suggestObj.suggested}`));
 			const options = { stdio: 'ignore' };
@@ -162,4 +169,5 @@ async function upgradePlugins(unattended = false) {
 	}
 }
 
+exports.getUpgradeConfirmation = getUpgradeConfirmation;
 exports.upgradePlugins = upgradePlugins;

--- a/test/upgrade-plugins.js
+++ b/test/upgrade-plugins.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const assert = require('assert');
+
+const prompt = require('prompt');
+
+const { getUpgradeConfirmation } = require('../src/cli/upgrade-plugins');
+
+describe('Upgrade plugins', () => {
+	describe('getUpgradeConfirmation()', () => {
+		const originalIsTTY = process.stdin.isTTY;
+		const originalGet = prompt.get;
+
+		afterEach(() => {
+			process.stdin.isTTY = originalIsTTY;
+			prompt.get = originalGet;
+		});
+
+		it('should confirm without prompting when unattended', async () => {
+			prompt.get = async () => assert.fail('prompt should not be called when unattended');
+			assert.strictEqual(await getUpgradeConfirmation(true), true);
+		});
+
+		it('should decline without prompting when stdin is not a TTY', async () => {
+			process.stdin.isTTY = false;
+			prompt.get = async () => assert.fail('prompt should not be called without a TTY');
+			assert.strictEqual(await getUpgradeConfirmation(false), false);
+		});
+
+		it('should prompt and confirm on a yes answer when stdin is a TTY', async () => {
+			process.stdin.isTTY = true;
+			prompt.get = async () => ({ upgrade: 'y' });
+			assert.strictEqual(await getUpgradeConfirmation(false), true);
+		});
+
+		it('should prompt and decline on answers other than yes', async () => {
+			process.stdin.isTTY = true;
+			prompt.get = async () => ({ upgrade: 'n' });
+			assert.strictEqual(await getUpgradeConfirmation(false), false);
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Since #14460, plugins installed through the ACP correctly survive a container recreation. That fix exposed a latent bug in `nodebb upgrade`: on the next
`git pull && docker compose down && docker compose up --build -d`, the container hangs forever during startup, and the forum never comes up. The log stops here:

```
3. Checking installed plugins for updates...Checking installed plugins and themes for updates...   OK

A total of 2 package(s) can be upgraded:

  * nodebb-plugin-cards (0.4.1 -> 0.4.2)
  * nodebb-plugin-sso-google (3.2.1 -> 4.0.0)
```

## Cause

The docker entrypoint runs `nodebb upgrade` whenever `install/package.json` changes (`build_forum()` in `install/docker/entrypoint.sh`). The upgrade's `plugins` step calls `upgradePlugins()` without `--unattended`, and when it finds upgradable plugins it prompts on stdin:

```js
result = await prompt.get({
    name: 'upgrade',
    description: '\nProceed with upgrade (y|n)?',
    ...
```

In a detached container (or CI) there is no TTY and stdin never delivers an answer, so the prompt — and the whole entrypoint — blocks forever. `docker ps` shows the container "Up", but NodeBB never starts.

Before #14460 this path was unreachable in docker: the persisted `package.json` was clobbered on every recreation, so the plugin check never found extraneous plugins and never prompted. Preserving the plugins (correctly) made the prompt reachable for every docker user with at least one ACP-installed plugin that has an update available.

## Fix

Extract the confirmation logic into `getUpgradeConfirmation()` and skip the prompt when `process.stdin.isTTY` is not set, treating it as a "no": plugins are left untouched and the existing `Package upgrades skipped. Check for upgrades at any time by running "./nodebb upgrade -p".` message is printed, so the upgrade proceeds to the schema/build steps and the forum starts.

Auto-answering "yes" instead was rejected on purpose: it would silently apply major version bumps (e.g. `nodebb-plugin-sso-google` 3.2.1 → 4.0.0) on every container start. Operators who want automatic plugin upgrades can already opt in with `./nodebb upgrade --unattended`, which is unchanged.

## Testing

- New `test/upgrade-plugins.js` covers `getUpgradeConfirmation()`: unattended → proceed without prompting; no TTY → decline without prompting; TTY → prompt honored for both yes and no answers.
- Reproduced the hang on a GCE VM running the bundled `docker-compose.yml` (MongoDB) with two ACP-installed plugins pending updates: the container sat blocked on the prompt indefinitely (`nodebb upgrade --config=/opt/config/config.json` alive for 25+ minutes with no TTY attached).
