### PR TITLE
feat: support internal text fragment links

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -87,6 +87,12 @@ ajaxify.widgets = { render: render };
 	};
 
 	ajaxify.go = function (url, callback, quiet) {
+		if (utils.hasTextFragment(url)) {
+			url = ajaxify.removeRelativePath(url.replace(/^\/|\/$/g, ''));
+			window.location.href = utils.prependRelativePath(url, config.relative_path);
+			return true;
+		}
+
 		// Automatically reconnect to socket and re-ajaxify on success
 		if (!socket.connected && parseInt(app.user.uid, 10) >= 0) {
 			app.reconnect();
@@ -200,15 +206,9 @@ ajaxify.widgets = { render: render };
 		ajaxify.currentPage = url.split(/[?#]/)[0];
 		ajaxify.requestedPage = null;
 		if (window.history && window.history.pushState) {
-			const prependSlash = url && !url.startsWith('?') && !url.startsWith('#');
-			const { relative_path } = config;
-			const historyUrl = prependSlash ?
-				(relative_path + '/' + url) :
-				relative_path + (url || (relative_path ? '' : '/'));
-
 			window.history[!quiet ? 'pushState' : 'replaceState']({
 				url: url,
-			}, '', historyUrl);
+			}, '', utils.prependRelativePath(url, config.relative_path));
 		}
 	};
 
@@ -584,7 +584,10 @@ $(document).ready(function () {
 						const pathname = this.href.replace(rootAndPath, '');
 
 						// Special handling for urls with hashes
-						if (window.location.pathname === this.pathname && this.hash.length) {
+						if (utils.hasTextFragment(this)) {
+							ajaxify.go(pathname);
+							e.preventDefault();
+						} else if (window.location.pathname === this.pathname && this.hash.length) {
 							window.location.hash = this.hash;
 						} else if (ajaxify.go(pathname)) {
 							e.preventDefault();

--- a/public/src/utils.common.js
+++ b/public/src/utils.common.js
@@ -727,6 +727,24 @@ const utils = {
 			);
 	},
 
+	prependRelativePath: function (url, relativePath) {
+		const prependSlash = url && !url.startsWith('?') && !url.startsWith('#');
+		return prependSlash ?
+			(relativePath + '/' + url) :
+			relativePath + (url || (relativePath ? '' : '/'));
+	},
+
+	hasTextFragment: function (url) {
+		try {
+			const hash = url instanceof URL ? url.hash : new URL(url, 'http://localhost').hash;
+			const directiveStart = hash.indexOf(':~:');
+			const directive = directiveStart === -1 ? '' : hash.slice(directiveStart + 3);
+			return Boolean(directive && directive.split('&').some(value => value.startsWith('text=')));
+		} catch (err) {
+			return false;
+		}
+	},
+
 	rtrim: function (str) {
 		return str.replace(/\s+$/g, '');
 	},

--- a/test/utils.js
+++ b/test/utils.js
@@ -513,6 +513,40 @@ describe('Utility Methods', () => {
 		});
 	});
 
+	describe('prependRelativePath', () => {
+		it('should preserve the relative-path behaviour used by ajaxify history', () => {
+			assert.strictEqual(utils.prependRelativePath('topic/1#:~:text=target', '/forum'), '/forum/topic/1#:~:text=target');
+			assert.strictEqual(utils.prependRelativePath('?sort=latest', '/forum'), '/forum?sort=latest');
+			assert.strictEqual(utils.prependRelativePath('#post', '/forum'), '/forum#post');
+			assert.strictEqual(utils.prependRelativePath('', '/forum'), '/forum');
+			assert.strictEqual(utils.prependRelativePath('', ''), '/');
+		});
+	});
+
+	describe('hasTextFragment', () => {
+		it('should detect text fragments with and without a regular fragment', () => {
+			assert(utils.hasTextFragment('/topic/1#:~:text=target'));
+			assert(utils.hasTextFragment('/topic/1#post:~:text=target'));
+		});
+
+		it('should detect text among multiple fragment directives', () => {
+			assert(utils.hasTextFragment('/topic/1#:~:unknown=one&text=target'));
+			assert(utils.hasTextFragment('/topic/1#:~:unknown=x:~:y&text=target'));
+			assert(utils.hasTextFragment('/topic/1#:~:text=first&text=second'));
+		});
+
+		it('should ignore regular and encoded fragments', () => {
+			assert(!utils.hasTextFragment('/topic/1#post'));
+			assert(!utils.hasTextFragment('/topic/1#%3A~%3Atext%3Dtarget'));
+			assert(!utils.hasTextFragment('/topic/1#:~:text%3Dtarget'));
+		});
+
+		it('should handle URL objects and invalid values', () => {
+			assert(utils.hasTextFragment(new URL('https://example.org/topic/1#:~:text=target')));
+			assert(!utils.hasTextFragment('http://['));
+		});
+	});
+
 	describe('isSafeHref', () => {
 		it('should return true for http/https url', (done) => {
 			assert(utils.isSafeHref('http://nodebb.org'));


### PR DESCRIPTION
Resolves #12711.

Internal links containing a text fragment were handled through Ajaxify, so supporting browsers never performed the document navigation needed to locate and highlight the requested text.

This change:

- detects `text=` fragment directives after the first `:~:` delimiter, including multiple directives and valid repeated delimiters inside directive values;
- performs a native document navigation for those links while retaining the existing unsaved-changes confirmation path; and
- reuses Ajaxify's history URL construction so leading slashes and subfolder installations keep their existing semantics.

Validation:

- 5 focused utility tests pass;
- ESLint, syntax checks, `git diff --check`, and a fresh asset build pass;
- trusted Chromium clicks were tested for normal, same-page, repeated-delimiter, and unsaved Cancel/Confirm paths; and
- a real service-worker message was tested under `config.relative_path = '/forum'`, preserving the subfolder and query while triggering a full navigation.