### PR TITLE
fix: bring chat modal to front on interaction so overlapping chat modals stack correctly

### DIFF
--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -299,6 +299,16 @@ define('chat', [
 		return $('#chat-modal-' + roomId);
 	};
 
+	function bringModalToFront(chatModal) {
+		const chatModals = $('.chat-modal');
+		if (chatModals.length <= 1) {
+			return;
+		}
+		chatModals.css('zIndex', '');
+		const zIndex = parseInt(chatModal.css('zIndex'), 10) || 1055;
+		chatModal.css('zIndex', zIndex + 1);
+	}
+
 	Chat.modalExists = function (roomId) {
 		return $('#chat-modal-' + roomId).length !== 0;
 	};
@@ -371,6 +381,7 @@ define('chat', [
 				chatModal.attr('data-uuid', uuid);
 				chatModal.css('position', 'fixed');
 				chatModal.appendTo($('body'));
+				bringModalToFront(chatModal);
 				chatModal.find('.timeago').timeago();
 				chatModal.find('[data-bs-toggle="tooltip"]').tooltip({ trigger: 'hover', container: '#content' });
 				ChatsMessages.wrapImagesInLinks(chatModal.find('[component="chat/messages"] .chat-content'));
@@ -400,6 +411,10 @@ define('chat', [
 				chatModal.find('button[data-action="minimize"]').on('click', function () {
 					const uuid = chatModal.attr('data-uuid');
 					Chat.minimize(uuid);
+				});
+
+				chatModal.on('mousedown', function () {
+					bringModalToFront(chatModal);
 				});
 
 				chatModal.on('mouseup', function () {
@@ -563,6 +578,7 @@ define('chat', [
 		require(['forum/chats/messages'], function (ChatsMessages) {
 			const chatModal = $('.chat-modal[data-uuid="' + uuid + '"]');
 			chatModal.removeClass('hide');
+			bringModalToFront(chatModal);
 			taskbar.updateActive(uuid);
 			ChatsMessages.scrollToBottomAfterImageLoad(chatModal.find('.chat-content'));
 			Chat.focusInput(chatModal);


### PR DESCRIPTION
## Problem

Chat modals never manage `z-index` between themselves. All of them share Bootstrap's default modal `z-index`, so stacking order is fixed by DOM insertion order forever — `taskbar.updateActive` only highlights the taskbar item and does not raise the modal.

When two chat modals overlap (they all open at the same default position), the chat the user is currently interacting with can remain painted and hit-tested *below* another modal. Combined with the modal root being a full-viewport `pe-none` layer (only `.modal-content` catches pointer events), clicks in the overlap region land on the wrong chat.

### Reproduction
1. Open chat modal A containing an image, then open chat modal B on top of it.
2. Interact with A (click its visible edge / restore it from the taskbar) — it stays under B in stacking order.
3. Right-click in the overlap area: the browser shows the image context menu for the image in the *other* chat, even though no image is visible at that point ("Copy image address" yields the covered chat's image URL).

## Fix

Add `bringModalToFront()` which resets the inline `z-index` of all chat modals and raises the target one above the shared base. It is called when a modal is created, on `mousedown` anywhere in a modal, and when a modal is restored from the taskbar (`Chat.load`) — so the chat the user is interacting with is always the top-most one, and hit-testing matches what is visually in front.