### PR TITLE
feat: expose category privilege copying via v3 API

### DIFF
--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -136,6 +136,8 @@ paths:
     $ref: 'write/categories/cid/watch/member.yaml'
   /categories/{cid}/privileges:
     $ref: 'write/categories/cid/privileges.yaml'
+  /categories/{cid}/privileges/copy:
+    $ref: 'write/categories/cid/privileges/copy.yaml'
   /categories/{cid}/privileges/{privilege}:
     $ref: 'write/categories/cid/privileges/privilege.yaml'
   /categories/{cid}/privileges/{privilege}/{member}:

--- a/public/openapi/write/categories/cid/privileges/copy.yaml
+++ b/public/openapi/write/categories/cid/privileges/copy.yaml
@@ -1,0 +1,41 @@
+post:
+  tags:
+    - categories
+  summary: copy category privileges from another category
+  description: Copies category privileges from a source category to the target category.
+  parameters:
+    - in: path
+      name: cid
+      schema:
+        type: integer
+        minimum: 1
+      required: true
+      description: The target category id
+      example: 1
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            fromCid:
+              type: integer
+              minimum: 1
+              description: The source category id
+              example: 1
+            group:
+              type: string
+              description: Copy only this group's privileges; omit to copy all users and groups
+              example: registered-users
+            filter:
+              type: string
+              description: Copy only privileges in this type, such as `viewing`, `posting`, or `moderation`; omit to copy every type
+              example: viewing
+          required:
+            - fromCid
+  responses:
+    '200':
+      description: Privileges successfully copied
+      content:
+        $ref: ../privileges.yaml#/get/responses/200/content

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -215,9 +215,8 @@ categoriesAPI.copyPrivileges = async (caller, data) => {
 
 	const group = data.group || '';
 	const filter = data.filter || '';
-	const [fromExists, toExists, groupExists] = await Promise.all([
-		categories.exists(data.fromCid),
-		categories.exists(data.toCid),
+	const [[fromExists, toExists], groupExists] = await Promise.all([
+		categories.exists([data.fromCid, data.toCid]),
 		group ? groups.exists(group) : true,
 	]);
 	if (!fromExists || !toExists) {

--- a/src/api/categories.js
+++ b/src/api/categories.js
@@ -8,6 +8,7 @@ const user = require('../user');
 const groups = require('../groups');
 const privileges = require('../privileges');
 const activitypub = require('../activitypub');
+const utils = require('../utils');
 
 const categoriesAPI = module.exports;
 
@@ -197,6 +198,39 @@ categoriesAPI.getPrivileges = async (caller, { cid }) => {
 	}
 
 	return responsePayload;
+};
+
+categoriesAPI.copyPrivileges = async (caller, data) => {
+	await hasAdminPrivilege(caller.uid, 'privileges');
+
+	if (!data || !utils.isNumber(data.fromCid) || !utils.isNumber(data.toCid)) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	if (data.group !== undefined && typeof data.group !== 'string') {
+		throw new Error('[[error:invalid-data]]');
+	}
+	if (data.filter !== undefined && typeof data.filter !== 'string') {
+		throw new Error('[[error:invalid-data]]');
+	}
+
+	const group = data.group || '';
+	const filter = data.filter || '';
+	const [fromExists, toExists, groupExists] = await Promise.all([
+		categories.exists(data.fromCid),
+		categories.exists(data.toCid),
+		group ? groups.exists(group) : true,
+	]);
+	if (!fromExists || !toExists) {
+		throw new Error('[[error:no-category]]');
+	}
+	if (!groupExists) {
+		throw new Error('[[error:no-group]]');
+	}
+	if (filter && !privileges.categories.getPrivilegesByFilter(filter).length) {
+		throw new Error('[[error:invalid-data]]');
+	}
+
+	await categories.copyPrivilegesFrom(data.fromCid, data.toCid, group, filter);
 };
 
 categoriesAPI.setPrivilege = async (caller, data) => {

--- a/src/controllers/write/categories.js
+++ b/src/controllers/write/categories.js
@@ -81,6 +81,18 @@ Categories.getPrivileges = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.categories.getPrivileges(req, { cid: req.params.cid }));
 };
 
+Categories.copyPrivileges = async (req, res) => {
+	await api.categories.copyPrivileges(req, {
+		fromCid: req.body.fromCid,
+		toCid: req.params.cid,
+		group: req.body.group,
+		filter: req.body.filter,
+	});
+
+	const privilegeSet = await api.categories.getPrivileges(req, { cid: req.params.cid });
+	helpers.formatApiResponse(200, res, privilegeSet);
+};
+
 Categories.setPrivilege = async (req, res) => {
 	const { cid, privilege } = req.params;
 	const member = req.params.member || req.body.member;

--- a/src/routes/write/categories.js
+++ b/src/routes/write/categories.js
@@ -26,6 +26,7 @@ module.exports = function () {
 	setupApiRoute(router, 'delete', '/:cid/watch/:member', [...middlewares, middleware.assert.category], controllers.write.categories.setWatchState);
 
 	setupApiRoute(router, 'get', '/:cid/privileges', [...middlewares], controllers.write.categories.getPrivileges);
+	setupApiRoute(router, 'post', '/:cid/privileges/copy', [...middlewares, middleware.checkRequired.bind(null, ['fromCid'])], controllers.write.categories.copyPrivileges);
 	setupApiRoute(router, 'put', '/:cid/privileges/:privilege', [...middlewares, middleware.checkRequired.bind(null, ['member'])], controllers.write.categories.setPrivilege);
 	setupApiRoute(router, 'delete', '/:cid/privileges/:privilege', [...middlewares], controllers.write.categories.setPrivilege);
 	setupApiRoute(router, 'delete', '/:cid/privileges/:privilege/:member', [...middlewares], controllers.write.categories.setPrivilege);

--- a/test/categories.js
+++ b/test/categories.js
@@ -11,6 +11,8 @@ const Topics = require('../src/topics');
 const User = require('../src/user');
 const groups = require('../src/groups');
 const privileges = require('../src/privileges');
+const utils = require('../src/utils');
+const helpers = require('./helpers');
 
 describe('Categories', () => {
 	let categoryObj;
@@ -582,6 +584,120 @@ describe('Categories', () => {
 			await socketCategories.copyPrivilegesFrom({ uid: adminUid }, { fromCid: parentCid, toCid: child1.cid, group: 'registered-users' });
 			const canDelete = await privileges.categories.can('topics:delete', child1.cid, 0);
 			assert(!canDelete);
+		});
+
+		describe('copy privileges via API', () => {
+			let privilegeUid;
+			let unprivilegedUid;
+			let privilegeJar;
+			let unprivilegedJar;
+			let groupName;
+
+			before(async () => {
+				const privilegeUsername = utils.generateUUID().slice(0, 8);
+				const unprivilegedUsername = utils.generateUUID().slice(0, 8);
+				[privilegeUid, unprivilegedUid] = await Promise.all([
+					User.create({ username: privilegeUsername, password: '123456' }),
+					User.create({ username: unprivilegedUsername, password: '123456' }),
+				]);
+				await privileges.admin.give(['admin:privileges'], privilegeUid);
+
+				[{ jar: privilegeJar }, { jar: unprivilegedJar }] = await Promise.all([
+					helpers.loginUser(privilegeUsername, '123456'),
+					helpers.loginUser(unprivilegedUsername, '123456'),
+				]);
+
+				groupName = utils.generateUUID().slice(0, 8);
+				await groups.create({ name: groupName });
+			});
+
+			after(async () => {
+				await Promise.all([
+					User.deleteAccount(privilegeUid),
+					User.deleteAccount(unprivilegedUid),
+					groups.destroy(groupName),
+				]);
+			});
+
+			async function createCategoryPair() {
+				const [from, to] = await Promise.all([
+					Categories.create({ name: utils.generateUUID().slice(0, 8) }),
+					Categories.create({ name: utils.generateUUID().slice(0, 8) }),
+				]);
+				return { fromCid: from.cid, toCid: to.cid };
+			}
+
+			it('should copy privileges through the v3 route with only admin:privileges', async () => {
+				const { fromCid, toCid } = await createCategoryPair();
+				await privileges.categories.give(['groups:moderate'], fromCid, groupName);
+
+				const { response, body } = await helpers.request('post', `/api/v3/categories/${toCid}/privileges/copy`, {
+					jar: privilegeJar,
+					body: { fromCid },
+				});
+
+				assert.strictEqual(response.statusCode, 200);
+				assert(await groups.isMember(groupName, `cid:${toCid}:privileges:groups:moderate`));
+				const group = body.response.groups.find(group => group.name === groupName);
+				assert(group);
+				assert.strictEqual(group.privileges['groups:moderate'], true);
+			});
+
+			it('should copy only the requested group and privilege type', async () => {
+				const { fromCid, toCid } = await createCategoryPair();
+				await privileges.categories.give(['groups:moderate', 'groups:find'], fromCid, groupName);
+
+				const { response } = await helpers.request('post', `/api/v3/categories/${toCid}/privileges/copy`, {
+					jar: privilegeJar,
+					body: { fromCid, group: groupName, filter: 'moderation' },
+				});
+
+				assert.strictEqual(response.statusCode, 200);
+				assert(await groups.isMember(groupName, `cid:${toCid}:privileges:groups:moderate`));
+				assert.strictEqual(await groups.isMember(groupName, `cid:${toCid}:privileges:groups:find`), false);
+			});
+
+			it('should reject callers without admin:privileges', async () => {
+				const { fromCid, toCid } = await createCategoryPair();
+				const { response } = await helpers.request('post', `/api/v3/categories/${toCid}/privileges/copy`, {
+					jar: unprivilegedJar,
+					body: { fromCid },
+				});
+
+				assert.strictEqual(response.statusCode, 403);
+				await assert.rejects(
+					apiCategories.copyPrivileges({ uid: unprivilegedUid }, { fromCid, toCid }),
+					{ message: '[[error:no-privileges]]' },
+				);
+			});
+
+			it('should validate source and target categories', async () => {
+				const { fromCid, toCid } = await createCategoryPair();
+				await assert.rejects(
+					apiCategories.copyPrivileges({ uid: privilegeUid }, { fromCid: 9999999, toCid }),
+					{ message: '[[error:no-category]]' },
+				);
+				await assert.rejects(
+					apiCategories.copyPrivileges({ uid: privilegeUid }, { fromCid, toCid: 9999999 }),
+					{ message: '[[error:no-category]]' },
+				);
+				await assert.rejects(
+					apiCategories.copyPrivileges({ uid: privilegeUid }, { fromCid: 'all', toCid }),
+					{ message: '[[error:invalid-data]]' },
+				);
+			});
+
+			it('should validate the optional group and filter', async () => {
+				const { fromCid, toCid } = await createCategoryPair();
+				await assert.rejects(
+					apiCategories.copyPrivileges({ uid: privilegeUid }, { fromCid, toCid, group: 'does-not-exist' }),
+					{ message: '[[error:no-group]]' },
+				);
+				await assert.rejects(
+					apiCategories.copyPrivileges({ uid: privilegeUid }, { fromCid, toCid, filter: 'does-not-exist' }),
+					{ message: '[[error:invalid-data]]' },
+				);
+			});
 		});
 	});
 


### PR DESCRIPTION
## Summary

- add `POST /api/v3/categories/:cid/privileges/copy`
- require `fromCid` and support optional `group` and `filter` selectors
- reuse `Categories.copyPrivilegesFrom` and preserve its plugin hook
- require `admin:privileges` and validate source, target, group, and filter inputs
- return the refreshed target privilege set, matching adjacent privilege mutations
- document the operation in the Write API schema

## Proposed contract

This is a draft so the public API shape can be confirmed before merge. The current proposal uses an action-style `POST` route and returns HTTP 200 with the refreshed target state. If `PUT` or a 204 response is preferred, I can adjust the implementation and schema without changing the underlying copy behavior.

`filter` deliberately remains a string instead of a fixed OpenAPI enum because category privilege types can be added by plugins.

## Tests

- focused category API tests: 6 passing
- complete category suite: 67 passing
- filtered OpenAPI schema harness: 7 passing
- focused ESLint and `git diff --check`: passing

Addresses #14467
