### PR TITLE
fix(activitypub): add image attachments to chat message notes

### DIFF
--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -1,10 +1,13 @@
 'use strict';
 
+const crypto = require('crypto');
 const nconf = require('nconf');
 const mime = require('mime').default;
 const path = require('path');
 const sanitize = require('sanitize-html');
 const tokenizer = require('sbd');
+
+const md5 = filename => crypto.createHash('md5').update(filename).digest('hex');
 
 const db = require('../database');
 const meta = require('../meta');
@@ -39,6 +42,58 @@ const sanitizeConfig = {
 		source: ['type', 'src', 'srcset', 'sizes', 'media', 'height', 'width'],
 		img: ['alt', 'height', 'ismap', 'src', 'usemap', 'width', 'srcset'],
 	},
+};
+
+Mocks._buildAttachments = (attachment, source) => {
+	attachment = attachment.map(({ mediaType, url, width, height }) => {
+		let type;
+
+		switch (true) {
+			case mediaType && mediaType.startsWith('image'): {
+				type = 'Image';
+				break;
+			}
+
+			default: {
+				type = 'Link';
+				break;
+			}
+		}
+
+		const payload = { type, mediaType, url };
+
+		if (width || height) {
+			payload.width = width;
+			payload.height = height;
+		}
+
+		return payload;
+	});
+
+	// Retrieve alt text from content (if found)
+	if (source?.content && source?.mediaType === 'text/markdown') {
+		const mdImageRegex = /!\[(.+?)\]\(([^\\)]+)\)/g;
+		const found = new Map();
+		let current = mdImageRegex.exec(source.content);
+		while (current !== null) {
+			const [, alt, src] = current;
+			found.set(src.replace('-resized', ''), alt);
+			current = mdImageRegex.exec(source.content);
+		}
+
+		attachment = attachment.map((entry) => {
+			if (found.has(entry.url)) {
+				entry.name = found.get(entry.url);
+			}
+
+			return entry;
+		});
+	}
+
+	// 'image' seems to be used as the preview image in lemmy/piefed, use the first one.
+	const image = attachment.filter(entry => entry.type === 'Image')?.shift();
+
+	return { attachment, image };
 };
 
 Mocks._normalize = async (object) => {
@@ -696,30 +751,6 @@ Mocks.notes.public = async (post) => {
 	}
 
 	let attachment = await posts.attachments.get(post.pid) || [];
-	const normalizeAttachment = attachment => attachment.map(({ mediaType, url, width, height }) => {
-		let type;
-
-		switch (true) {
-			case mediaType && mediaType.startsWith('image'): {
-				type = 'Image';
-				break;
-			}
-
-			default: {
-				type = 'Link';
-				break;
-			}
-		}
-
-		const payload = { type, mediaType, url };
-
-		if (width || height) {
-			payload.width = width;
-			payload.height = height;
-		}
-
-		return payload;
-	});
 
 	// Special handling for main posts (as:Article w/ as:Note preview)
 	const isArticle = post.pid === post.topic.mainPid && !generatedTitle;
@@ -753,30 +784,8 @@ Mocks.notes.public = async (post) => {
 		match = posts.imgRegex.exec(post.content);
 	}
 
-	attachment = normalizeAttachment(attachment);
-
-	// Retrieve alt text from content (if found)
-	if (source?.content && source?.mediaType === 'text/markdown') {
-		const mdImageRegex = /!\[(.+?)\]\(([^\\)]+)\)/g;
-		const found = new Map();
-		let current = mdImageRegex.exec(source.content);
-		while (current !== null) {
-			const [, alt, src] = current;
-			found.set(src.replace('-resized', ''), alt);
-			current = mdImageRegex.exec(source.content);
-		}
-
-		attachment = attachment.map((attachment) => {
-			if (found.has(attachment.url)) {
-				attachment.name = found.get(attachment.url);
-			}
-
-			return attachment;
-		});
-	}
-
-	// 'image' seems to be used as the preview image in lemmy/piefed, use the first one.
-	const image = attachment.filter(entry => entry.type === 'Image')?.shift();
+	const { attachment: normalizedAttachment, image } = Mocks._buildAttachments(attachment, source);
+	attachment = normalizedAttachment;
 	let preview;
 	let summary = null;
 	let sensitive = null;
@@ -942,6 +951,36 @@ Mocks.notes.private = async ({ messageObj }) => {
 		}
 	}
 
+	// Build attachments from image URLs found in content
+	const imageUrls = [];
+	let match = posts.imgRegex.exec(messageObj.content);
+	while (match !== null) {
+		if (match[1]) {
+			const { pathname, href: url } = new URL(match[1]);
+			imageUrls.push({ pathname, url });
+		}
+		match = posts.imgRegex.exec(messageObj.content);
+	}
+
+	const sizeObjs = await Promise.all(imageUrls.map(({ pathname }) => {
+		return db.getObject(`upload:${md5(pathname)}`);
+	}));
+
+	let attachment = imageUrls.map(({ pathname, url }, idx) => {
+		const mediaType = mime.getType(pathname);
+		const sizeObj = sizeObjs[idx];
+
+		const entry = { mediaType, url };
+		if (sizeObj?.width || sizeObj?.height) {
+			entry.width = sizeObj.width;
+			entry.height = sizeObj.height;
+		}
+		return entry;
+	});
+
+	const { attachment: normalizedAttachment, image } = Mocks._buildAttachments(attachment, source);
+	attachment = normalizedAttachment;
+
 	let object = {
 		'@context': 'https://www.w3.org/ns/activitystreams',
 		id,
@@ -960,7 +999,8 @@ Mocks.notes.private = async ({ messageObj }) => {
 		content: messageObj.content,
 		source,
 		tag,
-		// attachment: [], // todo
+		attachment,
+		image,
 		// replies: `${id}/replies`, // todo
 	};
 


### PR DESCRIPTION
Extract shared attachment normalization logic into Mocks._buildAttachments helper.

Both notes.public and notes.private now use the same pipeline:

- Type normalization via switch (true) on mediaType
- Alt text enrichment from markdown source
- First image extraction for preview

Chat messages previously had no attachment support (// todo), so pasted images were not included in outgoing ActivityPub objects.

Assisted-by: unsloth/Qwen3.6-35B-A3B-GGUF
