### PR TITLE
feat: allow password reset by username

### DIFF
--- a/public/language/en-GB/reset_password.json
+++ b/public/language/en-GB/reset_password.json
@@ -12,6 +12,10 @@
 	"enter-email-address": "Enter Email Address",
 	"password-reset-sent": "If the specified address corresponds to an existing user account, a password reset email was sent. Please note that only one email will be sent per minute.",
 	"invalid-email": "Invalid Email / Email does not exist!",
+	"enter-username-or-email": "Please enter your <strong>username or email address</strong> and we will send reset instructions to the email address on the account.",
+	"enter-username-or-email-address": "Enter Username or Email Address",
+	"password-reset-identifier-sent": "If the specified username or email address corresponds to an existing user account, a password reset email was sent. Please note that only one email will be sent per minute.",
+	"invalid-username-or-email": "Enter a username or email address.",
 	"password-too-short": "The password entered is too short, please pick a different password.",
 	"passwords-do-not-match": "The two passwords you've entered do not match.",
 	"password-expired": "Your password has expired, please choose a new password"

--- a/public/src/client/reset.js
+++ b/public/src/client/reset.js
@@ -10,8 +10,9 @@ define('forum/reset', ['alerts'], function (alerts) {
 		const successEl = $('#success');
 
 		$('#reset').on('click', function () {
-			if (inputEl.val() && inputEl.val().indexOf('@') !== -1) {
-				socket.emit('user.reset.send', inputEl.val(), function (err) {
+			const identifier = inputEl.val().trim();
+			if (identifier) {
+				socket.emit('user.reset.send', identifier, function (err) {
 					if (err) {
 						return alerts.error(err);
 					}

--- a/src/socket.io/user.js
+++ b/src/socket.io/user.js
@@ -26,25 +26,27 @@ require('./user/registration')(SocketUser);
 
 SocketUser.reset = {};
 
-SocketUser.reset.send = async function (socket, email) {
-	if (!email) {
+SocketUser.reset.send = async function (socket, identifier) {
+	if (typeof identifier !== 'string' || !identifier.trim()) {
 		throw new Error('[[error:invalid-data]]');
 	}
+	identifier = identifier.trim();
 
 	if (meta.config['password:disableEdit']) {
 		throw new Error('[[error:no-privileges]]');
 	}
 	async function logEvent(text) {
+		const identifierField = utils.isEmailValid(identifier) ? 'email' : 'username';
 		await events.log({
 			type: 'password-reset',
 			text: text,
 			ip: socket.ip,
 			uid: socket.uid,
-			email: email,
+			[identifierField]: identifier,
 		});
 	}
 	try {
-		await user.reset.send(email);
+		await user.reset.send(identifier);
 		await logEvent('[[success:success]]');
 		await sleep(2500 + (utils.secureRandom(0, 500) - 250));
 	} catch (err) {

--- a/src/user/reset.js
+++ b/src/user/reset.js
@@ -42,8 +42,12 @@ UserReset.generate = async function (uid) {
 	return code;
 };
 
-UserReset.send = async function (email) {
-	const uid = await user.getUidByEmail(email);
+UserReset.send = async function (identifier) {
+	if (typeof identifier !== 'string' || !identifier.trim()) {
+		throw new Error('[[error:invalid-email]]');
+	}
+	identifier = identifier.trim();
+	const uid = await getUidByIdentifier(identifier);
 	if (!uid) {
 		throw new Error('[[error:invalid-email]]');
 	}
@@ -64,6 +68,20 @@ UserReset.send = async function (email) {
 		await db.deleteObjectField('locks', `reset${uid}`);
 	}
 };
+
+async function getUidByIdentifier(identifier) {
+	if (utils.isEmailValid(identifier)) {
+		return await user.getUidByEmail(identifier);
+	}
+
+	const uid = await user.getUidByUsername(identifier);
+	if (!uid) {
+		return 0;
+	}
+	const email = await user.getUserField(uid, 'email');
+	const emailUid = email && await user.getUidByEmail(email);
+	return parseInt(emailUid, 10) === parseInt(uid, 10) ? uid : 0;
+}
 
 async function lockReset(uid) {
 	const value = `reset${uid}`;

--- a/src/views/emails/reset.tpl
+++ b/src/views/emails/reset.tpl
@@ -9,7 +9,7 @@
 			<table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
 				<tr>
 					<td style="padding: 40px 40px 6px 40px; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; font-size: 15px; line-height: 20px; color: #555555;">
-						<h1 style="margin: 0; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; font-size: 24px; line-height: 27px; color: #333333; font-weight: normal;">{{tx("email:greeting-no-name")}}</h1>
+						<h1 style="margin: 0; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; font-size: 24px; line-height: 27px; color: #333333; font-weight: normal;">{{tx("email:greeting-with-name", txEscape(username))}}</h1>
 					</td>
 				</tr>
 				<tr>

--- a/src/views/reset.tpl
+++ b/src/views/reset.tpl
@@ -1,21 +1,21 @@
 <div class="flex-fill row justify-content-center">
 	<div class="col-12 col-md-5 col-lg-4 px-md-0">
 		<div class="alert alert-info">
-			{{tx("reset_password:enter-email")}}
+			{{tx("reset_password:enter-username-or-email")}}
 		</div>
 
 		<div class="card card-body bg-light">
 			<div class="alert alert-success alert-dismissible hide" id="success">
 				<button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-				{{tx("reset_password:password-reset-sent")}}
+				{{tx("reset_password:password-reset-identifier-sent")}}
 			</div>
 			<div class="alert alert-danger alert-dismissible hide" id="error">
 				<button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-				{{tx("reset_password:invalid-email")}}
+				{{tx("reset_password:invalid-username-or-email")}}
 			</div>
 			<form onsubmit="return false;">
 				<div class="mb-3">
-					<input type="email" class="form-control" id="email" placeholder="{{tx("reset_password:enter-email-address")}}" autocomplete="off">
+					<input type="text" class="form-control" id="email" placeholder="{{tx("reset_password:enter-username-or-email-address")}}" autocomplete="username">
 				</div>
 				<div class="d-grid">
 					<button class="btn btn-primary" id="reset" type="submit">{{tx("reset_password:reset-password")}}</button>

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -19,6 +19,7 @@ const topics = require('../src/topics');
 const helpers = require('./helpers');
 const meta = require('../src/meta');
 const events = require('../src/events');
+const utils = require('../src/utils');
 
 const socketAdmin = require('../src/socket.io/admin');
 const apiAdmin = require('../src/api/admin');
@@ -749,6 +750,28 @@ describe('socket.io', () => {
 			const event = eventsData[0];
 			assert.strictEqual(event.type, 'password-reset');
 			assert.strictEqual(event.text, '[[success:success]]');
+			assert.strictEqual(event.email, 'regular@test.com');
+			assert.strictEqual(Object.hasOwn(event, 'username'), false);
+		});
+
+		it('should accept an exact username and classify it correctly in the event log', async () => {
+			const username = `reset-${utils.generateUUID().slice(0, 8)}`;
+			const uid = await user.create({
+				username,
+				email: `${username}@nodebb.org`,
+			}, { emailVerification: 'verify' });
+			await socketUser.reset.send({ uid: 0 }, username);
+			const [eventsData, codes] = await Promise.all([
+				events.getEvents({ filter: '', start: 0, stop: 0 }),
+				db.getObject('reset:uid'),
+			]);
+			const event = eventsData[0];
+			assert.strictEqual(event.type, 'password-reset');
+			assert.strictEqual(event.text, '[[success:success]]');
+			assert.strictEqual(event.username, username);
+			assert.strictEqual(Object.hasOwn(event, 'email'), false);
+			assert(Object.values(codes).some(codeUid => parseInt(codeUid, 10) === uid));
+			await user.reset.cleanByUid(uid);
 		});
 
 		it('should not generate code if rate limited', async () => {

--- a/test/user/reset.js
+++ b/test/user/reset.js
@@ -117,12 +117,44 @@ describe('Password reset (library methods)', () => {
 describe('locks', () => {
 	let uid;
 	let email;
+	let username;
 	beforeEach(async () => {
-		const username = utils.generateUUID().slice(0, 10);
+		username = utils.generateUUID().slice(0, 10);
 		email = `${username}@nodebb.org`;
 		uid = await user.create({ username, email }, {
 			emailVerification: 'verify',
 		});
+	});
+
+	it('should send a reset email for an exact username', async () => {
+		const code = await user.reset.send(username);
+		assert.strictEqual(parseInt(await db.getObjectField('reset:uid', code), 10), uid);
+	});
+
+	it('should share the per-user rate limit between username and email requests', async () => {
+		await user.reset.send(username);
+		await assert.rejects(user.reset.send(email), {
+			message: '[[error:reset-rate-limited]]',
+		});
+	});
+
+	it('should not generate a reset code for an unknown username', async () => {
+		const count = await db.sortedSetCard('reset:issueDate');
+		await assert.rejects(user.reset.send(utils.generateUUID().slice(0, 10)), {
+			message: '[[error:invalid-email]]',
+		});
+		assert.strictEqual(await db.sortedSetCard('reset:issueDate'), count);
+	});
+
+	it('should not generate a reset code when the username has no confirmed email mapping', async () => {
+		const username = utils.generateUUID().slice(0, 10);
+		const uid = await user.create({ username });
+		await user.setUserField(uid, 'email', `${username}@unconfirmed.test`);
+		const count = await db.sortedSetCard('reset:issueDate');
+		await assert.rejects(user.reset.send(username), {
+			message: '[[error:invalid-email]]',
+		});
+		assert.strictEqual(await db.sortedSetCard('reset:issueDate'), count);
 	});
 
 	it('should disallow reset request if one was made within the minute', async () => {


### PR DESCRIPTION
## Summary

- allow the existing password-reset form to accept an email address or an exact username
- preserve the existing confirmed-email eligibility check, generic public response, response delay, and per-UID throttle
- include the account username in the reset email and classify username-based reset events correctly

## Behaviour and privacy

This is a proposal for the combined `/reset` flow discussed in #7344. A username is eligible only when the email stored on that user maps back to the same UID through the existing `email:uid` index. Unknown usernames, accounts without that mapping, and rate-limited requests all retain the same public success response and do not expose the stored email address.

Username and email requests converge on the same UID before locking, so switching identifiers cannot bypass the existing per-user email interval.

The open design question is whether this combined flow is preferable to a separate “Retrieve your username / email” page and email template.

## Tests

- `npx mocha test/user/reset.js --timeout 10000` (18 passing)
- `npx mocha test/socket.io.js --timeout 10000` (69 passing)
- `node nodebb build`
- focused ESLint for changed JavaScript and tests
- `git diff --check`

Refs #7344
