### PR TITLE
fix: retarget animated navigator scrolls after layout shifts

### DIFF
--- a/public/src/modules/navigator.js
+++ b/public/src/modules/navigator.js
@@ -712,6 +712,13 @@ define('navigator', [
 		let done = false;
 
 		function animateScroll() {
+			function calculateScrollTop() {
+				if (postHeight < viewportHeight - navbarHeight - topicHeaderHeight) {
+					return scrollTo.offset().top - (viewportHeight / 2) + (postHeight / 2);
+				}
+				return scrollTo.offset().top - navbarHeight - topicHeaderHeight;
+			}
+
 			function reenableScroll() {
 				// Re-enable onScroll behaviour
 				setTimeout(() => { // fixes race condition from jQuery — onAnimateComplete called too quickly
@@ -738,12 +745,7 @@ define('navigator', [
 				}
 			}
 
-			let scrollTop;
-			if (postHeight < viewportHeight - navbarHeight - topicHeaderHeight) {
-				scrollTop = scrollTo.offset().top - (viewportHeight / 2) + (postHeight / 2);
-			} else {
-				scrollTop = scrollTo.offset().top - navbarHeight - topicHeaderHeight;
-			}
+			const scrollTop = calculateScrollTop();
 
 			if (duration === 0) {
 				$(window).scrollTop(scrollTop);
@@ -753,7 +755,22 @@ define('navigator', [
 			}
 			$('html, body').animate({
 				scrollTop: scrollTop + 'px',
-			}, duration, onAnimateComplete);
+			}, {
+				duration,
+				step(value, tween) {
+					const previousScrollTop = tween.nodebbScrollTop === undefined ? scrollTop : tween.nodebbScrollTop;
+					const nextScrollTop = calculateScrollTop();
+					const delta = nextScrollTop - previousScrollTop;
+					if (delta) {
+						// Keep the tween aligned if content above the target changes height.
+						tween.start += delta;
+						tween.end += delta;
+						tween.now += delta;
+						tween.nodebbScrollTop = nextScrollTop;
+					}
+				},
+				complete: onAnimateComplete,
+			});
 		}
 
 		function highlightPost() {

--- a/test/navigator.js
+++ b/test/navigator.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Client navigator', () => {
+	let navigator;
+	let animateOptions;
+	let targetTop;
+
+	before(() => {
+		const genericEl = {
+			find: () => genericEl,
+			on: () => genericEl,
+			off: () => genericEl,
+			outerHeight: () => 0,
+		};
+		const windowEl = {
+			height: () => 600,
+			on: () => windowEl,
+			off: () => windowEl,
+		};
+		const animatedEl = {
+			animate: (properties, options) => {
+				animateOptions = options;
+			},
+		};
+
+		const window = {};
+		const $ = (selector) => {
+			if (selector === window) {
+				return windowEl;
+			}
+			if (selector === 'html, body') {
+				return animatedEl;
+			}
+			return genericEl;
+		};
+		const define = (name, dependencies, factory) => {
+			navigator = factory(
+				{},
+				{ get: () => ({ outerHeight: () => 50 }) },
+				{ fire: async () => {} },
+				{},
+				{}
+			);
+		};
+
+		const navigatorPath = path.join(__dirname, '../public/src/modules/navigator.js');
+		vm.runInNewContext(fs.readFileSync(navigatorPath, 'utf8'), {
+			$,
+			define,
+			window,
+		}, {
+			filename: navigatorPath,
+		});
+	});
+
+	it('retargets an active scroll tween when content above the target changes height', async () => {
+		targetTop = 500;
+		const targetEl = {
+			length: 1,
+			outerHeight: () => 100,
+			offset: () => ({ top: targetTop }),
+		};
+
+		await navigator.scrollToElement(targetEl, false, 400);
+
+		assert.strictEqual(animateOptions.duration, 400);
+		const tween = { start: 0, end: 250, now: 125 };
+		animateOptions.step(125, tween);
+		assert.deepStrictEqual(tween, { start: 0, end: 250, now: 125 });
+
+		targetTop = 800;
+		animateOptions.step(125, tween);
+		assert.deepStrictEqual(tween, {
+			start: 300,
+			end: 550,
+			now: 425,
+			nodebbScrollTop: 550,
+		});
+
+		targetTop = 700;
+		tween.now = 487.5;
+		animateOptions.step(487.5, tween);
+		assert.deepStrictEqual(tween, {
+			start: 200,
+			end: 450,
+			now: 387.5,
+			nodebbScrollTop: 450,
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- recalculate the navigator destination while a jQuery scroll animation is active
- shift each scroll tween's start, end, and current position by the detected layout delta
- preserve the existing duration, easing, instant-scroll path, and centered/top-aligned placement
- add an isolated regression test for positive and negative target movement

## Scope

The exact in-topic Ctrl/Cmd+F arrow flow reported in #8654 was removed in `64192731a0`; current search-result navigation uses an instant jump. This draft addresses the same remaining race in general animated `navigator.scrollToElement` callers. It deliberately does not claim to restore or directly fix the removed search workflow.

## Reproduction and verification

A controlled Chrome 151 fixture loaded an unsized 720×900 image above the target halfway through a 400 ms animation. Current code finished with the target 781.5 px below its intended position. Retargeting the active tween finished at 267.5 px versus an intended approximately 269 px and remained stable. The same fixture confirmed that native scroll anchoring already handles images loading after the animation, and that native smooth `scrollIntoView` has the same during-animation race.

- `node node_modules/mocha/bin/mocha.js test/navigator.js --timeout 10000` (1 passing)
- ESLint for `public/src/modules/navigator.js` and `test/navigator.js`
- `git diff --check`

Refs #8654
