### PR TITLE
fix: trust_proxy upgrade script writes to wrong config.json when started with --config (breaks Docker logins)

### DIFF
--- a/src/upgrades/4.14.3/trust_proxy.js
+++ b/src/upgrades/4.14.3/trust_proxy.js
@@ -8,8 +8,6 @@ module.exports = {
 	name: 'Backfill trust_proxy for upgraded installs',
 	timestamp: Date.UTC(2026, 6, 28),
 	method: async function () {
-		// Read/write the same config file NodeBB was started with (`--config`/CONFIG),
-		// it is not necessarily <app>/config.json (e.g. Docker mounts it at /opt/config)
 		const pathToConfig = path.resolve(__dirname, '../../../', nconf.get('config') || 'config.json');
 
 		let configJSON;

--- a/src/upgrades/4.14.4/trust_proxy_config_path.js
+++ b/src/upgrades/4.14.4/trust_proxy_config_path.js
@@ -5,11 +5,13 @@ const path = require('path');
 const nconf = require('nconf');
 
 module.exports = {
-	name: 'Backfill trust_proxy for upgraded installs',
-	timestamp: Date.UTC(2026, 6, 28),
+	name: 'Backfill trust_proxy into the config file specified via --config',
+	timestamp: Date.UTC(2026, 6, 29),
 	method: async function () {
-		// Read/write the same config file NodeBB was started with (`--config`/CONFIG),
-		// it is not necessarily <app>/config.json (e.g. Docker mounts it at /opt/config)
+		// 4.14.3/trust_proxy.js wrote to a hardcoded <app>/config.json, missing installs
+		// started with `--config`/CONFIG pointing elsewhere (e.g. Docker mounts it at
+		// /opt/config), which left those forums with broken sessions/logins behind a
+		// reverse proxy. Re-run the backfill against the config file actually in use.
 		const pathToConfig = path.resolve(__dirname, '../../../', nconf.get('config') || 'config.json');
 
 		let configJSON;

--- a/src/upgrades/4.14.4/trust_proxy_config_path.js
+++ b/src/upgrades/4.14.4/trust_proxy_config_path.js
@@ -8,10 +8,6 @@ module.exports = {
 	name: 'Backfill trust_proxy into the config file specified via --config',
 	timestamp: Date.UTC(2026, 6, 29),
 	method: async function () {
-		// 4.14.3/trust_proxy.js wrote to a hardcoded <app>/config.json, missing installs
-		// started with `--config`/CONFIG pointing elsewhere (e.g. Docker mounts it at
-		// /opt/config), which left those forums with broken sessions/logins behind a
-		// reverse proxy. Re-run the backfill against the config file actually in use.
 		const pathToConfig = path.resolve(__dirname, '../../../', nconf.get('config') || 'config.json');
 
 		let configJSON;


### PR DESCRIPTION
## Problem

The v4.14.3 upgrade script `src/upgrades/4.14.3/trust_proxy.js` (added in 0b0de8a for #14510) backfills `trust_proxy: true` into a **hardcoded** `<app>/config.json`:

```js
const pathToConfig = '../../../config.json';
```

But installs started with `--config`/`CONFIG` pointing elsewhere never see the backfill. Notably, **every official Docker install** is affected: `install/docker/entrypoint.sh` runs `nodebb upgrade --config="$CONFIG_DIR/config.json"` with the config mounted at `/opt/config/config.json`. The script writes `/usr/src/app/config.json` (inside the container, discarded on rebuild), the real config never gets `trust_proxy`, and the upgrade is marked done in `schemaLog` — so it never runs again.

### Impact

After upgrading a Docker deployment behind a reverse proxy (the documented setup) to v4.14.3, `trust proxy` silently becomes `false`. With an `https` site URL the session cookie is `Secure`, `express-session` no longer considers the proxied connection secure, and **no session cookie is ever set** — every local login and SSO callback fails:

```
error: GET /auth/google/callback?state=...
Error: [[error:csrf-invalid]]
    at router.<computed>.req.session.registration (/usr/src/app/src/routes/authentication.js:116:52)
```

Interestingly, the first version of the script used `install.save()`, which resolves `nconf.get('config')` correctly — the hardcoded path came in with d4ecc53 ("test: fix tests due to updating config.json").

## Fix

1. **`src/upgrades/4.14.3/trust_proxy.js`** — resolve the config path the same way `app.js`/`install.save()` do (`nconf.get('config')`, falling back to `<app>/config.json`), and read via `fs` instead of `require` (no stale module cache). Installs that haven't upgraded yet now get the correct backfill.
2. **`src/upgrades/4.14.4/trust_proxy_config_path.js`** — new script (new `schemaLog` basename) that re-runs the corrected backfill, healing installs that already ran the broken one. No-ops when `trust_proxy` is already present, so it never overwrites an explicit value (including `false`).

## Verification

Tested on a live GCE Docker deployment (nginx + HTTPS + mongo) that was bitten by this exact bug:

- Reverted the config to the broken state (no `trust_proxy`), confirmed `❌ Setting 'trust proxy' to false` and `[[error:csrf-invalid]]` on all logins.
- Applied these two scripts as if merged, ran `./nodebb upgrade`: the mounted `/opt/config/config.json` gained `trust_proxy: true`.
- After restart: `🤝 Setting 'trust proxy' to true`, `Set-Cookie: express.sid=…; Secure` present again, and a full CSRF round-trip + password login succeeds.
- Also verified: an existing `trust_proxy: false` is left untouched, and existing config keys are preserved.
