### PR TITLE
Fix: live unread topic badge not updating for users watching a category

### DIFF
--- a/public/src/client/header/unread.js
+++ b/public/src/client/header/unread.js
@@ -5,7 +5,8 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 	const watchStates = {
 		ignoring: 1,
 		notwatching: 2,
-		watching: 3,
+		tracking: 3,
+		watching: 4,
 	};
 
 	unread.initUnreadTopics = function () {
@@ -15,7 +16,9 @@ define('forum/header/unread', ['hooks'], function (hooks) {
 			if (data && data.posts && data.posts.length && unreadTopics) {
 				const post = data.posts[0];
 				if (parseInt(post.uid, 10) === parseInt(app.user.uid, 10) ||
-					(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching)
+					(!post.topic.isFollowing &&
+						post.categoryWatchState !== watchStates.watching &&
+						post.categoryWatchState !== watchStates.tracking)
 				) {
 					return;
 				}


### PR DESCRIPTION
## Problem

The unread topic count badge in the header does not update in real time for users whose category watch state is set to **watching**. When a new post arrives, the badge stays hidden even though the server-rendered unread count includes the topic — it only appears after navigating to `/unread` (which re-syncs the badge from `ajaxify.data.topicCount`) or after a full page refresh.

## Cause

`public/src/client/header/unread.js` still defines the pre-3.6.0 watch state values:

```js
const watchStates = { ignoring: 1, notwatching: 2, watching: 3 };
```

Core added the `tracking` state in 3.6.0 (84fed97b41), shifting `watching` to 4 in `src/categories/watch.js`. The client was never updated, so the check in `onNewPost`:

```js
(!post.topic.isFollowing && post.categoryWatchState !== watchStates.watching)
```

actually compares against `tracking` (3). Users tracking a category get the live badge bump, while users **watching** it (4) are filtered out and never do — inconsistent with the server-side unread count logic in `src/topics/unread.js`, which counts topics for both watching and tracking states.

## Fix

Sync the client watch state table with core, and bump the badge when the recipient's category watch state is either `tracking` or `watching`, mirroring the server-side logic.