### PR TITLE
feat: allow granting post edit permission to groups

### DIFF
--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -189,7 +189,7 @@
 	"move-posts-instruction": "Click the posts you want to move then enter a topic ID or go to the target topic",
 	"move-topic-instruction": "Select the target category and then click move",
 	"change-owner-instruction": "Click the posts you want to assign to another user",
-	"manage-editors-instruction": "Manage the users who can edit this post below.",
+	"manage-editors-instruction": "Manage the users and groups who can edit this post below.",
 
 	"crossposts.instructions": "Select one or more categories to cross-post to. Topic(s) will be accessible from the original category and all cross-posted categories.",
 	"crossposts.listing": "This topic has been cross-posted to the following local categories:",

--- a/public/src/client/topic/manage-editors.js
+++ b/public/src/client/topic/manage-editors.js
@@ -15,9 +15,12 @@ define('forum/topic/manage-editors', [
 		}
 		const pid = postEl.attr('data-pid');
 
-		let editors = await socket.emit('posts.getEditors', { pid: pid });
+		const { users, groups } = await socket.emit('posts.getEditors', { pid: pid });
+		let editors = users;
+		let editorGroups = groups;
 		app.parseAndTranslate('modals/manage-editors', {
 			editors: editors,
+			editorGroups: editorGroups,
 		}, function (html) {
 			modal = html;
 
@@ -44,10 +47,29 @@ define('forum/topic/manage-editors', [
 				}
 			});
 
+			autocomplete.group(modal.find('#editor-group-search'), function (ev, ui) {
+				if (!editorGroups.includes(ui.item.group.name)) {
+					editorGroups.push(ui.item.group.name);
+					app.parseAndTranslate('modals/manage-editors', 'editorGroups', {
+						editorGroups: editorGroups,
+					}, function (html) {
+						modal.find('[component="topic/editor-groups"]').html(html);
+						modal.find('#editor-group-search').val('');
+					});
+				}
+			});
+
 			modal.on('click', 'button.remove-user-icon', function () {
 				const el = $(this).parents('[data-uid]');
 				const uid = el.attr('data-uid');
 				editors = editors.filter(e => String(e.uid) !== String(uid));
+				el.remove();
+			});
+
+			modal.on('click', 'button.remove-group-icon', function () {
+				const el = $(this).parents('[data-name]');
+				const name = el.attr('data-name');
+				editorGroups = editorGroups.filter(g => g !== name);
 				el.remove();
 			});
 		});
@@ -56,8 +78,10 @@ define('forum/topic/manage-editors', [
 	function saveEditors(pid) {
 		const uids = modal.find('[component="topic/editors"]>[data-uid]')
 			.map((i, el) => $(el).attr('data-uid')).get();
+		const groups = modal.find('[component="topic/editor-groups"]>[data-name]')
+			.map((i, el) => $(el).attr('data-name')).get();
 
-		socket.emit('posts.saveEditors', { pid: pid, uids: uids }, function (err) {
+		socket.emit('posts.saveEditors', { pid: pid, uids: uids, groups: groups }, function (err) {
 			if (err) {
 				return alerts.error(err);
 			}

--- a/public/src/modules/autocomplete.js
+++ b/public/src/modules/autocomplete.js
@@ -76,14 +76,14 @@ define('autocomplete', [
 			input,
 			onSelect,
 			source: (request, response) => {
-				socket.emit('groups.search', {
+				api.get('/groups', {
 					query: request.term,
-				}, function (err, results) {
+				}, function (err, result) {
 					if (err) {
 						return alerts.error(err);
 					}
-					if (results && results.length) {
-						const names = results.map(function (group) {
+					if (result && result.groups.length) {
+						const names = result.groups.map(function (group) {
 							return group && {
 								label: group.name,
 								value: group.name,

--- a/src/groups/delete.js
+++ b/src/groups/delete.js
@@ -25,7 +25,8 @@ module.exports = function (Groups) {
 				`group:${groupName}:pending`,
 				`group:${groupName}:invited`,
 				`group:${groupName}:owners`,
-				`group:${groupName}:member:pids`
+				`group:${groupName}:member:pids`,
+				`group:${groupName}:editor:pids`
 			);
 		});
 		const sets = groupNames.map(groupName => `${groupName.toLowerCase()}:${groupName}`);
@@ -34,6 +35,7 @@ module.exports = function (Groups) {
 			.map(groupName => slugify(groupName));
 
 		await removeGroupsFromPrivilegeGroups(groupNames);
+		await removeGroupsFromPostEditors(groupNames);
 		await Promise.all([
 			db.deleteAll(keys),
 			db.sortedSetRemove([
@@ -51,6 +53,14 @@ module.exports = function (Groups) {
 		]);
 		plugins.hooks.fire('action:groups.destroy', { groups: groupsData });
 	};
+
+	async function removeGroupsFromPostEditors(groupNames) {
+		await Promise.all(groupNames.map(
+			groupName => batch.processSortedSet(`group:${groupName}:editor:pids`, async (pids) => {
+				await db.setsRemove(pids.map(pid => `pid:${pid}:editors:groups`), groupName);
+			}, { batch: 500 })
+		));
+	}
 
 	async function removeGroupsFromPrivilegeGroups(groupNames) {
 		await batch.processSortedSet('groups:createtime', async (otherGroups) => {

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -222,6 +222,7 @@ module.exports = function (Groups) {
 		await db.rename(`group:${oldName}:pending`, `group:${newName}:pending`);
 		await db.rename(`group:${oldName}:invited`, `group:${newName}:invited`);
 		await db.rename(`group:${oldName}:member:pids`, `group:${newName}:member:pids`);
+		await updatePostEditorGroups(oldName, newName);
 
 		await renameGroupsMember(['groups:createtime', 'groups:visible:createtime', 'groups:visible:memberCount'], oldName, newName);
 		await renameGroupsMember(['groups:visible:name'], `${oldName.toLowerCase()}:${oldName}`, `${newName.toLowerCase()}:${newName}`);
@@ -244,6 +245,15 @@ module.exports = function (Groups) {
 
 			await Promise.all(usersData.map(u => user.setUserField(u.uid, 'groupTitle', JSON.stringify(u.newTitleArray))));
 		}, {});
+	}
+
+	async function updatePostEditorGroups(oldName, newName) {
+		await batch.processSortedSet(`group:${oldName}:editor:pids`, async (pids) => {
+			const keys = pids.map(pid => `pid:${pid}:editors:groups`);
+			await db.setsRemove(keys, oldName);
+			await db.setsAdd(keys, newName);
+		}, { batch: 500 });
+		await db.rename(`group:${oldName}:editor:pids`, `group:${newName}:editor:pids`);
 	}
 
 	async function renameGroupsMember(keys, oldName, newName) {

--- a/src/posts/delete.js
+++ b/src/posts/delete.js
@@ -84,7 +84,7 @@ module.exports = function (Posts) {
 			], pids),
 			Posts.attachments.empty(pids),
 			activitypub.notes.delete(pids),
-			db.deleteAll(pids.map(pid => `pid:${pid}:editors`)),
+			deleteFromEditors(pids),
 		]);
 
 		await resolveFlags(postData, uid);
@@ -222,6 +222,21 @@ module.exports = function (Posts) {
 		const parentPids = _.uniq(postsWithParents.map(p => p.toPid));
 		const counts = await db.sortedSetsCard(parentPids.map(pid => `pid:${pid}:replies`));
 		await db.setObjectBulk(parentPids.map((pid, index) => [`post:${pid}`, { replies: counts[index] }]));
+	}
+
+	async function deleteFromEditors(pids) {
+		const groupNames = await db.getSetsMembers(pids.map(pid => `pid:${pid}:editors:groups`));
+		const bulkRemove = [];
+		pids.forEach((pid, index) => {
+			groupNames[index].forEach((groupName) => {
+				bulkRemove.push([`group:${groupName}:editor:pids`, pid]);
+			});
+		});
+		await db.sortedSetRemoveBulk(bulkRemove);
+		await db.deleteAll([
+			...pids.map(pid => `pid:${pid}:editors`),
+			...pids.map(pid => `pid:${pid}:editors:groups`),
+		]);
 	}
 
 	async function deleteFromGroups(pids) {

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -8,6 +8,7 @@ const meta = require('../meta');
 const posts = require('../posts');
 const topics = require('../topics');
 const categories = require('../categories');
+const groups = require('../groups');
 const user = require('../user');
 const activitypub = require('../activitypub');
 const helpers = require('./helpers');
@@ -145,6 +146,7 @@ privsPosts.canEdit = async function (pid, uid) {
 		isMod: posts.isModerator([pid], uid),
 		isOwner: posts.isOwner(pid, uid),
 		isEditor: db.isSetMember(`pid:${pid}:editors`, uid),
+		isGroupEditor: isGroupEditor(pid, uid),
 		edit: privsPosts.can('posts:edit', pid, uid),
 		postData: posts.getPostFields(pid, ['tid', 'timestamp', 'deleted', 'deleterUid']),
 		userData: user.getUserFields(uid, ['reputation']),
@@ -187,10 +189,18 @@ privsPosts.canEdit = async function (pid, uid) {
 
 	const result = await plugins.hooks.fire('filter:privileges.posts.edit', results);
 	return {
-		flag: result.edit && (result.isOwner || result.isEditor || result.isMod),
+		flag: result.edit && (result.isOwner || result.isEditor || result.isGroupEditor || result.isMod),
 		message: '[[error:no-privileges]]',
 	};
 };
+
+async function isGroupEditor(pid, uid) {
+	const groupNames = await db.getSetMembers(`pid:${pid}:editors:groups`);
+	if (!groupNames.length) {
+		return false;
+	}
+	return await groups.isMemberOfAny(uid, groupNames);
+}
 
 privsPosts.canDelete = async function (pid, uid) {
 	const postData = await posts.getPostFields(pid, ['uid', 'tid', 'timestamp', 'deleterUid']);

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const nconf = require('nconf');
+const _ = require('lodash');
 
 const db = require('../../database');
 const posts = require('../../posts');
 const flags = require('../../flags');
+const groups = require('../../groups');
 const privileges = require('../../privileges');
 const plugins = require('../../plugins');
 const social = require('../../social');
@@ -90,19 +92,48 @@ module.exports = function (SocketPosts) {
 			throw new Error('[[error:invalid-data]]');
 		}
 		await checkEditorPrivilege(socket.uid, data.pid);
-		const editorUids = await db.getSetMembers(`pid:${data.pid}:editors`);
-		const userData = await user.getUsersFields(editorUids, ['username', 'userslug', 'picture']);
-		return userData;
+		const [editorUids, groupNames] = await Promise.all([
+			db.getSetMembers(`pid:${data.pid}:editors`),
+			db.getSetMembers(`pid:${data.pid}:editors:groups`),
+		]);
+		const users = await user.getUsersFields(editorUids, ['username', 'userslug', 'picture']);
+		return { users: users, groups: groupNames.sort() };
 	};
 
 	SocketPosts.saveEditors = async function (socket, data) {
-		if (!data || !data.pid || !Array.isArray(data.uids)) {
+		if (!data || !data.pid || !Array.isArray(data.uids) || (data.groups !== undefined && !Array.isArray(data.groups))) {
 			throw new Error('[[error:invalid-data]]');
 		}
 		await checkEditorPrivilege(socket.uid, data.pid);
-		await db.delete(`pid:${data.pid}:editors`);
-		await db.setAdd(`pid:${data.pid}:editors`, data.uids);
+		const groupNames = await filterEditorGroups(data.groups || []);
+		const currentGroups = await db.getSetMembers(`pid:${data.pid}:editors:groups`);
+		const addedGroups = groupNames.filter(name => !currentGroups.includes(name));
+		const removedGroups = currentGroups.filter(name => !groupNames.includes(name));
+
+		await Promise.all([
+			db.delete(`pid:${data.pid}:editors`),
+			db.delete(`pid:${data.pid}:editors:groups`),
+			db.sortedSetRemove(removedGroups.map(name => `group:${name}:editor:pids`), data.pid),
+		]);
+		await Promise.all([
+			db.setAdd(`pid:${data.pid}:editors`, data.uids),
+			db.setAdd(`pid:${data.pid}:editors:groups`, groupNames),
+			db.sortedSetAddBulk(addedGroups.map(name => [`group:${name}:editor:pids`, Date.now(), data.pid])),
+		]);
 	};
+
+	async function filterEditorGroups(groupNames) {
+		groupNames = _.uniq(groupNames.filter(
+			name => name && typeof name === 'string' &&
+				!groups.isPrivilegeGroup(name) &&
+				!groups.ephemeralGroups.includes(name)
+		));
+		if (!groupNames.length) {
+			return [];
+		}
+		const exists = await groups.exists(groupNames);
+		return groupNames.filter((name, index) => exists[index]);
+	}
 
 	async function checkEditorPrivilege(uid, pid) {
 		const cid = await posts.getCidByPid(pid);

--- a/src/views/modals/manage-editors.tpl
+++ b/src/views/modals/manage-editors.tpl
@@ -13,12 +13,32 @@
 				</span>
 			</div>
 		</div>
-		<div class="d-flex flex-wrap" component="topic/editors">
+		<div class="d-flex flex-wrap mb-3" component="topic/editors">
 			{{{ each editors }}}
 			<div class="badge text-bg-light m-1 p-1 border d-inline-flex gap-1 align-items-center" data-uid="{./uid}">
 				{{buildAvatar(@value, "24px", true)}}
 				<a href="{config.relative_path}/user/{./userslug}">{./username}</a>
 				<button class="btn btn-ghost btn-sm p-0 remove-user-icon">
+					<i class="fa fa-fw fa-times"></i>
+				</button>
+			</div>
+			{{{ end }}}
+		</div>
+		<div class="mb-3">
+			<label class="form-label" for="editor-group-search"><strong>{{tx("groups:groups")}}</strong></label>
+			<div class="input-group">
+				<input id="editor-group-search" type="text" class="form-control" name="editor-group-search">
+				<span class="input-group-text" type="button">
+					<i class="fa fa-search"></i>
+				</span>
+			</div>
+		</div>
+		<div class="d-flex flex-wrap" component="topic/editor-groups">
+			{{{ each editorGroups }}}
+			<div class="badge text-bg-light m-1 p-1 border d-inline-flex gap-1 align-items-center" data-name="{@value}">
+				<i class="fa fa-fw fa-users text-muted"></i>
+				<span>{@value}</span>
+				<button class="btn btn-ghost btn-sm p-0 remove-group-icon">
 					<i class="fa fa-fw fa-times"></i>
 				</button>
 			</div>

--- a/test/posts.js
+++ b/test/posts.js
@@ -1228,8 +1228,8 @@ describe('Post\'s', () => {
 				uids: [editorUid],
 			});
 
-			const userData = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
-			assert.strictEqual(userData[0].username, 'editor user');
+			const { users } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
+			assert.strictEqual(users[0].username, 'editor user');
 
 			const result = await apiPosts.edit({ uid: editorUid }, { pid, content: 'edited by editor' });
 			assert.strictEqual(Object.hasOwn(result, 'ip'), false);
@@ -1237,6 +1237,133 @@ describe('Post\'s', () => {
 			assert.strictEqual(content, 'edited by editor');
 
 			meta.config.trackIpPerPost = oldValue;
+		});
+
+		it('should allow members of an editor group to edit the post', async () => {
+			const ownerUid = await user.create({ username: 'group owner user' });
+			const memberUid = await user.create({ username: 'group editor user' });
+			const outsiderUid = await user.create({ username: 'not a group member' });
+			await groups.create({ name: 'editors-test-group' });
+			await groups.join('editors-test-group', memberUid);
+
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic for group editor testing',
+				content: 'Some text here for the OP',
+			});
+			const { pid } = topic.postData;
+			await socketPosts.saveEditors({ uid: ownerUid }, {
+				pid: pid,
+				uids: [],
+				groups: ['editors-test-group'],
+			});
+
+			const { groups: groupNames } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
+			assert.deepStrictEqual(groupNames, ['editors-test-group']);
+			assert(await db.isSortedSetMember('group:editors-test-group:editor:pids', pid));
+
+			await apiPosts.edit({ uid: memberUid }, { pid, content: 'edited by group member' });
+			assert.strictEqual(await posts.getPostField(pid, 'content'), 'edited by group member');
+
+			const canEdit = await privileges.posts.canEdit(pid, outsiderUid);
+			assert.strictEqual(canEdit.flag, false);
+		});
+
+		it('should keep group editors working when the group is renamed', async () => {
+			const ownerUid = await user.create({ username: 'rename owner user' });
+			const memberUid = await user.create({ username: 'rename editor user' });
+			await groups.create({ name: 'editors-rename-group' });
+			await groups.join('editors-rename-group', memberUid);
+
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic for group rename testing',
+				content: 'Some text here for the OP',
+			});
+			const { pid } = topic.postData;
+			await socketPosts.saveEditors({ uid: ownerUid }, {
+				pid: pid,
+				uids: [],
+				groups: ['editors-rename-group'],
+			});
+
+			await groups.update('editors-rename-group', { name: 'editors-renamed-group' });
+
+			const { groups: groupNames } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
+			assert.deepStrictEqual(groupNames, ['editors-renamed-group']);
+			assert(await db.isSortedSetMember('group:editors-renamed-group:editor:pids', pid));
+			assert(!await db.exists('group:editors-rename-group:editor:pids'));
+
+			const canEdit = await privileges.posts.canEdit(pid, memberUid);
+			assert.strictEqual(canEdit.flag, true);
+		});
+
+		it('should remove group from post editors when the group is deleted', async () => {
+			const ownerUid = await user.create({ username: 'delete owner user' });
+			await groups.create({ name: 'editors-delete-group' });
+
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic for group delete testing',
+				content: 'Some text here for the OP',
+			});
+			const { pid } = topic.postData;
+			await socketPosts.saveEditors({ uid: ownerUid }, {
+				pid: pid,
+				uids: [],
+				groups: ['editors-delete-group'],
+			});
+
+			await groups.destroy('editors-delete-group');
+
+			const { groups: groupNames } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
+			assert.deepStrictEqual(groupNames, []);
+			assert(!await db.exists('group:editors-delete-group:editor:pids'));
+		});
+
+		it('should clean up editor groups when the post is purged', async () => {
+			const ownerUid = await user.create({ username: 'purge owner user' });
+			await groups.create({ name: 'editors-purge-group' });
+
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic for group purge testing',
+				content: 'Some text here for the OP',
+			});
+			const { pid } = topic.postData;
+			await socketPosts.saveEditors({ uid: ownerUid }, {
+				pid: pid,
+				uids: [],
+				groups: ['editors-purge-group'],
+			});
+
+			await posts.purge([pid], ownerUid);
+
+			assert(!await db.exists(`pid:${pid}:editors:groups`));
+			assert(!await db.isSortedSetMember('group:editors-purge-group:editor:pids', pid));
+		});
+
+		it('should not save privilege or non-existent groups as editors', async () => {
+			const ownerUid = await user.create({ username: 'filter owner user' });
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic for group filter testing',
+				content: 'Some text here for the OP',
+			});
+			const { pid } = topic.postData;
+			await socketPosts.saveEditors({ uid: ownerUid }, {
+				pid: pid,
+				uids: [],
+				groups: ['cid:0:privileges:admin:admincp', 'guests', 'does-not-exist-group'],
+			});
+
+			const { groups: groupNames } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
+			assert.deepStrictEqual(groupNames, []);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Implements the feature request discussed in https://community.nodebb.org/topic/19420 — allow granting edit permission on a post to entire groups, in addition to individual users, from the existing "Manage Editors" modal.

## Background

In the linked topic, @ClickAndGo asked for a way to grant post editing to a whole group in one click instead of selecting members one by one, and offered to open a PR.

@baris raised valid objections to a naive implementation:

> The current editors system is uid based, if you save a list of group names, if group names are edited it becomes outdated.

> For privileges the renameGroup function handles it by going through all groups and renaming it in the members zset (renameGroupsMember), but for posts that's not feasible. If a group is renamed going through all posts would not be scalable. This wouldn't be a problem if groups had unique ids like categories, but then groups.isMember(uid, 'administrators') like calls won't work if name stops being the unique identifier.

## Design — how each concern is addressed

This PR uses a **reverse index**, the same pattern core already uses for `group:<name>:member:pids`:

- `pid:<pid>:editors:groups` — set of group names allowed to edit the post (alongside the existing `pid:<pid>:editors` uid set).
- `group:<name>:editor:pids` — zset of pids that granted the group editing rights.

**Stale names on rename:** `Groups.renameGroup` now updates only the posts listed in the group's `editor:pids` zset via `batch.processSortedSet`, then renames the zset itself (O(1), same as the existing `member:pids` rename). Cost is proportional to the number of posts that reference the renamed group — **not** to the total number of posts. This follows the same precedent as `updateMemberGroupTitles`, which already batch-iterates group members on rename.

**No group ids introduced:** group names remain the unique identifier; `groups.isMember(uid, name)`-style calls are untouched. The permission check in `privileges.posts.canEdit` reads the post's group set and calls `groups.isMemberOfAny(uid, names)` (which is cached), so nothing is resolved through ids.

**Cleanup:**
- Group deletion removes the group from all referencing posts (batch over its `editor:pids` zset) and deletes the zset.
- Post purge removes the pid from each granted group's `editor:pids` zset and deletes the post's group set.

**Validation:** privilege groups, ephemeral groups (`guests`, `spiders`, `fediverse`) and non-existent group names are filtered out on save.

## API change

`posts.getEditors` (socket) now returns `{ users, groups }` instead of a bare user array; `posts.saveEditors` accepts an optional `groups` array. The core client and tests are updated accordingly.

## UI

The Manage Editors modal gains a group search field (reusing `autocomplete.group`) with removable badges, mirroring the existing user picker.

## Tests

- group members can edit, non-members cannot
- rename keeps group editors working and migrates the reverse index
- group deletion removes it from post editors
- post purge cleans up both directions
- privilege/ephemeral/non-existent groups are rejected on save
