### PR TITLE
fix: autocomplete menu position in rtl

### DIFF
--- a/public/scss/jquery-ui.scss
+++ b/public/scss/jquery-ui.scss
@@ -6,3 +6,13 @@
 @import 'jquery-ui/themes/base/draggable';
 @import 'jquery-ui/themes/base/sortable';
 @import 'jquery-ui/themes/base/theme';
+
+// jquery-ui positions its menus by setting `left` inline, so rtlcss must not
+// flip the stylesheet's `left: 0` to `right: 0` — otherwise the menu ends up
+// anchored on both edges and stretches across the page in rtl
+/*rtl:begin:ignore*/
+.ui-autocomplete {
+	left: 0;
+	right: auto;
+}
+/*rtl:end:ignore*/

--- a/public/src/modules/autocomplete.js
+++ b/public/src/modules/autocomplete.js
@@ -14,6 +14,7 @@ define('autocomplete', [
 		const { input, onSelect } = acParams;
 		app.loadJQueryUI(function () {
 			input.autocomplete({
+				position: getMenuPosition(),
 				...acParams,
 				open: function () {
 					$(this).autocomplete('widget').css('z-index', 100005);
@@ -119,6 +120,17 @@ define('autocomplete', [
 			},
 		});
 	};
+
+	// jquery-ui defaults to anchoring the menu on the left edge of the input,
+	// which is the wrong edge in rtl
+	function getMenuPosition() {
+		const edge = document.querySelector('html').getAttribute('data-dir') === 'rtl' ? 'right' : 'left';
+		return {
+			my: `${edge} top`,
+			at: `${edge} bottom`,
+			collision: 'none',
+		};
+	}
 
 	function handleOnSelect(input, onselect, event, ui) {
 		onselect = onselect || function () { };


### PR DESCRIPTION
### Problem

In RTL communities, every user/group/tag picker that goes through `modules/autocomplete` renders its dropdown wrong: the suggestion rows stretch across the full width of the page, or the list appears at the opposite edge of the page from the input.

This affects the post editors picker, change-owner, group member search, ACP user/admin pickers — anything calling `autocomplete.user()` / `.group()` / `.tag()`.

### Cause

jQuery UI's base stylesheet has:

```css
.ui-autocomplete { position: absolute; top: 0; left: 0; }
```

`client-rtl.css` is produced by running the bundle through `rtlcss`, which flips that `left: 0` into `right: 0`. But jQuery UI positions the menu at runtime by setting `left` **inline** (`ul.position(...)` in `_suggest`). The element therefore ends up with `right: 0` from the stylesheet *and* `left: <n>px` inline — an absolutely positioned box anchored to both edges, so it stretches from the input to the far side of the viewport. Before the first `position()` call it has only `right: 0`, which is the "list is on the wrong side of the page" case.

Separately, jQuery UI's default `position` option (`my: "left top", at: "left bottom"`) anchors on the left edge of the input, which is the wrong edge in RTL.

### Fix

- Re-assert `left: 0; right: auto` for `.ui-autocomplete` inside an `/*rtl:begin:ignore*/` block so `rtlcss` leaves it alone, matching the assumption the widget's JS makes. No effect on LTR.
- Default the widget's `position` option to the input's right edge when `html[data-dir="rtl"]`. Callers can still override it, since `params` is spread after the default.

### Testing

Verified against the real build chain (sass → rtlcss) that the RTL output now ends with `left: 0; right: auto` after the jQuery UI rule, and that LTR output is unchanged. Checked in a Hebrew (RTL) forum on Harmony that the editors picker, change-owner and ACP pickers now drop down under the input at the correct width, and confirmed no regression in LTR.