### PR TITLE
Fix: resync notification count when loading the notification list

### DIFF
--- a/public/src/modules/notifications.js
+++ b/public/src/modules/notifications.js
@@ -37,6 +37,11 @@ define('notifications', [
 			triggerEl = null;
 		}
 		callback = callback || function () {};
+		// resync the unread count in case a socket push was missed
+		// or a notification was rescinded server-side
+		api.get('/notifications/count').then(({ unread }) => {
+			Notifications.updateNotifCount(unread);
+		}).catch(alerts.error);
 		api.get('/notifications').then((data) => {
 			const notifs = data.unread.concat(data.read).sort(function (a, b) {
 				return parseInt(a.datetime, 10) > parseInt(b.datetime, 10) ? -1 : 1;

--- a/public/src/modules/notifications.js
+++ b/public/src/modules/notifications.js
@@ -37,12 +37,10 @@ define('notifications', [
 			triggerEl = null;
 		}
 		callback = callback || function () {};
-		// resync the unread count in case a socket push was missed
-		// or a notification was rescinded server-side
-		api.get('/notifications/count').then(({ unread }) => {
-			Notifications.updateNotifCount(unread);
-		}).catch(alerts.error);
 		api.get('/notifications').then((data) => {
+			// resync the unread count in case a socket push was missed
+			// or a notification was rescinded server-side
+			Notifications.updateNotifCount(data.unread.length);
 			const notifs = data.unread.concat(data.read).sort(function (a, b) {
 				return parseInt(a.datetime, 10) > parseInt(b.datetime, 10) ? -1 : 1;
 			});


### PR DESCRIPTION
## Problem

The notification badge, favicon bubble and app badge are only ever updated via socket pushes (`event:notifications.updateCount`) and the initial page render. When the client's view of the count goes stale, nothing ever corrects it until a full page refresh:

- A notification is **rescinded server-side after delivery** — post deleted (`posts/delete.js`), flag resolved (`flags.js`), vote retracted via ActivityPub (`activitypub/inbox.js`). `Notifications.rescind` deletes the notification, so the server-side count is correct, but no `updateCount` is pushed to affected users.
- A `pushCount` emit is lost during a brief transport drop that doesn't trigger a full reconnect (`meta.reconnected` does resync, but only on an actual reconnect event).

In both cases the user sees a count on the bell and favicon, opens the dropdown, finds no unread notifications — and the stale badge still doesn't clear.

## Fix

Fetch `/api/v3/notifications/count` alongside the notification list in `Notifications.loadNotifications`, and apply it via `updateNotifCount`. Opening the dropdown (or any other list load) now always resyncs the badge with the server, making stale counts self-healing regardless of what caused them.