### PR TITLE
fix: mark chat notifications read when received in the currently open room

### DIFF
--- a/public/src/modules/notifications.js
+++ b/public/src/modules/notifications.js
@@ -106,6 +106,11 @@ define('notifications', [
 		}
 		const { template } = ajaxify.data;
 		if (template.chats && String(ajaxify.data.roomId) === String(notifData.roomId)) {
+			// user is already looking at this room, mark the notification read
+			// instead of leaving it unread until the next room load
+			if (notifData.nid) {
+				markNotification(notifData.nid, true);
+			}
 			return;
 		}
 


### PR DESCRIPTION
## Problem

When a chat-related notification arrives while the user is already viewing the room it belongs to, `Notifications.onNewNotification` returns early — it suppresses the toast and the count update, but leaves the notification unread. The notification then lingers in the unread list until the room is loaded again (`loadRoom` / `chatsAPI.mark` are the only places that call `Messaging.markRoomNotificationsRead`).

This can happen with core chat notifications (multi-tab sessions, socket reconnect races around the `chat_room_<roomId>` join), and consistently with notifications created by plugins that carry a `roomId` (e.g. message reactions), since those are created regardless of who is currently in the room.

## Fix

Mark the incoming notification read instead of silently ignoring it, mirroring how topic notifications are handled two lines below via `topics.markTopicNotificationsRead` when the user is already in the topic.

Marking by nid (rather than marking the whole room read) keeps the room's own unread state untouched; related unread notifications for the same room are still cleared server-side through the existing `mergeId` handling in `Notifications.markReadMultiple`.

There is no race with the push pipeline: `event:new_notification` is only emitted after the nid has been added to `uid:<uid>:notifications:unread`.