### PR TITLE
fix: enforce email:disableEdit in the email change interstitial

### DIFF
--- a/src/controllers/accounts/edit.js
+++ b/src/controllers/accounts/edit.js
@@ -94,6 +94,11 @@ editController.email = async function (req, res, next) {
 		return next();
 	}
 
+	const isAdmin = await privileges.admin.can('admin:users', req.uid);
+	if (meta.config['email:disableEdit'] && !isAdmin) {
+		return helpers.notAllowed(req, res);
+	}
+
 	req.session.returnTo = `/uid/${targetUid}`;
 	req.session.registration = req.session.registration || {};
 	req.session.registration.updateEmail = true;

--- a/src/user/interstitials.js
+++ b/src/user/interstitials.js
@@ -56,9 +56,10 @@ Interstitials.email = async (data) => {
 			// Validate and send email confirmation
 			if (userData.uid) {
 				const isSelf = parseInt(userData.uid, 10) === parseInt(data.req.uid, 10);
-				const [isPasswordCorrect, canEdit, { email: current, 'email:confirmed': confirmed }, { allowed, error }] = await Promise.all([
+				const [isPasswordCorrect, canEdit, isAdmin, { email: current, 'email:confirmed': confirmed }, { allowed, error }] = await Promise.all([
 					user.isPasswordCorrect(userData.uid, formData.password, data.req.ip),
 					privileges.users.canEdit(data.req.uid, userData.uid),
+					privileges.admin.can('admin:users', data.req.uid),
 					user.getUserFields(userData.uid, ['email', 'email:confirmed']),
 					plugins.hooks.fire('filter:user.saveEmail', {
 						uid: userData.uid,
@@ -71,6 +72,13 @@ Interstitials.email = async (data) => {
 
 				if (!isPasswordCorrect) {
 					await sleep(2000);
+				}
+
+				// Changing or removing an existing email is not allowed if email edits are disabled.
+				// Setting an initial email is still allowed, otherwise users caught by
+				// `requireEmailAddress` would have no way out of the interstitial.
+				if (meta.config['email:disableEdit'] && !isAdmin && current.length && formData.email !== current) {
+					throw new Error('[[error:no-privileges]]');
 				}
 
 				if (formData.email && formData.email.length) {

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1490,10 +1490,35 @@ describe('Controllers', () => {
 		});
 
 		it('should not render edit/email if email:disableEdit is enabled', async () => {
+			// The route sits behind requirePageReAuth, so the controller is called directly here
+			const editController = require('../src/controllers/accounts/edit');
 			meta.config['email:disableEdit'] = 1;
-			const { jar } = await helpers.loginUser('foo', 'barbar');
-			const { response } = await request.get(`${nconf.get('url')}/api/user/foo/edit/email`, { jar });
-			assert.strictEqual(response.statusCode, 403);
+
+			let statusCode;
+			const req = {
+				uid: fooUid,
+				loggedIn: true,
+				path: '/user/foo/edit/email',
+				params: { userslug: 'foo' },
+				session: {},
+			};
+			const res = {
+				locals: { isAPI: true },
+				status: function (code) {
+					statusCode = code;
+					return this;
+				},
+				json: function () {
+					return this;
+				},
+			};
+			await editController.email(req, res, () => {
+				assert(false, 'next() should not have been called');
+			});
+
+			assert.strictEqual(statusCode, 403);
+			assert.strictEqual(req.session.registration, undefined);
+
 			meta.config['email:disableEdit'] = 0;
 		});
 	});

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -1499,6 +1499,7 @@ describe('Controllers', () => {
 				uid: fooUid,
 				loggedIn: true,
 				path: '/user/foo/edit/email',
+				originalUrl: '/api/user/foo/edit/email',
 				params: { userslug: 'foo' },
 				session: {},
 			};

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -516,6 +516,93 @@ describe('Controllers', () => {
 				assert.strictEqual(userData['email:confirmed'], 1);
 			});
 
+			describe('when email:disableEdit is enabled', () => {
+				afterEach(() => {
+					meta.config['email:disableEdit'] = 0;
+				});
+
+				async function getCallback(uid) {
+					const result = await user.interstitials.email({
+						userData: { uid: uid, updateEmail: true },
+						req: { uid: uid, session: { id: 0 } },
+						interstitials: [],
+					});
+					return result.interstitials[0].callback;
+				}
+
+				it('should not allow a regular user to change their email', async () => {
+					const username = utils.generateUUID().slice(0, 10);
+					const uid = await user.create({ username, email: `${username}@nodebb.org` }, {
+						emailVerification: 'verify',
+					});
+					const callback = await getCallback(uid);
+					meta.config['email:disableEdit'] = 1;
+
+					await assert.rejects(callback({ uid }, {
+						email: `${username}@nodebb.com`,
+					}), { message: '[[error:no-privileges]]' });
+
+					const userData = await user.getUserData(uid);
+					assert.strictEqual(userData.email, `${username}@nodebb.org`);
+				});
+
+				it('should not allow a regular user to clear their email', async () => {
+					meta.config.requireEmailAddress = 0;
+
+					const username = utils.generateUUID().slice(0, 10);
+					const uid = await user.create({ username, email: `${username}@nodebb.org` }, {
+						emailVerification: 'verify',
+					});
+					const callback = await getCallback(uid);
+					meta.config['email:disableEdit'] = 1;
+
+					await assert.rejects(callback({ uid }, {
+						email: '',
+					}), { message: '[[error:no-privileges]]' });
+
+					const userData = await user.getUserData(uid);
+					assert.strictEqual(userData.email, `${username}@nodebb.org`);
+
+					meta.config.requireEmailAddress = 1;
+				});
+
+				it('should still allow a user without an email to set one', async () => {
+					const username = utils.generateUUID().slice(0, 10);
+					const uid = await user.create({ username });
+					const callback = await getCallback(uid);
+					meta.config['email:disableEdit'] = 1;
+
+					await callback({ uid }, { email: `${username}@nodebb.org` });
+
+					const pending = await user.email.isValidationPending(uid, `${username}@nodebb.org`);
+					assert.strictEqual(pending, true);
+				});
+
+				it('should still allow an admin to change a user\'s email', async () => {
+					const username = utils.generateUUID().slice(0, 10);
+					const uid = await user.create({ username, email: `${username}@nodebb.org` }, {
+						emailVerification: 'verify',
+					});
+					const adminUid = await user.create({ username: utils.generateUUID().slice(0, 10) });
+					await groups.join('administrators', adminUid);
+					meta.config['email:disableEdit'] = 1;
+
+					const result = await user.interstitials.email({
+						userData: { uid: uid, updateEmail: true },
+						req: { uid: adminUid, session: { id: 0 } },
+						interstitials: [],
+					});
+					await result.interstitials[0].callback({ uid }, {
+						email: `${username}@nodebb.com`,
+					});
+
+					const pending = await user.email.isValidationPending(uid, `${username}@nodebb.com`);
+					assert.strictEqual(pending, true);
+
+					await groups.leave('administrators', adminUid);
+				});
+			});
+
 			describe('blocking access for unconfirmed emails', () => {
 				let jar;
 				let token;
@@ -1400,6 +1487,14 @@ describe('Controllers', () => {
 			const { jar } = await helpers.loginUser('foo', 'barbar');
 			const { response, body } = await request.get(`${nconf.get('url')}/api/user/foo/edit/username`, { jar });
 			assert.equal(response.statusCode, 200);
+		});
+
+		it('should not render edit/email if email:disableEdit is enabled', async () => {
+			meta.config['email:disableEdit'] = 1;
+			const { jar } = await helpers.loginUser('foo', 'barbar');
+			const { response } = await request.get(`${nconf.get('url')}/api/user/foo/edit/email`, { jar });
+			assert.strictEqual(response.statusCode, 403);
+			meta.config['email:disableEdit'] = 0;
 		});
 	});
 


### PR DESCRIPTION
### Problem

The `email:disableEdit` ACP setting ("Disable email changes") is only enforced in two places:

- the profile template hides the "Change email" link, based on `email:disableEdit` set in `src/controllers/accounts/helpers.js`
- `PUT /api/v3/users/:uid` resets `data.email` back to the old value in `src/api/users.js`

But that API route is not the flow the UI actually uses for email changes. The UI goes through `GET /user/:userslug/edit/email`, and unlike `editController.username` / `editController.password`, `editController.email` bypasses `renderRoute()` entirely — so the `${name}:disableEdit` check there never runs. It just sets `req.session.registration.updateEmail` and redirects to `/register/complete`, and `Interstitials.email` checks the password, `canEdit` and `filter:user.saveEmail`, but never the setting.

Result: with the setting enabled, a regular user who navigates directly to `/user/<their-slug>/edit/email` can still change their email, and (with `requireEmailAddress` off) clear it entirely. Only their own account is affected — the route bails out for other users and the interstitial throws `no-privileges` without `canEdit`.

### Change

- `editController.email` now returns `notAllowed` for non-admins when the setting is enabled.
- The email interstitial callback rejects changing or clearing an **existing** email for non-admins when the setting is enabled.

Setting an *initial* email is deliberately still allowed in the interstitial: `middleware.registrationComplete` forces `updateEmail` when `requireEmailAddress` is on and the user has no confirmed email, so blocking that case would trap those users in a redirect loop with no way out.

Admins (`admin:users`) are unaffected in both paths, matching the existing behaviour of `renderRoute()` for username/password.

### Tests

Added to `test/controllers.js`:

- regular user cannot change their email via the interstitial (email unchanged)
- regular user cannot clear their email via the interstitial (email unchanged)
- a user with no email can still set one
- an admin can still change another user's email
- `/api/user/foo/edit/email` returns 403 when the setting is enabled
