### PR TITLE
test: cover reset-token cleanup on email removal

### DIFF
--- a/test/user/emails.js
+++ b/test/user/emails.js
@@ -106,6 +106,21 @@ describe('email confirmation (library methods)', () => {
 		});
 	});
 
+	describe('remove', () => {
+		it('should invalidate outstanding password reset codes', async () => {
+			const resetUid = await user.create({
+				username: utils.generateUUID().slice(0, 10),
+				password: utils.generateUUID(),
+				email: `${utils.generateUUID()}@example.org`,
+			}, { emailVerification: 'verify' });
+			const code = await user.reset.generate(resetUid);
+
+			assert.strictEqual(await user.reset.validate(code), true);
+			await user.email.remove(resetUid);
+			assert.strictEqual(await user.reset.validate(code), false);
+		});
+	});
+
 	describe('canSendValidation', () => {
 		it('should return true if no validation is pending', async () => {
 			const ok = await user.email.canSendValidation(uid, 'test@example.com');


### PR DESCRIPTION
## Summary

- add regression coverage for #14591 to verify that removing an email invalidates outstanding password-reset codes
- exercise the real `user.reset.generate()`, `user.reset.validate()`, and `user.email.remove()` library paths
- protect the cleanup added in `349797ac427f1dba7a0d1362c39b8bfa75cae935` from regression

## Testing

- `npx eslint test/user/emails.js`
- `npx mocha test/user/emails.js --grep "outstanding password reset codes"` (1 passing)
- verified the targeted test fails without `user.reset.cleanByUid(uid)` (`true !== false`)
- `npx mocha test/user/emails.js` (19 passing)
