### PR TITLE
fix: parse multipart body before CSRF check on register routes

### DIFF
--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -159,9 +159,9 @@ Auth.reloadRoutes = async function (params) {
 
 	const upload = require('../middleware/multer');
 	const middlewares = [
+		upload.any(),
 		Auth.middleware.applyCSRF,
 		Auth.middleware.applyBlacklist,
-		upload.any(),
 	];
 
 	router.post('/register', middlewares, controllers.authentication.register);


### PR DESCRIPTION
Closes #14597

815e4c2b3e moved `upload.any()` behind `applyCSRF` on the register routes. `registerComplete.tpl` is a plain multipart form POST carrying the token in a hidden `csrf_token` field, and multer is the only body parser on those routes — so `req.body` was empty when `src/middleware/csrf.js` looked for the token, and every registration completion 403'd.

This restores the original ordering. The temp-file cleanup and `limits` added in 815e4c2b3e are unaffected by the position.

Note this means multipart parsing happens before CSRF validation on `/register`, `/register/complete` and `/register/abort`, as it did before v4.14.9. If gating the parse on CSRF is wanted, the token would have to move to the query string or a header instead.

Tested manually on a v4.14.9 instance: registration completes again, `/register` and `/register/abort` still work.
