### PR TITLE
fix: revalidate policy for pending registrations

### DIFF
--- a/src/controllers/authentication.js
+++ b/src/controllers/authentication.js
@@ -72,18 +72,23 @@ async function registerAndLoginUser(req, res, userData) {
 	return complete;
 }
 
+async function validateRegistrationPolicy(userData) {
+	const registrationType = meta.config.registrationType || 'normal';
+	if (registrationType === 'disabled') {
+		return false;
+	}
+	if (userData.token || registrationType === 'invite-only' || registrationType === 'admin-invite-only') {
+		await user.verifyInvitation(userData);
+	}
+	return true;
+}
+
 // POST /register
 authenticationController.register = async function (req, res) {
-	const registrationType = meta.config.registrationType || 'normal';
-
-	if (registrationType === 'disabled') {
-		return res.sendStatus(403);
-	}
-
 	const userData = req.body;
 	try {
-		if (userData.token || registrationType === 'invite-only' || registrationType === 'admin-invite-only') {
-			await user.verifyInvitation(userData);
+		if (!await validateRegistrationPolicy(userData)) {
+			return res.sendStatus(403);
 		}
 
 		user.checkUsernameLength(userData.username);
@@ -114,6 +119,14 @@ authenticationController.register = async function (req, res) {
 // POST /register/complete
 authenticationController.registerComplete = async function (req, res) {
 	try {
+		if (
+			req.session.registration?.register === true &&
+			!await validateRegistrationPolicy(req.session.registration)
+		) {
+			delete req.session.registration;
+			return res.sendStatus(403);
+		}
+
 		// For the interstitials that respond, execute the callback with the form body
 		const data = await user.interstitials.get(req, req.session.registration);
 		const callbacks = data.interstitials.reduce((memo, cur) => {

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -369,6 +369,95 @@ describe('authentication', () => {
 		assert.equal(body, '[[register:invite.error-invite-only]]');
 	});
 
+	describe('pending registrations', () => {
+		let previousConfig;
+
+		before(() => {
+			previousConfig = {
+				registrationType: meta.config.registrationType,
+				registrationApprovalType: meta.config.registrationApprovalType,
+				gdpr_enabled: meta.config.gdpr_enabled,
+				sendValidationEmail: meta.config.sendValidationEmail,
+			};
+		});
+
+		beforeEach(() => {
+			meta.config.registrationType = 'normal';
+			meta.config.registrationApprovalType = 'normal';
+			meta.config.gdpr_enabled = 1;
+			meta.config.sendValidationEmail = 0;
+		});
+
+		after(() => {
+			Object.assign(meta.config, previousConfig);
+		});
+
+		function registrationBody(username) {
+			return {
+				username,
+				email: `${username}@example.org`,
+				password: 'pending-registration-password',
+				'password-confirm': 'pending-registration-password',
+			};
+		}
+
+		async function parkRegistration(username) {
+			const jar = request.jar();
+			const { response, body } = await helpers.request('post', '/register', {
+				jar,
+				body: registrationBody(username),
+			});
+			assert.strictEqual(response.status, 200);
+			assert.strictEqual(body.next, `${nconf.get('relative_path')}/register/complete`);
+			assert.strictEqual(await user.getUidByUsername(username), null);
+			return jar;
+		}
+
+		async function completeRegistration(jar) {
+			return await helpers.request('post', '/register/complete', {
+				jar,
+				body: {
+					gdpr_agree_data: 'on',
+					gdpr_agree_email: 'on',
+				},
+				redirect: 'manual',
+			});
+		}
+
+		it('should complete if the registration policy still allows it', async () => {
+			const username = `policy${utils.generateUUID().slice(0, 8)}`;
+			const jar = await parkRegistration(username);
+			const { response } = await completeRegistration(jar);
+
+			assert.strictEqual(response.status, 302);
+			assert(await user.getUidByUsername(username));
+		});
+
+		it('should reject a pending registration after registrations are disabled', async () => {
+			const username = `policy${utils.generateUUID().slice(0, 8)}`;
+			const jar = await parkRegistration(username);
+			meta.config.registrationType = 'disabled';
+
+			const { response } = await completeRegistration(jar);
+
+			assert.strictEqual(response.status, 403);
+			assert.strictEqual(await user.getUidByUsername(username), null);
+		});
+
+		it('should reject an uninvited pending registration after invite-only mode is enabled', async () => {
+			const username = `policy${utils.generateUUID().slice(0, 8)}`;
+			const jar = await parkRegistration(username);
+			meta.config.registrationType = 'invite-only';
+
+			const { response } = await completeRegistration(jar);
+
+			assert.strictEqual(response.status, 302);
+			const redirect = new URL(response.headers.location, nconf.get('url'));
+			assert.strictEqual(redirect.searchParams.get('register'), '[[register:invite.error-invite-only]]');
+			assert.strictEqual(await user.getUidByUsername(username), null);
+		});
+	});
+
 	it('should fail to register if username is falsy or too short', async () => {
 		const userData = [
 			{ username: '', password: 'somepassword' },


### PR DESCRIPTION
## Summary

- centralize the current registration-policy check used by both `POST /register` and `POST /register/complete`
- reject a session-backed pending registration if registrations were disabled before its interstitials were completed
- revalidate invitation requirements and invitation tokens at completion time
- limit the new check to sessions marked `registration.register === true`, leaving existing-user interstitials unchanged

## Reproduction

With the GDPR interstitial enabled, start a guest registration without completing the consent form. The submitted user data is parked in `req.session.registration`. If an administrator then changes `registrationType` from `normal` to `disabled`, a fresh `POST /register` is rejected with 403, but the parked session could still create an account through `POST /register/complete`.

The same stale-policy path allowed an uninvited registration parked under `normal` to complete after the site changed to `invite-only`.

## Tests

- `npm run lint -- --no-cache`
- `npx mocha test/authentication.js --grep "pending registrations"` — 3 passing
- `npx mocha test/authentication.js` — 45 passing
- full Windows suite exercised — 8,435 passing, 1 pending; the remaining failure is an unrelated existing i18n-key mismatch (`admin\settings\api:token-once-title missing in ar`). The base commit's official GitHub Actions matrix is green.

Fixes #14570
