### PR TITLE
fix(crossposts): pinned topics throw, tags unindexed, no bump on reply

### DIFF
--- a/src/topics/crossposts.js
+++ b/src/topics/crossposts.js
@@ -85,9 +85,13 @@ Crossposts.add = async function (tid, cid, uid) {
 	const now = Date.now();
 	const crosspostId = utils.generateUUID();
 	if (!crosspostedCids.includes(String(cid))) {
-		const [topicData, pids] = await Promise.all([
-			topics.getTopicFields(tid, ['uid', 'cid', 'timestamp']),
+		const [topicData, pids, tags] = await Promise.all([
+			topics.getTopicFields(tid, [
+				'uid', 'cid', 'timestamp', 'lastposttime', 'pinned',
+				'postcount', 'viewcount', 'upvotes', 'downvotes',
+			]),
 			topics.getPids(tid),
+			topics.getTopicTags(tid),
 		]);
 		let pidTimestamps = await posts.getPostsFields(pids, ['timestamp']);
 		pidTimestamps = pidTimestamps.map(({ timestamp }) => timestamp);
@@ -95,19 +99,26 @@ Crossposts.add = async function (tid, cid, uid) {
 		if (cid === topicData.cid) {
 			throw new Error('[[error:invalid-cid]]');
 		}
-		const zsets = [
-			`cid:${topicData.cid}:tids`,
-			`cid:${topicData.cid}:tids:create`,
-			`cid:${topicData.cid}:tids:lastposttime`,
-			`cid:${topicData.cid}:uid:${topicData.uid}:tids`,
-			`cid:${topicData.cid}:tids:votes`,
-			`cid:${topicData.cid}:tids:posts`,
-			`cid:${topicData.cid}:tids:views`,
+
+		// Scores are derived from topic data, not copied from the source category's
+		// sorted sets — a pinned topic is absent from those sets, and copying a null
+		// score throws (`[[error:invalid-score, null]]`)
+		const votes = (parseInt(topicData.upvotes, 10) || 0) - (parseInt(topicData.downvotes, 10) || 0);
+		const bulkAdd = [
+			[`cid:${cid}:tids:lastposttime`, topicData.lastposttime, tid],
+			[`cid:${cid}:uid:${topicData.uid}:tids`, topicData.timestamp, tid],
+			...tags.map(tag => [`cid:${cid}:tag:${tag}:topics`, topicData.timestamp, tid]),
 		];
-		const scores = await db.sortedSetsScore(zsets, tid);
-		const bulkAdd = zsets.map((zset, idx) => {
-			return [zset.replace(`cid:${topicData.cid}`, `cid:${cid}`), scores[idx], tid];
-		});
+		if (topicData.pinned) {
+			bulkAdd.push([`cid:${cid}:tids:pinned`, now, tid]);
+		} else {
+			bulkAdd.push([`cid:${cid}:tids`, topicData.lastposttime, tid]);
+			bulkAdd.push([`cid:${cid}:tids:create`, topicData.timestamp, tid]);
+			bulkAdd.push([`cid:${cid}:tids:posts`, topicData.postcount || 0, tid]);
+			bulkAdd.push([`cid:${cid}:tids:votes`, votes, tid]);
+			bulkAdd.push([`cid:${cid}:tids:views`, topicData.viewcount || 0, tid]);
+		}
+
 		await Promise.all([
 			db.sortedSetAddBulk(bulkAdd),
 			db.sortedSetAdd(`cid:${cid}:pids`, pidTimestamps, pids),
@@ -116,7 +127,10 @@ Crossposts.add = async function (tid, cid, uid) {
 			uid > 0 ? db.sortedSetAdd(`uid:${uid}:crossposts`, now, crosspostId) : false,
 			topics.events.log(tid, { uid, type: 'crosspost', toCid: cid }),
 		]);
-		await categories.onTopicsMoved([cid]); // must be done after
+		await Promise.all([
+			topics.updateCategoryTagsCount([cid], tags),
+			categories.onTopicsMoved([cid]), // must be done after
+		]);
 	} else {
 		throw new Error('[[error:topic-already-crossposted]]');
 	}
@@ -154,18 +168,21 @@ Crossposts.remove = async function (tid, cid, uid) {
 		throw new Error('[[error:invalid-data]]');
 	}
 
-	const [author, pids] = await Promise.all([
+	const [author, pids, tags] = await Promise.all([
 		topics.getTopicField(tid, 'uid'),
 		topics.getPids(tid),
+		topics.getTopicTags(tid),
 	]);
 	let bulkRemove = [
 		`cid:${cid}:tids`,
 		`cid:${cid}:tids:create`,
 		`cid:${cid}:tids:lastposttime`,
+		`cid:${cid}:tids:pinned`,
 		`cid:${cid}:uid:${author}:tids`,
 		`cid:${cid}:tids:votes`,
 		`cid:${cid}:tids:posts`,
 		`cid:${cid}:tids:views`,
+		...tags.map(tag => `cid:${cid}:tag:${tag}:topics`),
 	];
 	bulkRemove = bulkRemove.map(zset => [zset, tid]);
 
@@ -176,7 +193,10 @@ Crossposts.remove = async function (tid, cid, uid) {
 		db.sortedSetRemove(`cid:${cid}:pids`, pids),
 		uid > 0 ? db.sortedSetRemove(`uid:${uid}:crossposts`, crosspostId) : false,
 	]);
-	await categories.onTopicsMoved([cid]);
+	await Promise.all([
+		topics.updateCategoryTagsCount([cid], tags),
+		categories.onTopicsMoved([cid]),
+	]);
 
 	topics.events.find(tid, { uid, toCid: cid, type: 'crosspost' }).then((eventIds) => {
 		topics.events.purge(tid, eventIds);

--- a/src/topics/recent.js
+++ b/src/topics/recent.js
@@ -63,14 +63,16 @@ module.exports = function (Topics) {
 		const topicData = await Topics.getTopicFields(tid, ['cid', 'deleted', 'pinned']);
 		const crossposts = await Topics.crossposts.get(tid);
 		const crosspostCids = crossposts.map(({ cid }) => cid);
-		const keys = [topicData.cid, ...crosspostCids].map(cid => `cid:${cid}:tids:lastposttime`);
+		const cids = [topicData.cid, ...crosspostCids];
 
-		await db.sortedSetsAdd(keys, lastposttime, tid);
+		await db.sortedSetsAdd(cids.map(cid => `cid:${cid}:tids:lastposttime`), lastposttime, tid);
 
 		await Topics.updateRecent(tid, lastposttime);
 
 		if (!topicData.pinned) {
-			await db.sortedSetAdd(`cid:${topicData.cid}:tids`, lastposttime, tid);
+			// crossposted categories are bumped too, otherwise the topic is stuck at
+			// the position it had when it was crossposted and sinks as others are replied to
+			await db.sortedSetsAdd(cids.map(cid => `cid:${cid}:tids`), lastposttime, tid);
 		}
 	};
 

--- a/test/crossposts.js
+++ b/test/crossposts.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const assert = require('assert');
+
+const db = require('./mocks/databasemock');
+const topics = require('../src/topics');
+const categories = require('../src/categories');
+const privileges = require('../src/privileges');
+const User = require('../src/user');
+const groups = require('../src/groups');
+
+describe('Crossposts', () => {
+	let uid;
+	let adminUid;
+	let sourceCategory;
+	let targetCategory;
+
+	before(async () => {
+		uid = await User.create({ username: 'crossposter', password: '123456' });
+		adminUid = await User.create({ username: 'crosspost-admin', password: '123456' });
+		await groups.join('administrators', adminUid);
+		sourceCategory = await categories.create({ name: 'crosspost source' });
+		targetCategory = await categories.create({ name: 'crosspost target' });
+		await privileges.categories.give(['groups:topics:crosspost'], targetCategory.cid, 'registered-users');
+	});
+
+	async function createTopic(data) {
+		const { topicData } = await topics.post({
+			uid,
+			cid: sourceCategory.cid,
+			title: 'crosspost test topic',
+			content: 'the content of the crosspost test topic',
+			...data,
+		});
+		return topicData;
+	}
+
+	it('should crosspost a pinned topic', async () => {
+		const { tid } = await createTopic();
+		await topics.tools.pin(tid, adminUid);
+
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		const [pinnedScore, tidsScore] = await Promise.all([
+			db.sortedSetScore(`cid:${targetCategory.cid}:tids:pinned`, tid),
+			db.sortedSetScore(`cid:${targetCategory.cid}:tids`, tid),
+		]);
+		assert(pinnedScore, 'crossposted pinned topic should be in the destination pinned set');
+		assert.strictEqual(tidsScore, null, 'a pinned topic should not be in the destination topic set');
+	});
+
+	it('should index the topic\'s tags in the destination category', async () => {
+		const { tid } = await createTopic({ tags: ['crosspost-tag'] });
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		const score = await db.sortedSetScore(`cid:${targetCategory.cid}:tag:crosspost-tag:topics`, tid);
+		assert(score, 'crossposted topic should be listed under its tags in the destination category');
+
+		await topics.crossposts.remove(tid, targetCategory.cid, uid);
+		const scoreAfter = await db.sortedSetScore(`cid:${targetCategory.cid}:tag:crosspost-tag:topics`, tid);
+		assert.strictEqual(scoreAfter, null, 'tag index should be cleaned up when the crosspost is removed');
+	});
+
+	it('should remove the topic from the destination sets when uncrossposted', async () => {
+		const { tid } = await createTopic();
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+		await topics.crossposts.remove(tid, targetCategory.cid, uid);
+
+		const scores = await db.sortedSetsScore([
+			`cid:${targetCategory.cid}:tids`,
+			`cid:${targetCategory.cid}:tids:create`,
+			`cid:${targetCategory.cid}:tids:lastposttime`,
+			`cid:${targetCategory.cid}:tids:pinned`,
+		], tid);
+		assert(scores.every(score => score === null), 'destination sets should not reference the topic');
+	});
+});

--- a/test/crossposts.js
+++ b/test/crossposts.js
@@ -61,6 +61,18 @@ describe('Crossposts', () => {
 		assert.strictEqual(scoreAfter, null, 'tag index should be cleaned up when the crosspost is removed');
 	});
 
+	it('should bump the topic in crossposted categories when it is replied to', async () => {
+		const { tid } = await createTopic();
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		const before = await db.sortedSetScore(`cid:${targetCategory.cid}:tids`, tid);
+		const { timestamp } = await topics.reply({ uid, tid, content: 'a reply to bump the topic' });
+
+		const after = await db.sortedSetScore(`cid:${targetCategory.cid}:tids`, tid);
+		assert(after > before, 'reply should bump the topic in the crossposted category');
+		assert.strictEqual(after, timestamp);
+	});
+
 	it('should remove the topic from the destination sets when uncrossposted', async () => {
 		const { tid } = await createTopic();
 		await topics.crossposts.add(tid, targetCategory.cid, uid);


### PR DESCRIPTION
Three sorted-set problems in `src/topics/crossposts.js`, found while looking at where a crossposted topic lands in the destination category. Split into two commits so the second can be dropped if you disagree with it.

### 1. Crossposting a pinned topic throws and leaves a half-written crosspost

`Crossposts.add()` copies scores out of the **source** category's sets:

https://github.com/NodeBB/NodeBB/blob/master/src/topics/crossposts.js#L98-L112

But `togglePin()` *removes* a pinned topic from `cid:<cid>:tids`, `:tids:create`, `:tids:posts`, `:tids:votes` and `:tids:views`, so every copied score is `null` and `sortedSetAddBulk` rejects with `[[error:invalid-score, null]]` (both [mongo](https://github.com/NodeBB/NodeBB/blob/master/src/database/mongo/sorted/add.js#L83-L85) and redis).

The throw happens inside a `Promise.all` whose siblings have already written `crosspost:<uuid>`, `tid:<tid>:crossposts` and `cid:<cid>:pids`, and `categories.onTopicsMoved()` never runs — so the user gets an error while the database keeps a crosspost record whose topic is in no topic set and whose category counts are stale.

Fixed by deriving the scores from topic data the way `Topics.tools.move()` does, and sending pinned topics to `cid:<cid>:tids:pinned`. This also drops the dependency on the source sets, which can be missing for other reasons (scheduled topics, for instance).

### 2. Tags were never indexed in the destination category

`move()` maintains `cid:<cid>:tag:<tag>:topics` and calls `updateCategoryTagsCount()`; `add()`/`remove()` did neither. Since `buildTopicsSortedSet()` intersects with those sets when a tag filter is active, filtering the destination category by a tag hid crossposted topics completely. `remove()` also left `cid:<cid>:tids:pinned` orphaned. Both now handled.

*Known remaining gap:* editing a topic's tags after it has been crossposted still only updates the topic's own category (`createTags`/`deleteTopicTags` are cid-scoped). Happy to follow up on that separately if you'd like it in the same pass.

### 3. Replies did not bump the topic in crossposted categories (second commit)

`updateLastPostTime()` already resolves the crossposted cids and updates `cid:<cid>:tids:lastposttime` for each — then writes `cid:<cid>:tids` for the topic's own category only:

https://github.com/NodeBB/NodeBB/blob/master/src/topics/recent.js#L61-L73

`cid:<cid>:tids` backs the default `recently_replied` sort, so a crossposted topic sat frozen at whatever position it held the moment it was crossposted and only sank from there. Given that the same function goes to the trouble of fetching crossposts for the sibling set, this reads like an oversight rather than a decision — but it *is* a visible behaviour change, hence the separate commit.

`:tids:posts`, `:tids:votes` and `:tids:views` have the same staleness, and are deliberately **not** touched here: unlike this one they would each need a new `crossposts.get()` on a hot write path. Opened #14659 to discuss whether that trade is worth making.

### Tests

New `test/crossposts.js`. Against `master` the three new cases fail with exactly the symptoms above:

```
1 passing
3 failing
  1) Error: [[error:invalid-score, null]]
  2) AssertionError: crossposted topic should be listed under its tags in the destination category
  3) AssertionError: reply should bump the topic in the crossposted category
```

and all four pass with the fixes applied.


