### PR TITLE
fix: do not federate crossposts to non-federated categories

### DIFF
--- a/src/activitypub/out.js
+++ b/src/activitypub/out.js
@@ -334,8 +334,11 @@ Out.announce.topic = enabledCheck(async (tid, uid, overrideCid) => {
 		return;
 	}
 
-	const allowed = await privileges.posts.can('topics:read', pid, activitypub._constants.uid);
-	if (!allowed) {
+	const [sourceAllowed, targetAllowed] = await Promise.all([
+		privileges.posts.can('topics:read', pid, activitypub._constants.uid),
+		overrideCid ? privileges.categories.can('topics:read', overrideCid, activitypub._constants.uid) : true,
+	]);
+	if (!sourceAllowed || !targetAllowed) {
 		activitypub.helpers.log(`[activitypub/api] Not federating announce of pid ${pid} to the fediverse due to privileges.`);
 		return;
 	}

--- a/src/controllers/write/topics.js
+++ b/src/controllers/write/topics.js
@@ -229,7 +229,7 @@ Topics.getCrossposts = async (req, res) => {
 Topics.crosspost = async (req, res) => {
 	const { cid } = req.body;
 	const crossposts = await topics.crossposts.add(req.params.tid, cid, req.uid);
-	await activitypub.out.announce.topic(req.params.tid, req.uid);
+	await activitypub.out.announce.topic(req.params.tid, req.uid, cid);
 
 	helpers.formatApiResponse(200, res, { crossposts });
 };

--- a/test/topics/crossposts.js
+++ b/test/topics/crossposts.js
@@ -635,6 +635,24 @@ describe('Crossposting (& related logic)', () => {
 				assert(actual.payload.cc.includes(authorUrl));
 				assert(actual.targets.includes(authorUrl));
 			});
+
+			it('should not send an Announce when crossposted to a non-federated category', async () => {
+				const username = utils.generateUUID().slice(0, 8);
+				const crossposter = await user.create({ username, password: '123456' });
+				const login = await helpers.loginUser(username, '123456');
+				activitypub._sent.clear();
+
+				const crosspostCid = (await categories.create({ name: utils.generateUUID().slice(0, 8) })).cid;
+				await privileges.categories.rescind(['groups:topics:read'], crosspostCid, 'fediverse');
+				const result = await helpers.request('post', `/api/v3/topics/${tid}/crossposts`, {
+					jar: login.jar,
+					csrf_token: login.csrf_token,
+					body: { cid: crosspostCid },
+				});
+
+				assert.strictEqual(result.response.statusCode, 200);
+				assert.strictEqual(activitypub._sent.size, 0);
+			});
 		});
 
 		describe('world canonical category (cid -1)', () => {


### PR DESCRIPTION
## Problem

The crosspost write controller receives the destination `cid`, but dropped it when calling `activitypub.out.announce.topic()`. The outbound Announce path therefore checked only whether the source post was readable by the fediverse pseudo-user and could send even when the destination category did not grant `topics:read` to `fediverse`.

The queued crosspost path already supplied the destination as `overrideCid`, but the shared outbound path did not validate that category either.

## Change

- pass the validated destination `cid` from the synchronous crosspost controller
- require `topics:read` for an explicit destination category before sending the Announce
- retain the existing source-post check and leave ordinary Announces without an override unchanged

This addresses the first checklist item in #13931 without changing the remaining delete, purge, or topic-event behavior.

## Tests

Added an API integration regression that crossposts successfully into a local category after `groups:topics:read` is removed from `fediverse` and verifies that no outbound Announce is sent. The existing positive case continues to verify that a federated destination sends one.

- `npx mocha test/topics/crossposts.js` (27 passing)
- `npx mocha test/activitypub/out.js` (25 passing)
- `npx eslint src/controllers/write/topics.js src/activitypub/out.js test/topics/crossposts.js`
