### PR TITLE
chore: stop loading user signatures in topic lists

### DIFF
--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -57,9 +57,6 @@ TopicObject:
             picture:
               type: string
               nullable: true
-            signature:
-              type: string
-              nullable: true
             status:
               type: string
             icon:text:
@@ -87,7 +84,6 @@ TopicObject:
             - reputation
             - postcount
             - picture
-            - signature
             - banned
             - status
             - icon:text

--- a/public/openapi/read/tags/tag.yaml
+++ b/public/openapi/read/tags/tag.yaml
@@ -127,9 +127,6 @@ get:
                             picture:
                               nullable: true
                               type: string
-                            signature:
-                              nullable: true
-                              type: string
                             banned:
                               type: number
                             status:

--- a/public/openapi/read/unread.yaml
+++ b/public/openapi/read/unread.yaml
@@ -91,9 +91,6 @@ get:
                                 picture:
                                   nullable: true
                                   type: string
-                                signature:
-                                  nullable: true
-                                  type: string
                                 banned:
                                   type: boolean
                                 status:
@@ -121,7 +118,6 @@ get:
                                 - reputation
                                 - postcount
                                 - picture
-                                - signature
                                 - banned
                                 - status
                                 - icon:text

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -101,7 +101,7 @@ Topics.getTopicsByTids = async function (tids, options) {
 
 		const [teasers, users, userSettings, categoriesData, guestHandles, thumbs] = await Promise.all([
 			Topics.getTeasers(topics, options),
-			user.getUsersFields(uids, ['uid', 'username', 'fullname', 'userslug', 'reputation', 'postcount', 'picture', 'signature', 'banned', 'status']),
+			user.getUsersFields(uids, ['uid', 'username', 'fullname', 'userslug', 'reputation', 'postcount', 'picture', 'banned', 'status']),
 			loadShowfullnameSettings(),
 			categories.getCategoriesFields(cids, ['cid', 'name', 'slug', 'icon', 'backgroundImage', 'imageClass', 'bgColor', 'color', 'disabled']),
 			loadGuestHandles(),

--- a/test/topics.js
+++ b/test/topics.js
@@ -2370,6 +2370,19 @@ describe('Topic\'s', () => {
 			assert.strictEqual(data.topics[0].title, 'old replied');
 			assert.strictEqual(data.topics[1].title, 'most recent replied');
 		});
+
+		it('should not expose the author signature', async () => {
+			await User.setUserField(topic.userId, 'signature', 'some signature');
+			const data = await topics.getSortedTopics({
+				cids: [category.cid],
+				uid: topic.userId,
+				start: 0,
+				stop: -1,
+				sort: 'recent',
+			});
+			assert(data.topics[0].user);
+			assert.strictEqual(data.topics[0].user.signature, undefined);
+		});
 	});
 
 	describe('scheduled topics', () => {


### PR DESCRIPTION
### What

`Topics.getTopicsByTids` requests the `signature` field for every topic author and attaches the resulting object to `topic.user` (`src/topics/index.js`). Nothing appears to read it — the bundled themes (Harmony, Persona, Peace, Lavender) only render `posts.user.signature`, which is populated by `Posts.getUserInfoForPosts`, a different code path. The field predates the `138154a71c` module reshuffle and looks vestigial.

### Why it's worth removing

Beyond being dead weight, the topic list is the one place the signature is returned **unfiltered**. `Posts.getUserInfoForPosts` blanks it out when `disableSignatures` is set or when the author is filtered out of the global `signature` privilege:

```js
if (!userData.signature || !signatureUids.has(userData.uid) || meta.config.disableSignatures) {
    return '';
}
```

`getTopicsByTids` applies neither check, so a signature saved while signatures are disabled (the write path doesn't check either — `User.updateProfile` validates length and `min:rep:signature`, but not the privilege) still ships in the JSON for `/api/category/:slug`, `/api/recent`, `/api/unread`, etc. It isn't rendered by any bundled theme, so this is a consistency issue rather than a security one — but it does mean an admin who disabled signatures is still serving them.

Dropping the field also trims up to `maximumSignatureLength` (255 by default) bytes per distinct author from every topic list response.

### Note / question

I deliberately left `src/controllers/accounts/helpers.js` alone. It also exposes the raw signature on the profile payload, but that looks intentional — the same function sets `userData.disableSignatures` for the template, so themes can decide whether to render it. If you'd rather the profile applied the same `disableSignatures` + privilege filter as post rendering, I'm happy to add it here; it seemed like your call rather than mine, and removing the field outright could break third-party themes.

### Tests

Added a case to `test/topics.js` asserting `topic.user.signature` is not present in `getSortedTopics` output.
