### PR TITLE
feat: hint when follow notifications are disabled

### DIFF
--- a/public/language/en-GB/tags.json
+++ b/public/language/en-GB/tags.json
@@ -13,5 +13,6 @@
 	"watching.description": "Notify me of new topics.",
 	"not-watching.description": "Do not notify me of new topics.",
 	"following-tag.message": "You will now be receiving notifications when somebody posts a topic with this tag.",
+	"following-tag.message-no-notifications": "You are now following this tag, but your notification setting is set to none.",
 	"not-following-tag.message": "You will not receive notifications when somebody posts a topic with this tag."
 }

--- a/public/language/en-GB/topic.json
+++ b/public/language/en-GB/topic.json
@@ -90,6 +90,7 @@
 	"deleted-message": "This topic has been deleted. Only users with topic management privileges can see it.",
 
 	"following-topic.message": "You will now be receiving notifications when somebody posts to this topic.",
+	"following-topic.message-no-notifications": "You are now following this topic, but your notification setting is set to none.",
 	"not-following-topic.message": "You will see this topic in the unread topics list, but you will not receive notifications when somebody posts to this topic.",
 	"ignoring-topic.message": "You will no longer see this topic in the unread topics list.  You will be notified when you are mentioned or your post is up voted.",
 

--- a/public/openapi/read/admin/config.yaml
+++ b/public/openapi/read/admin/config.yaml
@@ -161,6 +161,10 @@ get:
                 type: string
               hideReadNotifications:
                 type: boolean
+              notificationType_new-reply:
+                type: string
+              notificationType_new-topic-with-tag:
+                type: string
               openOutgoingLinksInNewTab:
                 type: boolean
               topicSearchEnabled:

--- a/public/openapi/read/config.yaml
+++ b/public/openapi/read/config.yaml
@@ -154,6 +154,10 @@ get:
                 type: string
               hideReadNotifications:
                 type: boolean
+              notificationType_new-reply:
+                type: string
+              notificationType_new-topic-with-tag:
+                type: string
               openOutgoingLinksInNewTab:
                 type: boolean
               topicSearchEnabled:

--- a/public/src/client/account/tags.js
+++ b/public/src/client/account/tags.js
@@ -33,7 +33,7 @@ define('forum/account/tags', [
 				alerts.alert({
 					alert_id: 'follow_tag',
 					message: config['notificationType_new-topic-with-tag'] === 'none' ?
-						'[[modules:chat.notification-settings]]: [[modules:chat.notification-setting-none]]' :
+						'[[tags:following-tag.message-no-notifications]]' :
 						'[[tags:following-tag.message]]',
 					type: 'success',
 					timeout: 5000,

--- a/public/src/client/account/tags.js
+++ b/public/src/client/account/tags.js
@@ -32,7 +32,9 @@ define('forum/account/tags', [
 			api.put(`/tags/${event.item}/follow`, {}).then(() => {
 				alerts.alert({
 					alert_id: 'follow_tag',
-					message: '[[tags:following-tag.message]]',
+					message: config['notificationType_new-topic-with-tag'] === 'none' ?
+						'[[modules:chat.notification-settings]]: [[modules:chat.notification-setting-none]]' :
+						'[[tags:following-tag.message]]',
 					type: 'success',
 					timeout: 5000,
 				});

--- a/public/src/client/tag.js
+++ b/public/src/client/tag.js
@@ -22,7 +22,9 @@ define('forum/tag', [
 			api[method](`/tags/${ajaxify.data.tag}/follow`, {}).then(() => {
 				let message = '';
 				if (type === 'follow') {
-					message = '[[tags:following-tag.message]]';
+					message = config['notificationType_new-topic-with-tag'] === 'none' ?
+						'[[modules:chat.notification-settings]]: [[modules:chat.notification-setting-none]]' :
+						'[[tags:following-tag.message]]';
 				} else if (type === 'unfollow') {
 					message = '[[tags:not-following-tag.message]]';
 				}

--- a/public/src/client/tag.js
+++ b/public/src/client/tag.js
@@ -23,7 +23,7 @@ define('forum/tag', [
 				let message = '';
 				if (type === 'follow') {
 					message = config['notificationType_new-topic-with-tag'] === 'none' ?
-						'[[modules:chat.notification-settings]]: [[modules:chat.notification-setting-none]]' :
+						'[[tags:following-tag.message-no-notifications]]' :
 						'[[tags:following-tag.message]]';
 				} else if (type === 'unfollow') {
 					message = '[[tags:not-following-tag.message]]';

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -171,7 +171,7 @@ define('forum/topic/threadTools', [
 				let message = '';
 				if (type === 'follow') {
 					message = state && config['notificationType_new-reply'] === 'none' ?
-						'[[modules:chat.notification-settings]]: [[modules:chat.notification-setting-none]]' :
+						'[[topic:following-topic.message-no-notifications]]' :
 						(state ? '[[topic:following-topic.message]]' : '[[topic:not-following-topic.message]]');
 				} else if (type === 'ignore') {
 					message = state ? '[[topic:ignoring-topic.message]]' : '[[topic:not-following-topic.message]]';

--- a/public/src/client/topic/threadTools.js
+++ b/public/src/client/topic/threadTools.js
@@ -170,7 +170,9 @@ define('forum/topic/threadTools', [
 			api[method](`/topics/${tid}/${type}`, {}, () => {
 				let message = '';
 				if (type === 'follow') {
-					message = state ? '[[topic:following-topic.message]]' : '[[topic:not-following-topic.message]]';
+					message = state && config['notificationType_new-reply'] === 'none' ?
+						'[[modules:chat.notification-settings]]: [[modules:chat.notification-setting-none]]' :
+						(state ? '[[topic:following-topic.message]]' : '[[topic:not-following-topic.message]]');
 				} else if (type === 'ignore') {
 					message = state ? '[[topic:ignoring-topic.message]]' : '[[topic:not-following-topic.message]]';
 				}

--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -143,6 +143,8 @@ apiController.loadConfig = async function (req) {
 		}
 	}
 	config.hideReadNotifications = settings.hideReadNotifications;
+	config['notificationType_new-reply'] = settings['notificationType_new-reply'];
+	config['notificationType_new-topic-with-tag'] = settings['notificationType_new-topic-with-tag'];
 
 	// Overrides based on privilege
 	config.disableChatMessageEditing = isAdminOrGlobalMod ? false : config.disableChatMessageEditing;

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -9,6 +9,7 @@ const util = require('util');
 const db = require('./mocks/databasemock');
 const request = require('../src/request');
 const api = require('../src/api');
+const apiController = require('../src/controllers/api');
 const categories = require('../src/categories');
 const topics = require('../src/topics');
 const posts = require('../src/posts');
@@ -61,6 +62,32 @@ describe('Controllers', () => {
 		const { response, body } = await request.get(`${nconf.get('url')}/api/config`);
 		assert.equal(response.statusCode, 200);
 		assert(body.csrf_token);
+	});
+
+	it('should expose notification settings used by client-side subscription hints', async () => {
+		await Promise.all([
+			user.setSetting(fooUid, 'notificationType_new-reply', 'none'),
+			user.setSetting(fooUid, 'notificationType_new-topic-with-tag', 'none'),
+		]);
+
+		try {
+			const config = await apiController.loadConfig({
+				uid: fooUid,
+				loggedIn: true,
+				user: { uid: fooUid },
+				query: {},
+				headers: {},
+				body: {},
+				session: {},
+			});
+			assert.strictEqual(config['notificationType_new-reply'], 'none');
+			assert.strictEqual(config['notificationType_new-topic-with-tag'], 'none');
+		} finally {
+			await Promise.all([
+				user.setSetting(fooUid, 'notificationType_new-reply', 'notification'),
+				user.setSetting(fooUid, 'notificationType_new-topic-with-tag', 'notification'),
+			]);
+		}
 	});
 
 	it('should load /config with no csrf_token as spider', async () => {


### PR DESCRIPTION
## Summary

- expose the current user's reply and followed-tag notification delivery settings in the client config
- show a localized `Notification Settings: No notifications` hint after a successful topic or tag follow when the corresponding delivery setting is `none`
- document both user-specific config fields in the public and admin OpenAPI schemas

The original setting keys are used in the client config so a settings save updates them in the current session without requiring a full reload. Existing translations are composed for the hint; no language files are changed.

## Verification

- added a controller regression test for both user-specific config values
- verified the focused controller test passes
- verified all 51 locales provide both reused translation strings
- verified the complete i18n suite passes (3,838 tests)
- ESLint, OpenAPI YAML parsing, and `git diff --check` pass

Closes #12557
