### PR TITLE
fix: update url hash when switching tabs on ACP plugins page

### DIFF
--- a/public/src/admin/extend/plugins.js
+++ b/public/src/admin/extend/plugins.js
@@ -18,6 +18,13 @@ define('admin/extend/plugins', [
 			$(`.nav-pills button[data-bs-target="${window.location.hash}"]`).trigger('click');
 		}
 
+		$('#plugin-tabs').on('shown.bs.tab', function (ev) {
+			const target = $(ev.target).attr('data-bs-target');
+			if (target) {
+				history.replaceState(null, null, target);
+			}
+		});
+
 		const searchInputEl = $('#plugin-search');
 
 		pluginsList.on('click', 'button[data-action="toggleActive"]', function () {


### PR DESCRIPTION
@
On `/admin/extend/plugins` the tabs are plain Bootstrap tabs (`<button data-bs-toggle="tab">`), so switching a tab never changes the URL.

`Plugins.init` already handles the opposite direction — on load it reads `window.location.hash` and clicks the matching tab — but nothing writes the hash back, so the active tab cannot be linked to and is lost on refresh.

This adds a `shown.bs.tab` listener that writes the tab target to the URL with `history.replaceState` (not `pushState`, to avoid filling browser history on every click, and not `location.hash =`, to avoid the scroll jump).
@