### PR TITLE
Fix: send unread count with new notifications

### DIFF
--- a/public/src/modules/notifications.js
+++ b/public/src/modules/notifications.js
@@ -100,7 +100,8 @@ define('notifications', [
 		});
 	};
 
-	Notifications.onNewNotification = async function (notifData) {
+	Notifications.onNewNotification = async function (data) {
+		const { notification: notifData, unreadCount } = data;
 		if (ajaxify.currentPage === 'notifications') {
 			ajaxify.refresh();
 		}
@@ -119,8 +120,8 @@ define('notifications', [
 			return;
 		}
 
-		if (notifData.hasOwnProperty('unreadCount')) {
-			Notifications.updateNotifCount(notifData.unreadCount);
+		if (unreadCount !== undefined) {
+			Notifications.updateNotifCount(unreadCount);
 		}
 
 		if (!unreadNotifs[notifData.nid]) {

--- a/public/src/modules/notifications.js
+++ b/public/src/modules/notifications.js
@@ -119,8 +119,9 @@ define('notifications', [
 			return;
 		}
 
-		const { unread } = await api.get('/notifications/count');
-		Notifications.updateNotifCount(unread);
+		if (notifData.hasOwnProperty('unreadCount')) {
+			Notifications.updateNotifCount(notifData.unreadCount);
+		}
 
 		if (!unreadNotifs[notifData.nid]) {
 			unreadNotifs[notifData.nid] = notifData;

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -248,13 +248,13 @@ async function pushToUids(uids, notification) {
 					uid,
 					notification,
 				});
-				const payload = { ...notification };
 				const uidsInRoom = await websockets.getUidsInRoom(`uid_${uid}`);
+				let unreadCount;
 				if (uidsInRoom.length) {
 					// only calculate the unread count for users connected right now
-					payload.unreadCount = await User.notifications.getUnreadCount(uid);
+					unreadCount = await User.notifications.getUnreadCount(uid);
 				}
-				websockets.in(`uid_${uid}`).emit('event:new_notification', payload);
+				websockets.in(`uid_${uid}`).emit('event:new_notification', { notification, unreadCount });
 			}));
 		}
 	}

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -248,7 +248,8 @@ async function pushToUids(uids, notification) {
 					uid,
 					notification,
 				});
-				websockets.in(`uid_${uid}`).emit('event:new_notification', notification);
+				const unreadCount = await User.notifications.getUnreadCount(uid);
+				websockets.in(`uid_${uid}`).emit('event:new_notification', { ...notification, unreadCount });
 			}));
 		}
 	}

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -248,8 +248,13 @@ async function pushToUids(uids, notification) {
 					uid,
 					notification,
 				});
-				const unreadCount = await User.notifications.getUnreadCount(uid);
-				websockets.in(`uid_${uid}`).emit('event:new_notification', { ...notification, unreadCount });
+				const payload = { ...notification };
+				const uidsInRoom = await websockets.getUidsInRoom(`uid_${uid}`);
+				if (uidsInRoom.length) {
+					// only calculate the unread count for users connected right now
+					payload.unreadCount = await User.notifications.getUnreadCount(uid);
+				}
+				websockets.in(`uid_${uid}`).emit('event:new_notification', payload);
 			}));
 		}
 	}


### PR DESCRIPTION
## Problem

When a new notification is delivered, every recipient client reacts to `event:new_notification` by issuing a REST call to `/api/v3/notifications/count` and applying the response to the badge/favicon (`public/src/modules/notifications.js`).

That REST response is **not ordered** relative to `event:notifications.updateCount` socket pushes, so a stale response can arrive after — and overwrite — a newer authoritative count. Typical repro with two tabs/devices:

1. A notification arrives; tab B starts its REST count fetch.
2. Tab A is viewing the relevant topic/chat room, so the notification is auto-marked read (`onNewNotification` in-topic/in-room handling), and the server pushes `updateCount(0)` to all of the user's sockets.
3. Tab B applies the 0 from the socket, then the late REST response (served before the mark-read) arrives with the old count and re-applies it.

Result: a phantom unread badge and favicon bubble with no unread notifications behind it, persisting until the next push or a full page refresh. The same race exists with mark-all-read from another tab and with near-simultaneous notifications.

## Fix

Compute the recipient's unread count server-side in `pushToUids` and embed it in the `event:new_notification` payload; drop the client-side refetch.

Each tab then decides locally: the embedded count is applied unless the tab is currently viewing the relevant topic or chat room — that tab keeps its existing behaviour of skipping the bump and waiting for the post-read count push, so no transient +1 flicker is introduced there.

All count updates now travel over the same ordered socket channel as read events, which eliminates the race — and removes a per-recipient HTTP round-trip on every notification delivery.