### PR TITLE
fix: banned user via master token API request causes 500 error

### DIFF
--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -70,8 +70,9 @@ module.exports = function (middleware) {
 			} else if (user.hasOwnProperty('master') && user.master === true) {
 				// If the token received was a master token, a _uid must also be present for all calls
 				const body = req.body || {};
-				if (body.hasOwnProperty('_uid') || req.query.hasOwnProperty('_uid')) {
-					user.uid = body._uid || req.query._uid;
+				const query = req.query || {};
+				if (body.hasOwnProperty('_uid') || query.hasOwnProperty('_uid')) {
+					user.uid = body._uid || query._uid;
 					delete user.master;
 					return await finishLogin(req, user);
 				}
@@ -238,6 +239,10 @@ module.exports = function (middleware) {
 		if (req.loggedIn) {
 			const canLoginIfBanned = await user.bans.canLoginIfBanned(req.uid);
 			if (!canLoginIfBanned) {
+				// Token-authenticated requests get an error response instead of a redirect
+				if (req.headers.hasOwnProperty('authorization')) {
+					return controllers.helpers.notAllowed(req, res, '[[error:user-banned]]');
+				}
 				req.logout(() => {
 					res.redirect('/');
 				});

--- a/test/authentication.js
+++ b/test/authentication.js
@@ -682,5 +682,18 @@ describe('authentication', () => {
 			assert.strictEqual(response.statusCode, 200);
 			assert.strictEqual(body.username, 'apiUserTarget');
 		});
+
+		it('should return an error if master api token _uid points to a banned user', async () => {
+			await user.bans.ban(newUid);
+			const { response, body } = await helpers.request('get', `/api/categories?_uid=${newUid}`, {
+				headers: {
+					Authorization: `Bearer ${masterToken}`,
+				},
+			});
+
+			assert.strictEqual(response.statusCode, 403);
+			assert.strictEqual(body.error, '[[error:user-banned]]');
+			await user.bans.unban(newUid);
+		});
 	});
 });


### PR DESCRIPTION
Closes #12739

## Problem

A `GET` page-route API request (e.g. `/api/categories`) made with a master token and a `_uid` belonging to a banned user results in a 500 error instead of a meaningful response.

The request authenticates successfully, then hits `middleware.redirectToHomeIfBanned`, which calls `req.logout()` and `res.redirect('/')`. The API client follows the redirect to `/` (still carrying the `Authorization` header), where no `_uid` query param exists — producing `[[error:api.master-token-no-uid]]` (and, as originally reported, a `TypeError` when `req.query` was unset).

## Fix

- In `redirectToHomeIfBanned`, token-authenticated requests (those carrying an `Authorization` header) now receive a proper `notAllowed` response (`403` with `[[error:user-banned]]`) instead of being logged out and redirected to the home page. Cookie/session-based requests keep the existing logout + redirect behaviour.
- Hardened the master-token `_uid` lookup in `authenticate` to guard against a missing `req.query`, mirroring the existing guard on `req.body`.

## Test

Added a test to `test/authentication.js`: a master token request with `_uid` of a banned user now returns `403` / `[[error:user-banned]]`.