### PR TITLE
fix: make jQuery resolution compatible with pnpm

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -191,7 +191,7 @@
         "sass-embedded": "1.100.0"
     },
     "resolutions": {
-        "*/jquery": "3.7.1"
+        "jquery": "3.7.1"
     },
     "bugs": {
         "url": "https://github.com/NodeBB/NodeBB/issues"


### PR DESCRIPTION
## Summary

- replace the unsupported `*/jquery` resolution selector with the package-wide `jquery` selector
- keep every jQuery consumer pinned to 3.7.1 while allowing pnpm to parse the manifest

## Verification

- reproduced `ERR_PNPM_INVALID_OVERRIDES_SELECTOR` with pnpm 8.14.0 before the change
- completed a full install with pnpm 8.14.0 after the change
- verified `jquery`, `jquery-ui`, `jquery-form`, `jquery-deserialize`, `timeago`, and Bootbox resolve to jQuery 3.7.1
- verified Yarn 1.22.22 retains its existing resolution behavior
- verified Yarn 4.12.0 no longer emits `YN0057` and resolves all jQuery consumers to 3.7.1

Closes #12262
