### PR TITLE
fix: link merged notifications to first unread post

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -160,18 +160,40 @@ Notifications.filterExists = async function (nids) {
 };
 
 Notifications.findRelated = async function (mergeIds, set) {
+	const notificationData = await getRelatedNotificationData(mergeIds, set);
+	return notificationData.map(notification => notification.nid);
+};
+
+async function getRelatedNotificationData(mergeIds, set, fields = []) {
 	mergeIds = mergeIds.filter(Boolean);
 	if (!mergeIds.length) {
 		return [];
 	}
-	// A related notification is one in a zset that has the same mergeId
 	const nids = await db.getSortedSetMembers(set);
-
 	const keys = nids.map(nid => `notifications:${nid}`);
-	const notificationData = await db.getObjectsFields(keys, ['mergeId']);
-	const notificationMergeIds = notificationData.map(notifObj => String(notifObj.mergeId));
+	const notificationData = await db.getObjectsFields(keys, _.uniq(['mergeId', ...fields]));
 	const mergeSet = new Set(mergeIds.map(id => String(id)));
-	return nids.filter((nid, idx) => mergeSet.has(notificationMergeIds[idx]));
+	// getSortedSetMembers returns oldest first, so consumers can retain the first match per mergeId.
+	return notificationData.reduce((related, notification, index) => {
+		if (notification && mergeSet.has(String(notification.mergeId))) {
+			related.push({ ...notification, nid: nids[index] });
+		}
+		return related;
+	}, []);
+}
+
+Notifications.findOldestRelated = async function (mergeIds, set) {
+	const notificationData = await getRelatedNotificationData(mergeIds, set, ['path', 'pid']);
+	const oldestByMergeId = new Map();
+	notificationData.forEach((notification) => {
+		const mergeId = String(notification.mergeId);
+		if (oldestByMergeId.has(mergeId)) {
+			return;
+		}
+		notification.pid = utils.isNumber(notification.pid) ? parseInt(notification.pid, 10) || 0 : notification.pid;
+		oldestByMergeId.set(mergeId, notification);
+	});
+	return [...oldestByMergeId.values()];
 };
 
 Notifications.create = async function (data) {

--- a/src/user/notifications.js
+++ b/src/user/notifications.js
@@ -1,6 +1,7 @@
 
 'use strict';
 
+const nconf = require('nconf');
 const winston = require('winston');
 const _ = require('lodash');
 
@@ -95,8 +96,12 @@ async function deleteUserNids(nids, uid) {
 }
 
 async function getNotificationsFromSet(set, uid, start, stop) {
-	const nids = await db.getSortedSetRevRange(set, start, stop);
-	return await UserNotifications.getNotifications(nids, uid);
+	const isUnread = set.endsWith(':notifications:unread');
+	const requestedCount = stop - start + 1;
+	const nids = await db.getSortedSetRevRange(set, start, isUnread ? stop + 1 : stop);
+	return await UserNotifications.getNotifications(nids.slice(0, requestedCount), uid, {
+		relatedSet: isUnread && nids.length > requestedCount ? set : null,
+	});
 }
 
 UserNotifications.ownsNids = async function (nids, uid) {
@@ -107,7 +112,7 @@ UserNotifications.ownsNids = async function (nids, uid) {
 	return nids.map((nid, index) => (isInRead[index] || isInUnread[index]));
 };
 
-UserNotifications.getNotifications = async function (nids, uid) {
+UserNotifications.getNotifications = async function (nids, uid, options = {}) {
 	if (!Array.isArray(nids) || !nids.length) {
 		return [];
 	}
@@ -133,7 +138,25 @@ UserNotifications.getNotifications = async function (nids, uid) {
 	});
 
 	await deleteUserNids(deletedNids, uid);
+	let oldestRelated = [];
+	if (options.relatedSet) {
+		const mergeIds = _.uniq(notificationData.map(n => n && n.mergeId)).filter(
+			mergeId => String(mergeId || '').startsWith('notifications:user-posted-to|')
+		);
+		oldestRelated = await notifications.findOldestRelated(mergeIds, options.relatedSet);
+	}
 	notificationData = await notifications.merge(notificationData);
+	if (oldestRelated.length) {
+		const oldestByMergeId = new Map(oldestRelated.map(n => [String(n.mergeId), n]));
+		notificationData.forEach((notification) => {
+			const oldest = notification && !notification.read && oldestByMergeId.get(String(notification.mergeId));
+			if (oldest && oldest.path) {
+				notification.path = oldest.path.startsWith('http') ?
+					oldest.path : `${nconf.get('relative_path')}${oldest.path}`;
+				notification.pid = oldest.pid;
+			}
+		});
+	}
 	await Promise.all(notificationData.map(async (n) => {
 		if (n?.bodyShort) {
 			n.bodyShort = posts.sanitize(await tx.translate(n.bodyShort, userSettings.userLang));

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -207,6 +207,86 @@ describe('Notifications', () => {
 		assert.equal(`${nconf.get('relative_path')}/post/${pid}`, notifications.unread[0].path, 'the notification should link to the first unread post');
 	});
 
+	it('should link to the first unread post when a merged notification exceeds the dropdown limit', async () => {
+		const watcherUid = await user.create({ username: 'watcher-over-limit' });
+		const { cid } = await categories.create({
+			name: 'Notification limit test category',
+			description: 'Test category created by testing script',
+		});
+		const { topicData } = await topics.post({
+			uid: watcherUid,
+			cid: cid,
+			title: 'Notification limit test topic',
+			content: 'The topic content.',
+		});
+		const { tid } = topicData;
+		await topics.unfollow(tid, watcherUid);
+
+		const replies = [];
+		for (let index = 0; index < 52; index += 1) {
+			// eslint-disable-next-line no-await-in-loop
+			replies.push(await topics.reply({
+				uid: uid,
+				content: `Reply ${index + 1}.`,
+				tid: tid,
+			}));
+		}
+
+		const timestamp = Date.now();
+		const unrelated = await notifications.create({
+			type: 'new-reply',
+			bodyShort: 'Unrelated notification',
+			nid: 'notification-limit:unrelated',
+			mergeId: 'notifications:user-posted-to|unrelated',
+			path: '/post/unrelated',
+			pid: 'unrelated',
+			tid: 'unrelated',
+			from: uid,
+		});
+		await db.sortedSetAdd(`uid:${watcherUid}:notifications:unread`, timestamp - 1, unrelated.nid);
+		const createdNotifications = await Promise.all(replies.map(async ({ pid }, index) => {
+			const notification = await notifications.create({
+				type: 'new-reply',
+				bodyShort: tx.compile('notifications:user-posted-to', 'poster', topicData.title),
+				nid: `notification-limit:tid:${tid}:pid:${pid}`,
+				mergeId: `notifications:user-posted-to|${tid}`,
+				path: `/post/${pid}`,
+				pid: pid,
+				tid: tid,
+				from: uid,
+				topicTitle: topicData.title,
+			});
+			await db.sortedSetAdd(`uid:${watcherUid}:notifications:unread`, timestamp + index, notification.nid);
+			return notification;
+		}));
+
+		const result = await user.notifications.get(watcherUid);
+		assert.equal(result.unread.length, 1, 'there should be 1 merged unread notification');
+		assert.equal(
+			result.unread[0].path,
+			`${nconf.get('relative_path')}/post/${replies[0].pid}`,
+			'the merged notification should link to the first unread post even when it is outside the loaded batch'
+		);
+		assert.strictEqual(result.unread[0].pid, replies[0].pid, 'the first unread pid should remain a number');
+
+		await Promise.all([
+			db.sortedSetRemove(`uid:${watcherUid}:notifications:unread`, createdNotifications[0].nid),
+			db.sortedSetAdd(`uid:${watcherUid}:notifications:read`, timestamp, createdNotifications[0].nid),
+		]);
+		const afterReadingOldest = await user.notifications.get(watcherUid);
+		assert.equal(afterReadingOldest.unread.length, 1, 'there should still be 1 merged unread notification');
+		assert.equal(
+			afterReadingOldest.unread[0].path,
+			`${nconf.get('relative_path')}/post/${replies[1].pid}`,
+			'the merged notification should advance to the next oldest unread post'
+		);
+		assert.strictEqual(
+			afterReadingOldest.unread[0].pid,
+			replies[1].pid,
+			'the next unread pid should remain a number'
+		);
+	});
+
 	it('should get notification by nid', async () => {
 		const [notifObj] = await socketNotifications.get({ uid: uid }, { nids: [notification.nid] });
 		assert.equal(notifObj.bodyShort, 'bodyShort');


### PR DESCRIPTION
## Summary

- detect a truncated unread-notification batch with one lookahead item
- resolve the oldest actual unread topic-reply notification before merging the visible batch
- preserve the existing 50-item response and fast path when the batch is not truncated
- keep the corrected `pid` numeric across database adapters

## Implementation note

The fallback is limited to a truncated unread batch and to `notifications:user-posted-to` merge IDs. It reads the user's unread notification set to find the exact oldest matching record. This avoids relying on topic bookmarks, which may be absent, stale, or configured with a different unread threshold. A persistent per-user merge-ID index could make this lookup bounded, but would add write-path and migration complexity.

## Tests

- `npx eslint src/notifications.js src/user/notifications.js test/notifications.js`
- `npx mocha test/notifications.js --timeout 20000` (37 passing)
- regression with 52 related unread notifications plus an older unrelated merge ID
- regression after moving the oldest related notification to the read set

Fixes #8186
