### PR TITLE
feat: add full name to ACP user search

### DIFF
--- a/public/language/en-GB/admin/manage/users.json
+++ b/public/language/en-GB/admin/manage/users.json
@@ -48,6 +48,7 @@
 	"search.uid-placeholder": "Enter a user ID to search",
 	"search.username": "By User Name",
 	"search.username-placeholder": "Enter a username to search",
+	"search.fullname": "By Full Name",
 	"search.email": "By Email",
 	"search.email-placeholder": "Enter a email to search",
 	"search.ip": "By IP Address",

--- a/src/views/admin/manage/users.tpl
+++ b/src/views/admin/manage/users.tpl
@@ -13,6 +13,7 @@
 				</div>
 				<select id="user-search-by" class="form-select form-select-sm w-auto">
 					<option value="username" {{{if searchBy_username}}}selected{{{end}}}>{{tx("admin/manage/users:search.username")}}</option>
+					<option value="fullname" {{{if searchBy_fullname}}}selected{{{end}}}>{{tx("admin/manage/users:search.fullname")}}</option>
 					<option value="email" {{{if searchBy_email}}}selected{{{end}}}>{{tx("admin/manage/users:search.email")}}</option>
 					<option value="uid" {{{if searchBy_uid}}}selected{{{end}}}>{{tx("admin/manage/users:search.uid")}}</option>
 					<option value="ip" {{{if searchBy_ip}}}selected{{{end}}}>{{tx("admin/manage/users:search.ip")}}</option>

--- a/test/controllers-admin.js
+++ b/test/controllers-admin.js
@@ -234,6 +234,44 @@ describe('Admin Controllers', () => {
 		assert.strictEqual(body.users[0].username, 'admin');
 	});
 
+	it('should expose full name search in the ACP user selector', async () => {
+		await groups.join('administrators', adminUid);
+		({ jar } = await helpers.loginUser('admin', 'barbar'));
+		const { response, body } = await request.get(`${nconf.get('url')}/admin/manage/users`, { jar: jar });
+		assert.strictEqual(response.statusCode, 200);
+		assert(body.includes('<option value="fullname"'));
+		assert(body.includes('By Full Name'));
+	});
+
+	it('should search users by full name in the ACP', async () => {
+		await groups.join('administrators', adminUid);
+		({ jar } = await helpers.loginUser('admin', 'barbar'));
+		const uids = await Promise.all([
+			user.create({ username: 'fullnamesearch-acp-1', fullname: 'Profile Scanner Match' }),
+			user.create({ username: 'fullnamesearch-acp-2', fullname: 'Profile Scanner Match' }),
+		]);
+		const { response, body } = await request.get(
+			`${nconf.get('url')}/api/admin/manage/users?query=pRoFiLe%20ScAnNeR&searchBy=fullname`,
+			{ jar: jar, json: true }
+		);
+		assert.strictEqual(response.statusCode, 200);
+		assert.deepStrictEqual(body.users.map(user => user.uid).sort(), uids.sort());
+		assert.strictEqual(body.matchCount, 2);
+		assert.strictEqual(body.page, 1);
+		assert.strictEqual(body.pageCount, 1);
+		assert.strictEqual(body.resultsPerPage, 50);
+		assert.strictEqual(body.searchBy_fullname, true);
+	});
+
+	it('should keep ACP full name search restricted to administrators', async () => {
+		const { jar: regularJar } = await helpers.loginUser('regular', 'regularpwd');
+		const { response } = await request.get(
+			`${nconf.get('url')}/api/admin/manage/users?query=profile&searchBy=fullname`,
+			{ jar: regularJar, json: true }
+		);
+		assert.strictEqual(response.statusCode, 403);
+	});
+
 	it('should return empty results if query is too short', async () => {
 		const { response, body } = await request.get(`${nconf.get('url')}/api/admin/manage/users?query=a`, { jar: jar });
 		assert.strictEqual(response.statusCode, 200);


### PR DESCRIPTION
## Summary

- add **Full Name** to the search-field selector in ACP > Manage > Users
- reuse the existing indexed `fullname:sorted` search path
- cover the rendered selector, case-insensitive matches and pagination metadata, and administrator-only access

This draft deliberately implements only the already-indexed full-name slice. It does not scan website, about, signature, or custom fields, and it changes no API, response field, index, or privilege. Broader profile-field search needs a separate indexing and privacy contract.

## Testing

- `node ./nodebb build`
- focused ACP full-name tests: 3 passing
- complete user-search suite: 7 passing
- focused ESLint and `git diff --check`: passing

Related to #12396
