### PR TITLE
fix: only offer categories the user can crosspost to

### DIFF
--- a/public/src/client/topic/crosspost.js
+++ b/public/src/client/topic/crosspost.js
@@ -54,6 +54,7 @@ define('forum/topic/crosspost', [
 			}
 			categoryFilter.init($('[component="category/dropdown"]'), {
 				onHidden: onCategoriesSelected,
+				privilege: 'topics:crosspost',
 				hideAll: true,
 				hideUncategorized: true,
 				localOnly: true,


### PR DESCRIPTION
### Problem

The crosspost modal's category dropdown is filtered by `topics:read` — the `categorySearch` default — but `topics.crossposts.add()` requires `topics:crosspost` on the **destination** category:

https://github.com/NodeBB/NodeBB/blob/master/src/topics/crossposts.js#L68-L77

So the dropdown happily offers categories the crosspost will be rejected for, and the user only finds out after picking one and getting `[[error:not-allowed]]`.

### Change

One line: pass `privilege: 'topics:crosspost'` to `categoryFilter.init()`, so `searchApi.categories` filters the list server-side to categories the user can actually crosspost into. Same pattern as the fork modal (`privilege: 'moderate'`) and quick reply (`privilege: 'topics:create'`).

The button itself stays as-is and the modal still opens for everyone — per review discussion, the destination list is the right place to enforce this, since the destination isn't known until the user picks one.
