### PR TITLE
fix: honor topic sort in navigator scroller, closes #12480

### DIFF
--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -201,6 +201,7 @@ define('navigator', [
 		return await socket.emit('posts.getPostTimestampByIndex', {
 			tid: ajaxify.data.tid,
 			index: index - 1,
+			sort: ajaxify.data.sortOption,
 		});
 	}
 
@@ -410,7 +411,11 @@ define('navigator', [
 		}
 		renderPostIndex = index;
 
-		const postData = await socket.emit('posts.getPostSummaryByIndex', { tid: ajaxify.data.tid, index: index - 1 });
+		const postData = await socket.emit('posts.getPostSummaryByIndex', {
+			tid: ajaxify.data.tid,
+			index: index - 1,
+			sort: ajaxify.data.sortOption,
+		});
 
 		const html = await app.parseAndTranslate('partials/topic/navigation-post', { post: postData });
 		paginationBlockEl
@@ -443,7 +448,11 @@ define('navigator', [
 	function generateUrl(index) {
 		const pathname = window.location.pathname.replace(config.relative_path, '');
 		const parts = pathname.split('/');
-		const newUrl = parts[1] + '/' + parts[2] + '/' + parts[3] + (index ? '/' + index : '');
+		let newUrl = parts[1] + '/' + parts[2] + '/' + parts[3] + (index ? '/' + index : '');
+		const { sort } = utils.params();
+		if (sort) {
+			newUrl += `?sort=${encodeURIComponent(sort)}`;
+		}
 		const data = {
 			newUrl,
 			index,

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -19,17 +19,21 @@ SocketPosts.getRawPost = async function (socket, pid) {
 	return await api.posts.getRaw(socket, { pid });
 };
 
+async function getPidByIndex(tid, index, sort) {
+	if (index === 0) {
+		return await topics.getTopicField(tid, 'mainPid');
+	}
+	const set = sort === 'most_votes' ? `tid:${tid}:posts:votes` : `tid:${tid}:posts`;
+	const reverse = sort === 'newest_to_oldest' || sort === 'most_votes';
+	const pids = await db[reverse ? 'getSortedSetRevRange' : 'getSortedSetRange'](set, index - 1, index - 1);
+	return pids.length ? pids[0] : null;
+}
+
 SocketPosts.getPostSummaryByIndex = async function (socket, data) {
 	if (data.index < 0) {
 		data.index = 0;
 	}
-	let pid;
-	if (data.index === 0) {
-		pid = await topics.getTopicField(data.tid, 'mainPid');
-	} else {
-		pid = await db.getSortedSetRange(`tid:${data.tid}:posts`, data.index - 1, data.index - 1);
-	}
-	pid = Array.isArray(pid) ? pid[0] : pid;
+	const pid = await getPidByIndex(data.tid, data.index, data.sort);
 	if (!pid) {
 		return 0;
 	}
@@ -41,13 +45,7 @@ SocketPosts.getPostTimestampByIndex = async function (socket, data) {
 	if (data.index < 0) {
 		data.index = 0;
 	}
-	let pid;
-	if (data.index === 0) {
-		pid = await topics.getTopicField(data.tid, 'mainPid');
-	} else {
-		pid = await db.getSortedSetRange(`tid:${data.tid}:posts`, data.index - 1, data.index - 1);
-	}
-	pid = Array.isArray(pid) ? pid[0] : pid;
+	const pid = await getPidByIndex(data.tid, data.index, data.sort);
 	const [postPrivileges] = await privileges.posts.get([pid], socket.uid);
 	if (!postPrivileges.read || !postPrivileges['topics:read'] || postPrivileges.disabled) {
 		throw new Error('[[error:no-privileges]]');

--- a/test/posts.js
+++ b/test/posts.js
@@ -918,6 +918,32 @@ describe('Post\'s', () => {
 			assert(utils.isNumber(timestamp));
 		});
 
+		it('should get post summary and timestamp by index with sort', async () => {
+			const result = await topics.post({
+				uid: voterUid,
+				cid: cid,
+				title: 'topic for sorted navigation',
+				content: 'main post',
+			});
+			await apiTopics.reply({ uid: voterUid }, { tid: result.topicData.tid, content: 'first reply' });
+			await sleep(5);
+			const lastReply = await apiTopics.reply({ uid: voterUid }, { tid: result.topicData.tid, content: 'second reply' });
+
+			const timestamp = await socketPosts.getPostTimestampByIndex({ uid: voterUid }, {
+				index: 1,
+				tid: result.topicData.tid,
+				sort: 'newest_to_oldest',
+			});
+			assert.strictEqual(timestamp, lastReply.timestamp);
+
+			const summary = await socketPosts.getPostSummaryByIndex({ uid: voterUid }, {
+				index: 1,
+				tid: result.topicData.tid,
+				sort: 'newest_to_oldest',
+			});
+			assert.strictEqual(summary.pid, lastReply.pid);
+		});
+
 		it('should get post timestamp by index', async () => {
 			const summary = await socketPosts.getPostSummaryByPid({ uid: voterUid }, {
 				pid: pid,


### PR DESCRIPTION
## Summary

Fixes #12480 — the topic navigator (scroller thumb) ignored the active post sort:

1. **Wrong timestamps/previews while dragging**: `posts.getPostTimestampByIndex` and `posts.getPostSummaryByIndex` always resolved the pid from `tid:<tid>:posts` in default (oldest-to-newest) order. When the topic was sorted by `newest_to_oldest` or `most_votes`, the thumb showed dates and post previews belonging to the wrong posts.
2. **Clicking the scroller reset the sort**: `generateUrl()` in `navigator.js` rebuilt the URL from the pathname only, dropping the `?sort=` query param, so navigating to an index reloaded the topic with the default sort.

## Changes

- `src/socket.io/posts.js`: both index-based socket calls now accept a `sort` param and resolve the pid using the same set/reverse logic as the topic controller and `topics.getMyNextPostIndex` (`most_votes` → votes set, `newest_to_oldest`/`most_votes` → reverse range, index 0 remains the main post). Behavior is unchanged when `sort` is not passed.
- `public/src/modules/navigator.js`: passes `ajaxify.data.sortOption` in both emits, and `generateUrl()` preserves the `sort` query param.
- `test/posts.js`: added a test asserting that index 1 with `newest_to_oldest` returns the newest reply's timestamp/summary.

## How I tested

- Verified index→pid resolution for all three cases (default, reverse, index 0) against a live Mongo instance.
- `eslint` passes on the changed files.