### PR TITLE
fix: revalidate deleted state before edit broadcast

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -142,17 +142,17 @@ postsAPI.edit = async function (caller, data) {
 			newTitle: editResult.topic.title,
 		});
 	}
-	const postObj = await posts.getPostSummaryByPids([editResult.post.pid], caller.uid, { parse: false, extraFields: ['edited'] });
+	const [postObj] = await posts.getPostSummaryByPids([editResult.post.pid], caller.uid, { parse: false, extraFields: ['edited'] });
 	postObj.content = editResult.post.content; // re-use already parsed html
-	const returnData = { ...postObj[0], ...editResult.post };
-	returnData.topic = { ...postObj[0].topic, ...editResult.post.topic };
+	const returnData = { ...postObj, ...editResult.post };
+	returnData.topic = { ...postObj.topic, ...editResult.post.topic };
 
 	if (!postObj.deleted) {
 		const topicScheduled = await topics.getTopicField(editResult.topic.tid, 'scheduled');
 		websockets.in(`topic_${editResult.topic.tid}`).emit('event:post_edited', editResult);
 		if (!topicScheduled) {
 			setImmediate(() => {
-				activitypub.out.update.note(caller.uid, postObj[0]);
+				activitypub.out.update.note(caller.uid, postObj);
 			});
 		}
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -19,6 +19,7 @@ const groups = require('../src/groups');
 const socketPosts = require('../src/socket.io/posts');
 const apiPosts = require('../src/api/posts');
 const apiTopics = require('../src/api/topics');
+const websockets = require('../src/socket.io');
 const meta = require('../src/meta');
 const file = require('../src/file');
 const helpers = require('./helpers');
@@ -1365,6 +1366,63 @@ describe('Post\'s', () => {
 				assert.strictEqual(events.length, 0);
 			});
 		});
+	});
+});
+
+describe('Post edit broadcasts', () => {
+	let ownerUid;
+	let moderatorUid;
+	let cid;
+
+	before(async () => {
+		ownerUid = await user.create({ username: `edit-owner-${utils.generateUUID()}` });
+		moderatorUid = await user.create({ username: `edit-moderator-${utils.generateUUID()}` });
+		({ cid } = await categories.create({ name: `edit-race-${utils.generateUUID()}` }));
+		await groups.join('Global Moderators', moderatorUid);
+	});
+
+	it('should not broadcast an edit to the topic room after a concurrent deletion', async () => {
+		const { postData } = await topics.post({
+			uid: ownerUid,
+			cid,
+			title: 'Concurrent edit and delete',
+			content: 'Original post content',
+		});
+		const emitted = [];
+		const originalIn = websockets.in;
+		const originalGetPostData = posts.getPostData;
+		let intercept = true;
+
+		websockets.in = room => ({
+			emit: (event) => {
+				emitted.push({ room: String(room), event });
+			},
+		});
+		posts.getPostData = async (pid) => {
+			const data = await originalGetPostData(pid);
+			if (intercept && String(pid) === String(postData.pid)) {
+				intercept = false;
+				const staleData = { ...data, deleted: 0 };
+				await posts.delete(postData.pid, moderatorUid);
+				return staleData;
+			}
+			return data;
+		};
+
+		try {
+			await apiPosts.edit({ uid: ownerUid }, {
+				pid: postData.pid,
+				title: 'Edited after concurrent deletion',
+				content: 'This must stay out of the topic room',
+			});
+		} finally {
+			posts.getPostData = originalGetPostData;
+			websockets.in = originalIn;
+		}
+
+		assert.strictEqual(parseInt(await posts.getPostField(postData.pid, 'deleted'), 10), 1);
+		assert.strictEqual(emitted.some(item => item.room === `topic_${postData.tid}`), false);
+		assert.strictEqual(emitted.some(item => item.room.startsWith('uid_')), true);
 	});
 });
 


### PR DESCRIPTION
## Summary

- use the fresh post summary as the single object that drives the deleted-state decision
- keep the parsed content and ActivityPub update on that same refreshed object
- add a deterministic regression test where a deletion lands after the edit path captured its earlier snapshot

The regression asserts that the edit is not broadcast to the topic room after the post has been deleted, while the privileged user-room notifications are preserved.

This completes the intent of e6be0bfb533932dbc7fe597edb0bf9159f8c4b5b; `getPostSummaryByPids()` returns an array, so checking `postObj.deleted` never consulted the refreshed flag.

## Testing

- `npx eslint src/api/posts.js test/posts.js`
- `npx mocha test/posts.js --grep "should not broadcast an edit to the topic room after a concurrent deletion"`
- `npx mocha test/posts.js` (138 passing)

The regression test was also verified to fail against the prior array-property check.
