### PR TITLE
fix: sign application-context ActivityPub GET requests

### DIFF
--- a/src/activitypub/index.js
+++ b/src/activitypub/index.js
@@ -414,9 +414,9 @@ ActivityPub.get = async (type, id, uri, options) => {
 	}
 
 	let headers = {};
-	if (parseInt(id, 10) > 0) {
+	if (parseInt(id, 10) >= 0) {
 		const keyData = await ActivityPub.getPrivateKey(type, id);
-		headers = id >= 0 ? await ActivityPub.sign(keyData, uri) : {};
+		headers = await ActivityPub.sign(keyData, uri);
 	}
 
 	ActivityPub.helpers.log(`[activitypub/get] ${uri}`);

--- a/test/activitypub.js
+++ b/test/activitypub.js
@@ -97,6 +97,59 @@ describe('ActivityPub integration', () => {
 		});
 	});
 
+	describe('ActivityPub.get', () => {
+		let originalGet;
+		let uid;
+
+		before(async () => {
+			originalGet = request.get;
+			uid = await user.create({ username: utils.generateUUID() });
+		});
+
+		afterEach(() => {
+			request.get = originalGet;
+		});
+
+		async function getWithContext(id) {
+			const uri = `https://${utils.generateUUID()}.example.org/object`;
+			const body = { id: uri, type: 'Note' };
+			let headers;
+			request.get = async (url, options) => {
+				assert.strictEqual(url, uri);
+				({ headers } = options);
+				return { response: { statusCode: 200 }, body };
+			};
+
+			const result = await activitypub.get('uid', id, uri, { cache: false });
+			assert.strictEqual(result, body);
+			assert.strictEqual(headers.Accept, 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
+			return headers;
+		}
+
+		it('should sign requests using the application actor', async () => {
+			const headers = await getWithContext(0);
+
+			assert(headers.date);
+			assert(headers.signature);
+			assert(headers.signature.startsWith(`keyId="${nconf.get('url')}/actor#key"`));
+		});
+
+		it('should continue signing requests using the user actor', async () => {
+			const headers = await getWithContext(uid);
+
+			assert(headers.date);
+			assert(headers.signature);
+			assert(headers.signature.startsWith(`keyId="${nconf.get('url')}/uid/${uid}#key"`));
+		});
+
+		it('should leave requests from negative contexts unsigned', async () => {
+			const headers = await getWithContext(-1);
+
+			assert.strictEqual(headers.date, undefined);
+			assert.strictEqual(headers.signature, undefined);
+		});
+	});
+
 	describe('Helpers', () => {
 		describe('.query()', () => {
 


### PR DESCRIPTION
Adjust the signing eligibility in the shared ActivityPub GET path so IDs greater than or equal to zero obtain their existing key material and sign the outbound request, while negative contexts continue to send unsigned requests. Keep the current header merge order so caller-supplied headers and the ActivityStreams `Accept` header retain their existing behavior, and rely on the existing UID `0` key handling rather than adding a new signing abstraction. Add focused request-level regression coverage around `ActivityPub.get` by intercepting the existing request client and inspecting the outbound headers for application, user, and negative contexts. NodeBB resolves the canonical object in a relay-delivered `Announce` through `ActivityPub.get('uid', 0, uri)`, but the shared GET helper signs requests only when the numeric actor ID is greater than zero. UID `0` is the valid application actor and already has private-key support using the instance `/actor#key` identity, so its remote GET is unnecessarily unsigned. Mastodon instances with authorized fetch enabled reject that request with HTTP 401, causing NodeBB to return 424 and skip importing the relayed post. The reporter reproduced the failure on NodeBB 4.14.5 after a maintainer asked for confirmation against the latest stable release. Application context: call `ActivityPub.get('uid', 0, uniqueRemoteUri, { cache: false })`; verify the outbound request contains `date` and `signature` headers and that the signature identifies the instance `/actor#key`; Existing user context: call the same fetch with a positive UID; verify it remains signed with that user's `/uid/<uid>#key` identity.

Fixes #14531
