### PR TITLE
fix: restore develop CI after master merge

### DIFF
--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -95,7 +95,7 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 		const name = tag.name ? `name="${escape(tag.name)}" ` : '';
 		const property = tag.property ? `property="${escape(tag.property)}" ` : '';
 		const tagContent = tag.content ?
-			tag.translate ? _tx.call(this, tag.content) : escape(tag.content).replace(/\n/g, ' ') :
+			tag.translate ? escape(_tx.call(this, tag.content)).replace(/\n/g, ' ') : escape(tag.content).replace(/\n/g, ' ') :
 			'';
 		const content = tagContent ? `content="${tagContent}" ` : '';
 

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -487,13 +487,13 @@ usersAPI.listEmails = async (caller, { uid }) => {
 };
 
 usersAPI.getEmail = async (caller, { uid, email }) => {
-	const [isPrivileged, { showemail }, ownerUid] = await Promise.all([
+	const [isPrivileged, { showemail }, emailUid] = await Promise.all([
 		user.isAdminOrGlobalMod(caller.uid),
 		user.getSettings(uid),
-		db.sortedSetScore('email:uid', email.toLowerCase()),
+		db.sortedSetScore('email:uid', String(email).toLowerCase()),
 	]);
 	const isSelf = caller.uid === parseInt(uid, 10);
-	const exists = ownerUid && parseInt(ownerUid, 10) === parseInt(uid, 10);
+	const exists = parseInt(emailUid, 10) === parseInt(uid, 10);
 
 	return exists && (isSelf || isPrivileged || showemail);
 };


### PR DESCRIPTION
## What

- escape translated meta tag content after template-side translation
- handle an omitted email in `usersAPI.getEmail` and return a boolean for missing mappings

## Why

These are two independent regressions already present on the exact current `develop` base:

1. `_tx` can return translation markup. That markup and its quotes were emitted directly into a meta tag's `content` attribute.
2. `usersAPI.getEmail` called `toLowerCase()` on an omitted email and its existence predicate could return `null` instead of `false`.

The first failure masked the second in the CI matrix. Both changes restore the behavior covered by the existing regression tests and are kept separate from #14584.

## Testing

- `npx mocha test/categories.js --timeout 10000` (62 passing)
- focused `usersAPI.getEmail` regression test (1 passing)
- `npx mocha test/user.js --timeout 10000` (302 passing)
- `eslint public/src/modules/helpers.common.js src/api/users.js`
