### PR TITLE
fix: apply saved search preferences immediately

### DIFF
--- a/public/src/client/search.js
+++ b/public/src/client/search.js
@@ -229,6 +229,7 @@ define('forum/search', [
 			});
 			storage.setItem('search-preferences', JSON.stringify(saveData));
 			alerts.success('[[search:search-preferences-saved]]');
+			searchModule.query(data);
 			return false;
 		});
 


### PR DESCRIPTION
## Summary

- run the advanced search with the current form values immediately after saving preferences
- put the selected filters into the URL so the resulting page can be reloaded without falling back to the server defaults

## Verification

- ESLint and syntax checks pass for `public/src/client/search.js`
- verified on a local NodeBB instance that saving `In titles` changes the URL to include `in=titles`
- verified the selected filters remain active after the resulting page reloads
- verified the existing search path serializes empty terms, Unicode values, categories, tags, and other advanced filters

Closes #8784
