### PR TITLE
fix: update stale template path for search filters partial

### DIFF
--- a/public/src/client/search.js
+++ b/public/src/client/search.js
@@ -234,7 +234,7 @@ define('forum/search', [
 
 		$('#clear-preferences').on('click', async function () {
 			storage.removeItem('search-preferences');
-			const html = await app.parseAndTranslate('partials/search-filters', {});
+			const html = await app.parseAndTranslate('partials/search/filters', {});
 			$('[component="search/filters"]').replaceWith(html);
 			$('#search-in').val(ajaxify.data.searchDefaultIn);
 			$('#post-sort-by').val(ajaxify.data.searchDefaultSortBy);
@@ -294,7 +294,7 @@ define('forum/search', [
 		selectedUsers = _selectedUsers || [];
 		userFilter.init(el, {
 			selectedUsers: _selectedUsers,
-			template: 'partials/search-filters',
+			template: 'partials/search/filters',
 			onSelect: function (_selectedUsers) {
 				selectedUsers = _selectedUsers;
 			},
@@ -316,7 +316,7 @@ define('forum/search', [
 	function tagFilterDropdown(el, _selectedTags) {
 		selectedTags = _selectedTags;
 		async function renderSelectedTags() {
-			const html = await app.parseAndTranslate('partials/search-filters', 'tagFilterSelected', {
+			const html = await app.parseAndTranslate('partials/search/filters', 'tagFilterSelected', {
 				tagFilterSelected: selectedTags,
 			});
 			el.find('[component="tag/filter/selected"]').html(html);
@@ -354,7 +354,7 @@ define('forum/search', [
 				tagMap[tag.value] = tag;
 			});
 
-			const html = await app.parseAndTranslate('partials/search-filters', 'tagFilterResults', {
+			const html = await app.parseAndTranslate('partials/search/filters', 'tagFilterResults', {
 				tagFilterResults: result.tags,
 			});
 			el.find('[component="tag/filter/results"]').html(html);


### PR DESCRIPTION
`partials/search-filters` was renamed to `partials/search/filters` in 8b00bf2cd8 when search moved to core, but `search.js` still referenced the old path, so the filters dropdown broke when re-rendering (e.g. after clearing preferences, or filtering by user/tag).