### PR TITLE
fix: scope chat handlers to their own window to prevent cross-talk between chat modals and the chats page

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -71,7 +71,7 @@ define('forum/chats', [
 			Chats.addHotkeys();
 		}
 
-		const chatContentEl = $('[component="chat/message/content"]');
+		const chatContentEl = $('[component="chat/main-wrapper"] [component="chat/message/content"]');
 		messages.wrapImagesInLinks(chatContentEl);
 		if (ajaxify.data.scrollToIndex) {
 			messages.toggleScrollUpAlert(chatContentEl);
@@ -95,14 +95,14 @@ define('forum/chats', [
 	Chats.addEventListeners = function () {
 		const { roomId } = ajaxify.data;
 		const mainWrapper = $('[component="chat/main-wrapper"]');
-		const chatMessageContent = $('[component="chat/message/content"]');
-		const chatControls = components.get('chat/controls');
-		const chatInput = $('[component="chat/input"]');
+		const chatMessageContent = mainWrapper.find('[component="chat/message/content"]');
+		const chatControls = mainWrapper.find('[component="chat/controls"]');
+		const chatInput = mainWrapper.find('[component="chat/input"]');
 
-		Chats.addSendHandlers(roomId, chatInput, $('.expanded-chat button[data-action="send"]'));
+		Chats.addSendHandlers(roomId, chatInput, mainWrapper.find('.expanded-chat button[data-action="send"]'));
 		Chats.addMobileResizeHandler(chatMessageContent);
 		Chats.addPopoutHandler();
-		Chats.addActionHandlers(components.get('chat/message/window'), roomId);
+		Chats.addActionHandlers(mainWrapper.find('[component="chat/message/window"]'), roomId);
 		Chats.addManageHandler(roomId, chatControls.find('[data-action="manage"]'));
 		Chats.addRenameHandler(roomId, chatControls.find('[data-action="rename"]'));
 		Chats.addLeaveHandler(roomId, chatControls.find('[data-action="leave"]'));
@@ -119,12 +119,12 @@ define('forum/chats', [
 		Chats.addUploadHandler({
 			dragDropAreaEl: $('.chats-full'),
 			pasteEl: chatInput,
-			uploadFormEl: $('[component="chat/upload"]'),
-			uploadBtnEl: $('[component="chat/upload/button"]'),
+			uploadFormEl: mainWrapper.find('[component="chat/upload"]'),
+			uploadBtnEl: mainWrapper.find('[component="chat/upload/button"]'),
 			inputEl: chatInput,
 		});
 
-		$('[data-action="close"]').on('click', async function () {
+		mainWrapper.find('[data-action="close"]').on('click', async function () {
 			if (ajaxify.data.roomId) {
 				await api.del(`/chats/${ajaxify.data.roomId}/state`, {});
 			}
@@ -286,7 +286,7 @@ define('forum/chats', [
 
 	Chats.addPopoutHandler = function () {
 		$('[data-action="pop-out"]').on('click', function () {
-			const text = components.get('chat/input').val();
+			const text = components.get('chat/main-wrapper').find('[component="chat/input"]').val();
 			const roomId = ajaxify.data.roomId;
 
 			if (app.previousUrl && app.previousUrl.match(/chats/)) {
@@ -298,8 +298,8 @@ define('forum/chats', [
 				chatModule.openChat(roomId, ajaxify.data.uid);
 			}
 
-			$(window).one('action:chat.loaded', function () {
-				components.get('chat/input').val(text);
+			$(window).one('action:chat.loaded', function (ev, chatModal) {
+				$(chatModal).find('[component="chat/input"]').val(text);
 			});
 		});
 	};
@@ -454,10 +454,11 @@ define('forum/chats', [
 			}
 		});
 		mousetrap.bind('up', function (e) {
-			const inputEl = components.get('chat/input');
+			const mainWrapper = components.get('chat/main-wrapper');
+			const inputEl = mainWrapper.find('[component="chat/input"]');
 			if (e.target === inputEl.get(0) && !inputEl.val()) {
 				// Retrieve message id from messages list
-				const message = components.get('chat/messages').find('.chat-message[data-self="1"]').last();
+				const message = mainWrapper.find('[component="chat/messages"] .chat-message[data-self="1"]').last();
 				if (!message.length) {
 					return;
 				}
@@ -768,9 +769,9 @@ define('forum/chats', [
 			}
 
 			if (!utils.isMobile()) {
-				$('.expanded-chat [component="chat/input"]').focus();
+				$('[component="chat/main-wrapper"] [component="chat/input"]').focus();
 			}
-			messages.updateTextAreaHeight($(`[component="chat/messages"][data-roomid="${roomId}"]`));
+			messages.updateTextAreaHeight($(`[component="chat/main-wrapper"] [component="chat/messages"][data-roomid="${roomId}"]`));
 		}
 
 		chatNavWrapper.attr('data-loaded', roomId ? '1' : '0');

--- a/public/src/client/chats/events.js
+++ b/public/src/client/chats/events.js
@@ -50,7 +50,12 @@ define('forum/chats/events', [
 				Chats.newMessage = data.self === 0;
 			}
 
-			messages.appendChatMessage($('[component="chat/message/content"]'), data.message);
+			const chatContentEl = components.get('chat/main-wrapper')
+				.find('[component="chat/message/content"]');
+			// don't add if already added (via the chat modal handler)
+			if (chatContentEl.length && !chatContentEl.find(`[data-mid="${data.message.messageId}"]`).length) {
+				messages.appendChatMessage(chatContentEl, data.message);
+			}
 		}
 
 		if (!data.message.system) {

--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -386,9 +386,9 @@ define('chat', [
 				});
 
 				function gotoChats() {
-					const text = components.get('chat/input').val();
+					const text = chatModal.find('[component="chat/input"]').val();
 					$(window).one('action:ajaxify.end', function () {
-						components.get('chat/input').val(text);
+						components.get('chat/main-wrapper').find('[component="chat/input"]').val(text);
 					});
 
 					ajaxify.go(`user/${app.user.userslug}/chats/${roomId}`);

--- a/src/views/partials/chats/message-window.tpl
+++ b/src/views/partials/chats/message-window.tpl
@@ -29,7 +29,7 @@
 			</ul>
 			<script>
 				(function () {
-					const el = document.querySelector('[component="chat/message/content"]');
+					const el = document.querySelector('[component="chat/main-wrapper"] [component="chat/message/content"]');
 					if (el) {
 						requestAnimationFrame(() => {
 							el.scrollTop = el.scrollHeight;


### PR DESCRIPTION
## Problem

Chat modals are appended to `body` and persist across ajaxify navigation, so it is common to have more than one chat container in the DOM at once (two modals, or a modal alongside the full `/chats` page). Several handlers were bound with document-global selectors, so the windows interfered with each other:

- `Chats.addEventListeners` grabbed `$('[component="chat/input"]')`, `$('.expanded-chat button[data-action="send"]')`, `$('[component="chat/message/content"]')`, `components.get('chat/controls')`, `components.get('chat/message/window')`, etc. These match open modals too, and since `addSendHandlers`/`addScrollHandler` call `.off()` before binding, they **replaced the modal's own handlers** with ones bound to the page's `roomId`. Pressing Enter (or the send button) in a modal then read `inputEl.val()` from the first matched input, sent it to the wrong room (or sent nothing) and cleared **all** chat inputs. This persisted even after navigating away from the chats page.
- Scrolling in a modal triggered infinite scroll with the page's `roomId`, inserting another room's messages into the modal.
- Message actions (edit/delete/pin) and the room controls (rename/leave/delete) fired twice — once with the modal's `roomId` and once with the page's.
- `chatsReceive` appended incoming messages to every `[component="chat/message/content"]` on the page (jQuery `appendTo` clones into each target), so a message for the current room also showed up inside unrelated modals.
- Maximizing a modal (or pop-out) carried the draft text of the *first* chat input in the DOM and restored it into all of them.

## Fix

Scope every chats-page binding to `[component="chat/main-wrapper"]`, append received messages only to the page container (with the same `data-mid` dedup the modal path already has), read/restore drafts from the specific window they belong to, and scope the initial-scroll inline script in `message-window.tpl`.

No template markup changes; `onChatReconnect` intentionally remains global since it refreshes every open window by its own `data-roomid`.

## Testing

Manually verified on a live install:
- Modal for room B open while on `/chats` room A: Enter and send button deliver each message to its own room only; drafts are not cleared elsewhere.
- Incoming messages render only in their own window.
- Scrolling up in a modal loads that room's history.
- Two minimized modals with different drafts: maximizing each carries its own draft.
- Sending from a modal after navigating away from the chats page goes to the modal's room.