### PR TITLE
Split Domain support for remote users

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -208,6 +208,7 @@
     "tinyconBackground": "#ff0000",
     "activitypubEnabled": 1,
     "activitypubAllowLoopback": 0,
+    "activitypubAllowSplitDomain": 0,
     "activitypubParentTraversalDepth": 50,
     "activitypubPublicKeyFetchRateLimit": 256,
     "activitypubProbe": 1,

--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -208,7 +208,7 @@
     "tinyconBackground": "#ff0000",
     "activitypubEnabled": 1,
     "activitypubAllowLoopback": 0,
-    "activitypubAllowSplitDomain": 0,
+    "activitypubAllowSplitDomain": 1,
     "activitypubParentTraversalDepth": 50,
     "activitypubPublicKeyFetchRateLimit": 256,
     "activitypubProbe": 1,

--- a/public/language/en-GB/admin/settings/activitypub.json
+++ b/public/language/en-GB/admin/settings/activitypub.json
@@ -13,6 +13,8 @@
 	"publicKeyFetchRateLimit-help": "Maximum number of public key fetch requests allowed per minute per IP. (Default: 256)",
 	"allowLoopback": "Allow loopback processing",
 	"allowLoopback-help": "Useful for debugging purposes only. You should probably leave this disabled.",
+	"allowSplitDomain": "Allow split-domain federation",
+	"allowSplitDomain-help": "Enable to allow actors whose WebFinger handle domain differs from their ActivityPub document domain. This is useful for instances that separate identity (WebFinger) from content hosting (ActivityPub).",
 	"parentTraversalDepth": "Parent traversal depth",
 	"parentTraversalDepth-help": "Maximum number of times to traverse up the reply chain when building context. (Default: 50)",
 

--- a/src/activitypub/actors.js
+++ b/src/activitypub/actors.js
@@ -338,7 +338,6 @@ Actors.assertGroup = async (ids, options = {}) => {
 			const actor = (typeof id === 'object' && id.hasOwnProperty('id')) ? id : await activitypub.get('uid', 0, id, { cache: process.env.CI === 'true' });
 
 			// Verify actor.id hostname matches the queried URL's hostname (prevent spoofed id overwrite).
-			// This check runs unconditionally — before any WebFinger logic.
 			if (typeof id === 'string') {
 				const queriedHost = new URL(id).hostname;
 				const actorHost = new URL(actor.id).hostname;
@@ -347,14 +346,6 @@ Actors.assertGroup = async (ids, options = {}) => {
 					return null;
 				}
 			}
-
-			// Two-way WebFinger verification (includes backreference + optional split-domain forward check).
-			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor);
-			if (!verdict || !verdict.ok) {
-				activitypub.helpers.log(`[activitypub/actors] Webfinger verification failed (${verdict?.reason || 'unknown'}) for ${actor.id}`);
-				return null;
-			}
-			actor._canonicalHandle = verdict.canonicalHandle;
 
 			const typeOk = Array.isArray(actor.type) ?
 				actor.type.some(type => activitypub._constants.acceptableGroupTypes.has(type)) :

--- a/src/activitypub/actors.js
+++ b/src/activitypub/actors.js
@@ -347,6 +347,13 @@ Actors.assertGroup = async (ids, options = {}) => {
 				}
 			}
 
+			// Two-way WebFinger verification (backreference check for security).
+			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor);
+			if (!verdict || !verdict.ok) {
+				activitypub.helpers.log(`[activitypub/actors] Webfinger verification failed (${verdict?.reason || 'unknown'}) for ${actor.id}`);
+				return null;
+			}
+
 			const typeOk = Array.isArray(actor.type) ?
 				actor.type.some(type => activitypub._constants.acceptableGroupTypes.has(type)) :
 				activitypub._constants.acceptableGroupTypes.has(actor.type);

--- a/src/activitypub/actors.js
+++ b/src/activitypub/actors.js
@@ -59,7 +59,7 @@ Actors.qualify = async (ids, options = {}) => {
 	ids = ids.filter(id => !activitypub._constants.acceptablePublicAddresses.includes(id));
 
 	// Translate webfinger handles to uris
-	ids = (await Promise.all(ids.map(async (id) => {
+	const idsArr = (await Promise.all(ids.map(async (id) => {
 		const originalId = id;
 		if (activitypub.helpers.isWebfinger(id)) {
 			const host = id.replace(/^(acct:|@)/, '').split('@')[1];
@@ -67,7 +67,8 @@ Actors.qualify = async (ids, options = {}) => {
 				return 'loopback';
 			}
 
-			({ actorUri: id } = await activitypub.helpers.query(id));
+			const result = await activitypub.helpers.query(id);
+			({ actorUri: id } = result || { actorUri: null });
 		}
 		// ensure the final id is a valid URI
 		if (!id || !activitypub.helpers.isUri(id)) {
@@ -78,18 +79,18 @@ Actors.qualify = async (ids, options = {}) => {
 	})));
 
 	// Webfinger failures = assertion failure
-	if (!ids.length || !ids.every(Boolean)) {
+	if (!idsArr.length || !idsArr.every(Boolean)) {
 		return false;
 	}
 
 	// Filter out loopback uris — never persist local URIs as remote actors
-	ids = ids.filter(uri => uri !== 'loopback' && new URL(uri).host !== nconf.get('url_parsed').host);
+	const filtered = idsArr.filter(uri => uri !== 'loopback' && new URL(uri).host !== nconf.get('url_parsed').host);
 
 	// Separate those who need migration from user to category
 	const migrate = new Set();
 	if (options.qualifyGroup) {
-		const exists = await db.exists(ids.map(id => `userRemote:${id}`));
-		ids.forEach((id, idx) => {
+		const exists = await db.exists(filtered.map(id => `userRemote:${id}`));
+		filtered.forEach((id, idx) => {
 			if (exists[idx]) {
 				migrate.add(id);
 			}
@@ -99,14 +100,15 @@ Actors.qualify = async (ids, options = {}) => {
 	// Only assert those who haven't been seen recently (configurable), unless update flag passed in (force refresh)
 	if (!options.update) {
 		const upperBound = Date.now() - (1000 * 60 * 60 * 24 * meta.config.activitypubUserPruneDays);
-		const lastCrawled = await db.sortedSetScores('usersRemote:lastCrawled', ids.map(id => ((typeof id === 'object' && id.hasOwnProperty('id')) ? id.id : id)));
-		ids = ids.filter((id, idx) => {
+		const lastCrawled = await db.sortedSetScores('usersRemote:lastCrawled', filtered.map(id => ((typeof id === 'object' && id.hasOwnProperty('id')) ? id.id : id)));
+		const remaining = filtered.filter((id, idx) => {
 			const timestamp = lastCrawled[idx];
 			return migrate.has(id) || !timestamp || timestamp < upperBound;
 		});
+		return { ids: remaining };
 	}
 
-	return ids;
+	return { ids: filtered };
 };
 
 Actors.assert = async (ids, options = {}) => {
@@ -120,25 +122,28 @@ Actors.assert = async (ids, options = {}) => {
 	 *   - true: no new IDs processed; all passed-in IDs present.
 	 */
 
-	ids = await Actors.qualify(ids, options);
-	if (!ids || !ids.length) {
-		return ids;
+	const qualified = await Actors.qualify(ids, options);
+	if (!qualified || !qualified.ids || !qualified.ids.length) {
+		return qualified;
 	}
 
-	activitypub.helpers.log(`[activitypub/actors] Asserting ${ids.length} actor(s)`);
+	const { ids: idsArr } = qualified;
+
+	activitypub.helpers.log(`[activitypub/actors] Asserting ${idsArr.length} actor(s)`);
 
 	// NOTE: MAKE SURE EVERY DB ADDITION HAS A CORRESPONDING REMOVAL IN ACTORS.REMOVE!
 
 	const urlMap = new Map();
 	const followersUrlMap = new Map();
 	const pubKeysMap = new Map();
-	const categories = new Set();
-	let actors = await Promise.all(ids.map(async (id) => {
+	const actorCategories = new Set();
+	let actors = await Promise.all(idsArr.map(async (id) => {
 		try {
 			activitypub.helpers.log(`[activitypub/actors] Processing ${id}`);
 			const actor = (typeof id === 'object' && id.hasOwnProperty('id')) ? id : await activitypub.get('uid', 0, id, { cache: process.env.CI === 'true' });
 
-			// Verify actor.id hostname matches the queried URL's hostname (prevent spoofed id overwrite)
+			// Verify actor.id hostname matches the queried URL's hostname (prevent spoofed id overwrite).
+			// This check runs unconditionally — before any WebFinger logic.
 			if (typeof id === 'string') {
 				const queriedHost = new URL(id).hostname;
 				const actorHost = new URL(actor.id).hostname;
@@ -148,24 +153,24 @@ Actors.assert = async (ids, options = {}) => {
 				}
 			}
 
-			// webfinger backreference check
-			const { hostname: domain } = new URL(id);
-			const { actorUri: canonicalId } = await activitypub.helpers.query(`${actor.preferredUsername}@${domain}`);
-			if (id !== canonicalId) {
+			// Two-way WebFinger verification (includes backreference + optional split-domain forward check).
+			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor);
+			if (!verdict || !verdict.ok) {
+				activitypub.helpers.log(`[activitypub/actors] Webfinger verification failed (${verdict?.reason || 'unknown'}) for ${actor.id}`);
 				return null;
 			}
-
+			actor._canonicalHandle = verdict.canonicalHandle;
 
 			let typeOk = false;
 			if (Array.isArray(actor.type)) {
 				typeOk = actor.type.some(type => activitypub._constants.acceptableActorTypes.has(type));
 				if (!typeOk && actor.type.some(type => activitypub._constants.acceptableGroupTypes.has(type))) {
-					categories.add(actor.id);
+					actorCategories.add(actor.id);
 				}
 			} else {
 				typeOk = activitypub._constants.acceptableActorTypes.has(actor.type);
 				if (!typeOk && activitypub._constants.acceptableGroupTypes.has(actor.type)) {
-					categories.add(actor.id);
+					actorCategories.add(actor.id);
 				}
 			}
 
@@ -219,7 +224,7 @@ Actors.assert = async (ids, options = {}) => {
 		}
 	}));
 	actors = actors.filter(Boolean); // remove unresolvable actors
-	if (!actors.length && !categories.size) {
+	if (!actors.length && !actorCategories.size) {
 		return [];
 	}
 
@@ -285,8 +290,8 @@ Actors.assert = async (ids, options = {}) => {
 	}
 
 	// Handle any actors that should be asserted as a group instead
-	if (categories.size) {
-		const assertion = await Actors.assertGroup(Array.from(categories), options);
+	if (actorCategories.size) {
+		const assertion = await Actors.assertGroup(Array.from(actorCategories), options);
 		if (assertion === false) {
 			return false;
 		} else if (Array.isArray(assertion)) {
@@ -310,27 +315,30 @@ Actors.assertGroup = async (ids, options = {}) => {
 	 *   - true: no new IDs processed; all passed-in IDs present.
 	 */
 
-	ids = await Actors.qualify(ids, {
+	const qualified = await Actors.qualify(ids, {
 		qualifyGroup: true,
 		...options,
 	});
-	if (!ids) {
-		return ids;
+	if (!qualified || !qualified.ids) {
+		return qualified;
 	}
 
-	activitypub.helpers.log(`[activitypub/actors] Asserting ${ids.length} group(s)`);
+	const { ids: idsArr } = qualified;
+
+	activitypub.helpers.log(`[activitypub/actors] Asserting ${idsArr.length} group(s)`);
 
 	// NOTE: MAKE SURE EVERY DB ADDITION HAS A CORRESPONDING REMOVAL IN ACTORS.REMOVEGROUP!
 
 	const urlMap = new Map();
 	const followersUrlMap = new Map();
 	const pubKeysMap = new Map();
-	let groups = await Promise.all(ids.map(async (id) => {
+	let groups = await Promise.all(idsArr.map(async (id) => {
 		try {
 			activitypub.helpers.log(`[activitypub/actors] Processing group ${id}`);
 			const actor = (typeof id === 'object' && id.hasOwnProperty('id')) ? id : await activitypub.get('uid', 0, id, { cache: process.env.CI === 'true' });
 
-			// Verify actor.id hostname matches the queried URL's hostname (prevent spoofed id overwrite)
+			// Verify actor.id hostname matches the queried URL's hostname (prevent spoofed id overwrite).
+			// This check runs unconditionally — before any WebFinger logic.
 			if (typeof id === 'string') {
 				const queriedHost = new URL(id).hostname;
 				const actorHost = new URL(actor.id).hostname;
@@ -340,12 +348,13 @@ Actors.assertGroup = async (ids, options = {}) => {
 				}
 			}
 
-			// webfinger backreference check
-			const { hostname: domain } = new URL(id);
-			const { actorUri: canonicalId } = await activitypub.helpers.query(`${actor.preferredUsername}@${domain}`);
-			if (id !== canonicalId) {
+			// Two-way WebFinger verification (includes backreference + optional split-domain forward check).
+			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor);
+			if (!verdict || !verdict.ok) {
+				activitypub.helpers.log(`[activitypub/actors] Webfinger verification failed (${verdict?.reason || 'unknown'}) for ${actor.id}`);
 				return null;
 			}
+			actor._canonicalHandle = verdict.canonicalHandle;
 
 			const typeOk = Array.isArray(actor.type) ?
 				actor.type.some(type => activitypub._constants.acceptableGroupTypes.has(type)) :

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -223,12 +223,9 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 	}
 
 	// The subject's hostname tells us the canonical domain (A).
+	// Missing subjectHostname (e.g., legacy cache entries) defaults to same-domain.
 	const subjectHost = backref.subjectHostname;
-	const normalizedSubjectHost = subjectHost.toLowerCase();
-	const normalizedIdHost = idHostname.toLowerCase();
-
-	// Same-domain: subject hostname matches id hostname → standard backreference.
-	if (normalizedSubjectHost === normalizedIdHost) {
+	if (!subjectHost || subjectHost.toLowerCase() === idHostname.toLowerCase()) {
 		return {
 			ok: true,
 			splitDomain: false,
@@ -236,6 +233,8 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 			reason: null,
 		};
 	}
+
+	const normalizedSubjectHost = subjectHost.toLowerCase();
 
 	if (!meta.config.activitypubAllowSplitDomain) {
 		// Split-domain disabled; reject actors whose subject hostname differs

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -98,7 +98,7 @@ Helpers.isWebfinger = (value) => {
 	return false;
 };
 
-Helpers.query = async (id) => {
+Helpers.query = async (id, { strict = true } = {}) => {
 	const isUri = Helpers.isUri(id);
 	// username@host ids use acct: URI schema
 	const uri = isUri ? new URL(id) : new URL(`acct:${id}`);
@@ -112,6 +112,10 @@ Helpers.query = async (id) => {
 
 	const cached = webfingerCache.get(id);
 	if (cached !== undefined) {
+		// Gate cache read on strict: strict queries of cached split-domain payloads return false
+		if (strict && cached.splitDomain) {
+			return false;
+		}
 		return cached;
 	}
 
@@ -177,18 +181,117 @@ Helpers.query = async (id) => {
 	} else {
 		subjectHostname = subjectUrl.hostname;
 	}
-	if (subjectHostname !== hostname) {
+
+	// Check for split-domain: queried hostname differs from subject hostname.
+	const splitDomain = subjectHostname.toLowerCase() !== hostname.toLowerCase();
+	if (splitDomain && strict) {
+		// Strict mode: reject responses where the subject hostname differs
 		return false;
 	}
 
-	const payload = { subject, username, hostname, actorUri, publicKey, _raw: body };
+	const payload = {
+		subject, username, hostname, actorUri, publicKey,
+		_raw: body,
+		subjectHostname: subjectUrl.protocol === 'acct:' ? subjectHostname : subjectHostname,
+		splitDomain,
+	};
 	const claimedId = subjectUrl.pathname;
-	webfingerCache.set(claimedId, payload);
+	// Always cache by the queried id so subsequent queries hit the cache
+	webfingerCache.set(id, payload);
+	// Also cache by the claimed subject path for alias lookups
 	if (claimedId !== id) {
-		webfingerCache.set(id, payload);
+		webfingerCache.set(claimedId, payload);
 	}
 
 	return payload;
+};
+
+/**
+ * Verify an actor's identity via two-way WebFinger validation.
+ *
+ * For same-domain actors (standard), performs a single backreference check
+ * (domain B WebFinger must resolve to the actor's own id).
+ *
+ * For split-domain actors, performs a two-way validation:
+ *   1. Backreference via non-strict query on domain B (actor's id host)
+ *   2. Forward via strict query on domain A (subject's host) — only if split-domain is enabled
+ *
+ * @param {string} actorId - The actor's id URI (domain B)
+ * @param {object} actor - The fetched actor document
+ * @returns {{ ok: boolean, splitDomain: boolean, canonicalHandle: string|null, reason: string|null }|false}
+ *   Returns false if actorId cannot be parsed as a URI (shouldn't happen for valid actors).
+ *   Returns the structured verdict on success.
+ */
+Helpers.verifyActorWebfinger = async (actorId, actor) => {
+	if (!Helpers.isUri(actorId)) {
+		return false;
+	}
+
+	const idHostname = new URL(actorId).hostname;
+	const preferredUsername = actor.preferredUsername || 'user';
+
+	// Step 1: Backreference — non-strict query on domain B (the actor's id host).
+	// This allows the WebFinger subject to point elsewhere (split-domain forward target).
+	const backref = await Helpers.query(`${preferredUsername}@${idHostname}`, { strict: false });
+	if (!backref) {
+		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'no-backreference' };
+	}
+
+	// The backreference self-link must point at this exact actor document.
+	if (backref.actorUri !== actorId) {
+		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'subject-mismatch' };
+	}
+
+	// The subject's hostname tells us the canonical domain (A).
+	const subjectHost = backref.subjectHostname;
+	const normalizedSubjectHost = subjectHost.toLowerCase();
+	const normalizedIdHost = idHostname.toLowerCase();
+
+	// Same-domain: subject hostname matches id hostname → standard backreference.
+	if (normalizedSubjectHost === normalizedIdHost) {
+		return {
+			ok: true,
+			splitDomain: false,
+			canonicalHandle: `${preferredUsername}@${idHostname}`,
+			reason: null,
+		};
+	}
+
+	// Subject points to a different domain → candidate split-domain.
+	// Check if split-domain is enabled via config.
+	if (!meta.config.activitypubAllowSplitDomain) {
+		// Split-domain is disabled — reject actors whose subject hostname differs.
+		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'forward-mismatch' };
+	}
+
+	// Step 2: Forward query on domain A (the subject's host) with strict mode.
+	// This ensures domain A explicitly confirms this actor on B.
+	const forwardResult = await Helpers.query(`${preferredUsername}@${normalizedSubjectHost}`, { strict: true });
+	if (!forwardResult || forwardResult.actorUri !== actorId) {
+		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'forward-mismatch' };
+	}
+
+	// Two-way check passed — this is a genuine split-domain actor.
+	// Blocklist check: if domain A (canonical) is blocked, reject.
+	const blockCheck = await activitypub.instances.isAllowed(normalizedSubjectHost);
+	if (!blockCheck.allowed) {
+		activitypub.helpers.log(
+			`[activitypub/verify] canonical domain blocked (${normalizedSubjectHost}: ${blockCheck.severity}) for ${actorId}`,
+		);
+		return {
+			ok: false,
+			splitDomain: true,
+			canonicalHandle: null,
+			reason: 'canonical-blocked',
+		};
+	}
+
+	return {
+		ok: true,
+		splitDomain: true,
+		canonicalHandle: `${preferredUsername}@${normalizedSubjectHost}`,
+		reason: 'split-domain',
+	};
 };
 
 Helpers.generateKeys = async (type, id) => {

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -111,11 +111,7 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	hostname = hostname.trim();
 
 	const cached = webfingerCache.get(id);
-	if (cached !== undefined) {
-		// Gate cache read on strict: strict queries of cached split-domain payloads return false
-		if (strict && cached.splitDomain) {
-			return false;
-		}
+	if (cached !== undefined && !(strict && cached.splitDomain)) {
 		return cached;
 	}
 
@@ -206,19 +202,6 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	return payload;
 };
 
-/**
- * Verify an actor's identity via two-way WebFinger validation.
- *
- * For same-domain actors (standard), performs a single backreference check
- * (domain B WebFinger must resolve to the actor's own id).
- *
- * For split-domain actors, performs a two-way validation:
- *   1. Backreference via non-strict query on domain B (actor's id host)
- *   2. Forward via strict query on domain A (subject's host) — only if split-domain is enabled
- *
- *   Returns false if actorId cannot be parsed as a URI (shouldn't happen for valid actors).
- *   Returns the structured verdict on success.
- */
 Helpers.verifyActorWebfinger = async (actorId, actor) => {
 	if (!Helpers.isUri(actorId)) {
 		return false;
@@ -254,27 +237,18 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 		};
 	}
 
-	// Subject points to a different domain → candidate split-domain.
-	// Check if split-domain is enabled via config.
 	if (!meta.config.activitypubAllowSplitDomain) {
-		// Split-domain is disabled — reject actors whose subject hostname differs.
+		// Split-domain disabled; reject actors whose subject hostname differs
 		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'forward-mismatch' };
 	}
 
-	// Step 2: Forward query on domain A (the subject's host) with strict mode.
-	// This ensures domain A explicitly confirms this actor on B.
 	const forwardResult = await Helpers.query(`${preferredUsername}@${normalizedSubjectHost}`, { strict: true });
 	if (!forwardResult || forwardResult.actorUri !== actorId) {
 		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'forward-mismatch' };
 	}
 
-	// Two-way check passed — this is a genuine split-domain actor.
-	// Blocklist check: if domain A (canonical) is blocked, reject.
-	const blockCheck = await activitypub.instances.isAllowed(normalizedSubjectHost);
-	if (!blockCheck.allowed) {
-		activitypub.helpers.log(
-			`[activitypub/verify] canonical domain blocked (${normalizedSubjectHost}: ${blockCheck.severity}) for ${actorId}`,
-		);
+	const blocked = await activitypub.instances.isAllowed(normalizedSubjectHost);
+	if (!blocked.allowed) {
 		return {
 			ok: false,
 			splitDomain: true,

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -216,9 +216,6 @@ Helpers.query = async (id, { strict = true } = {}) => {
  *   1. Backreference via non-strict query on domain B (actor's id host)
  *   2. Forward via strict query on domain A (subject's host) — only if split-domain is enabled
  *
- * @param {string} actorId - The actor's id URI (domain B)
- * @param {object} actor - The fetched actor document
- * @returns {{ ok: boolean, splitDomain: boolean, canonicalHandle: string|null, reason: string|null }|false}
  *   Returns false if actorId cannot be parsed as a URI (shouldn't happen for valid actors).
  *   Returns the structured verdict on success.
  */

--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -235,6 +235,13 @@ Mocks.profile = async (actors) => {
 			return null;
 		}
 
+		// For split-domain: use the canonical domain (domain A) for the handle
+		// instead of the actor's id hostname (domain B)
+		const canonicalHost = actor._canonicalHandle ?
+			actor._canonicalHandle.split('@').slice(1).join('@') :
+			hostname;
+		const canonicalHostname = canonicalHost;
+
 		let picture;
 		if (icon) {
 			picture = typeof icon === 'string' ? icon : icon.url;
@@ -278,8 +285,8 @@ Mocks.profile = async (actors) => {
 
 		const payload = {
 			uid,
-			username: `${preferredUsername}@${hostname}`,
-			userslug: `${preferredUsername}@${hostname}`,
+			username: `${preferredUsername}@${canonicalHostname}`,
+			userslug: `${preferredUsername}@${canonicalHostname}`.toLowerCase(),
 			displayname: name,
 			fullname: name,
 			joindate: new Date(published).getTime() || Date.now(),
@@ -299,6 +306,9 @@ Mocks.profile = async (actors) => {
 			sharedInbox: endpoints ? endpoints.sharedInbox : null,
 			followersUrl: followers,
 			customFields: customFields && new URLSearchParams(customFields).toString(),
+
+			// Store the canonical webfinger handle for split-domain identity verification
+			webfinger: canonicalHostname === hostname ? undefined : `acct:${preferredUsername}@${canonicalHostname}`,
 		};
 
 		return payload;
@@ -334,6 +344,12 @@ Mocks.category = async (actors) => {
 			return null;
 		}
 
+		// For split-domain: use the canonical domain (domain A) for the handle
+		const canonicalHost = actor._canonicalHandle ?
+			actor._canonicalHandle.split('@').slice(1).join('@') :
+			hostname;
+		const canonicalHostname = canonicalHost;
+
 		// No support for category avatars yet ;(
 		// let picture;
 		// if (image) {
@@ -348,8 +364,8 @@ Mocks.category = async (actors) => {
 		const payload = {
 			cid,
 			name,
-			handle: `${preferredUsername}@${hostname}`,
-			slug: `${preferredUsername}@${hostname}`,
+			handle: `${preferredUsername}@${canonicalHostname}`,
+			slug: `${preferredUsername}@${canonicalHostname}`,
 			description: summary,
 			descriptionParsed: posts.sanitize(activitypub.helpers.renderEmoji(summary || '', tag)),
 			icon: backgroundImage ? 'fa-nbb-none' : 'fa-comments',
@@ -369,6 +385,9 @@ Mocks.category = async (actors) => {
 			_activitypub: {
 				postingRestrictedToMods,
 			},
+
+			// Store the canonical webfinger handle for split-domain identity verification
+			webfinger: canonicalHostname === hostname ? undefined : `acct:${preferredUsername}@${canonicalHostname}`,
 		};
 
 		return payload;

--- a/src/views/admin/federation/general.tpl
+++ b/src/views/admin/federation/general.tpl
@@ -22,6 +22,11 @@
 						<label class="form-check-label">{{tx("admin/settings/activitypub:allowLoopback")}}</label>
 						<p class="form-text">{{tx("admin/settings/activitypub:allowLoopback-help")}}</p>
 					</div>
+					<div class="form-check form-switch mb-3">
+						<input class="form-check-input" type="checkbox" data-field="activitypubAllowSplitDomain">
+						<label class="form-check-label">{{tx("admin/settings/activitypub:allowSplitDomain")}}</label>
+						<p class="form-text">{{tx("admin/settings/activitypub:allowSplitDomain-help")}}</p>
+					</div>
 					<div class="mb-3">
 						<label class="form-label" for="activitypubParentTraversalDepth">{{tx("admin/settings/activitypub:parentTraversalDepth")}}</label>
 						<input type="number" id="activitypubParentTraversalDepth" name="activitypubParentTraversalDepth" data-field="activitypubParentTraversalDepth" title="{{tx("admin/settings/activitypub:parentTraversalDepth")}}" class="form-control" />

--- a/test/activitypub/helpers.js
+++ b/test/activitypub/helpers.js
@@ -17,6 +17,7 @@ Helpers.mocks.person = (override = {}) => {
 		id = override.id;
 	}
 
+	const username = override.preferredUsername || `user_${uuid.slice(0, 8)}`;
 
 	const actor = {
 		'@context': [
@@ -30,7 +31,7 @@ Helpers.mocks.person = (override = {}) => {
 
 		type: 'Person',
 		name: slugify(id),
-		preferredUsername: id,
+		preferredUsername: username,
 
 		publicKey: {
 			id: `${id}#key`,
@@ -43,8 +44,11 @@ Helpers.mocks.person = (override = {}) => {
 	activitypub._cache.set(`0;${id}`, actor);
 	activitypub.helpers._webfingerCache.set(`${actor.preferredUsername}@example.org`, {
 		actorUri: id,
-		username: id,
+		username: username,
 		hostname: 'example.org',
+		subject: `acct:${username}@example.org`,
+		splitDomain: false,
+		subjectHostname: 'example.org',
 	});
 
 	return { id, actor };
@@ -60,8 +64,11 @@ Helpers.mocks.group = (override = {}) => {
 	activitypub._cache.set(`0;${id}`, actor);
 	activitypub.helpers._webfingerCache.set(`${actor.preferredUsername}@${hostname}`, {
 		actorUri: id,
-		username: id,
+		username: actor.preferredUsername,
 		hostname,
+		subject: `acct:${actor.preferredUsername}@${hostname}`,
+		splitDomain: false,
+		subjectHostname: hostname,
 	});
 
 	return { id, actor };

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -1,0 +1,365 @@
+'use strict';
+
+const assert = require('assert');
+const nconf = require('nconf');
+const utils = require('../../src/utils');
+
+const activitypub = require('../../src/activitypub');
+
+const Helpers = module.exports;
+
+Helpers.genSplitDomain = () => {
+	const username = `user_${utils.generateUUID().replace(/-/g, '').slice(0, 8)}`;
+	const domainA = `forum-${utils.generateUUID().replace(/-/g, '').slice(0, 6)}.example`;
+	const domainB = `ap-${utils.generateUUID().replace(/-/g, '').slice(0, 6)}.example`;
+	const actorUri = `https://${domainB}/uid/${username}`;
+	return { domainA, domainB, username, actorUri, preferredUsername: username };
+};
+
+Helpers.seedWebfinger = (domainA, domainB, username, actorUri) => {
+	activitypub.helpers._webfingerCache.set(`${username}@${domainB}`, {
+		actorUri, username, hostname: domainB,
+		subject: `acct:${username}@${domainA}`, splitDomain: true, subjectHostname: domainA,
+		_raw: {
+			links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+			publicKey: null, subject: `acct:${username}@${domainA}`,
+		},
+	});
+	activitypub.helpers._webfingerCache.set(`${username}@${domainA}`, {
+		actorUri, username, hostname: domainA,
+		subject: `acct:${username}@${domainA}`, splitDomain: false, subjectHostname: domainA,
+		_raw: {
+			links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+			publicKey: null, subject: `acct:${username}@${domainA}`,
+		},
+	});
+};
+
+Helpers.seedSameDomainWebfinger = (domainB, username, actorUri) => {
+	activitypub.helpers._webfingerCache.set(`${username}@${domainB}`, {
+		actorUri, username, hostname: domainB,
+		subject: `acct:${username}@${domainB}`, splitDomain: false, subjectHostname: domainB,
+		_raw: {
+			links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+			publicKey: null, subject: `acct:${username}@${domainB}`,
+		},
+	});
+};
+
+Helpers.seedActor = (actorUri, overrides = {}) => {
+	const actor = {
+		'@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+		id: actorUri, url: actorUri, inbox: `${actorUri}/inbox`, outbox: `${actorUri}/outbox`,
+		type: 'Person', name: overrides.name || overrides.preferredUsername || 'User',
+		preferredUsername: overrides.preferredUsername || 'user',
+		publicKey: { id: `${actorUri}#key`, owner: actorUri, publicKeyPem: 'test-key' },
+		followers: `${actorUri}/followers`, following: `${actorUri}/following`,
+		...overrides,
+	};
+	activitypub._cache.set(`0;${actorUri}`, actor);
+	return actor;
+};
+
+Helpers.reset = () => {
+	activitypub._cache.reset();
+	activitypub.helpers._webfingerCache.reset();
+	nconf.set('activitypubAllowSplitDomain', 1);
+	nconf.set('activitypubAllowLoopback', 0);
+};
+
+// ============================================================================
+
+describe('helpers.query strictness', () => {
+	beforeEach(Helpers.reset);
+
+	it('strict query of same-domain subject returns payload with splitDomain: false', async () => {
+		const { domainA, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedSameDomainWebfinger(domainA, username, actorUri);
+		const result = await activitypub.helpers.query(`${username}@${domainA}`);
+		assert.ok(result);
+		assert.equal(result.actorUri, actorUri);
+		assert.equal(result.splitDomain, false);
+	});
+
+	it('strict query of split-domain subject returns false', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		const result = await activitypub.helpers.query(`${username}@${domainB}`);
+		assert.equal(result, false);
+	});
+
+	it('non-strict query of split-domain subject returns full payload', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		const result = await activitypub.helpers.query(`${username}@${domainB}`, { strict: false });
+		assert.ok(result);
+		assert.equal(result.actorUri, actorUri);
+		assert.equal(result.splitDomain, true);
+		assert.equal(result.hostname, domainB);
+		assert.equal(result.subjectHostname, domainA);
+	});
+
+	it('cached split-domain payload is still rejected by strict query', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		const result = await activitypub.helpers.query(`${username}@${domainB}`);
+		assert.equal(result, false);
+	});
+});
+
+// ============================================================================
+
+describe('verifyActorWebfinger', () => {
+	beforeEach(Helpers.reset);
+
+	it('returns split-domain verdict for fully verified actor', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.ok(verdict.ok);
+		assert.equal(verdict.splitDomain, true);
+		assert.equal(verdict.canonicalHandle, `${username}@${domainA}`);
+		assert.equal(verdict.reason, 'split-domain');
+	});
+
+	it('returns same-domain verdict for same-domain actor', async () => {
+		const { username, actorUri } = Helpers.genSplitDomain();
+		const domain = new URL(actorUri).hostname;
+		Helpers.seedSameDomainWebfinger(domain, username, actorUri);
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.ok(verdict.ok);
+		assert.equal(verdict.splitDomain, false);
+		assert.equal(verdict.canonicalHandle, `${username}@${domain}`);
+	});
+
+	it('rejects with no-backreference when domain B WebFinger 404s', async () => {
+		const { domainA, username, actorUri } = Helpers.genSplitDomain();
+		activitypub.helpers._webfingerCache.set(`${username}@${domainA}`, {
+			actorUri, username, hostname: domainA,
+			subject: `acct:${username}@${domainA}`, splitDomain: false, subjectHostname: domainA,
+			_raw: {
+				links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+				publicKey: null,
+			},
+		});
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'no-backreference');
+	});
+
+	it('rejects with subject-mismatch when backreference self-link points elsewhere', async () => {
+		const { domainB, username, actorUri } = Helpers.genSplitDomain();
+		const spoofedUri = `https://${domainB}/uid/spoofed_user`;
+		activitypub.helpers._webfingerCache.set(`${username}@${domainB}`, {
+			actorUri: spoofedUri, username, hostname: domainB,
+			subject: `acct:${username}@${domainB}`, splitDomain: false, subjectHostname: domainB,
+			_raw: {
+				links: [{ rel: 'self', href: spoofedUri, type: 'application/activity+json' }],
+				publicKey: null,
+			},
+		});
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'subject-mismatch');
+	});
+
+	it('rejects with forward-mismatch when forward query 404s', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		activitypub.helpers._webfingerCache.set(`${username}@${domainB}`, {
+			actorUri, username, hostname: domainB,
+			subject: `acct:${username}@${domainA}`, splitDomain: true, subjectHostname: domainA,
+			_raw: {
+				links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+				publicKey: null,
+			},
+		});
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'forward-mismatch');
+	});
+
+	it('rejects when split-domain config is off', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		nconf.set('activitypubAllowSplitDomain', 0);
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'forward-mismatch');
+	});
+
+	it('rejects with canonical-blocked when domain A is blocklisted', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const origCheck = activitypub.instances._blocklists.check;
+		activitypub.instances._blocklists.check = async (domain) => {
+			if (domain === domainA) {
+				return { allowed: false, severity: 'filter', listUrl: 'https://bad.example' };
+			}
+			return origCheck.call(activitypub.instances._blocklists, domain);
+		};
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'canonical-blocked');
+		activitypub.instances._blocklists.check = origCheck;
+	});
+});
+
+// ============================================================================
+
+describe('Actors.assert - hostname mismatch', () => {
+	beforeEach(Helpers.reset);
+
+	it('rejects when queried hostname differs from actor.id hostname (gh#13352)', async () => {
+		const username = 'alice';
+		const queriedDomain = 'honest.example';
+		const actorDomain = 'spoof.example';
+		const actorUri = `https://${actorDomain}/uid/${username}`;
+		activitypub.helpers._webfingerCache.set(`${username}@${queriedDomain}`, {
+			actorUri, username, hostname: queriedDomain,
+			subject: `acct:${username}@${queriedDomain}`, splitDomain: false, subjectHostname: queriedDomain,
+			_raw: {
+				links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+				publicKey: null,
+			},
+		});
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const result = await activitypub.actors.assert([actorUri]);
+		assert.equal(result, false);
+	});
+
+	it('accepts same-domain actors via full WebFinger verification', async () => {
+		const { username, actorUri } = Helpers.genSplitDomain();
+		const domain = new URL(actorUri).hostname;
+		Helpers.seedSameDomainWebfinger(domain, username, actorUri);
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		const result = await activitypub.actors.assert([actorUri]);
+		assert.ok(Array.isArray(result));
+		assert.equal(result.length, 1);
+	});
+
+	it('rejects split-domain actor when config is off', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+		nconf.set('activitypubAllowSplitDomain', 0);
+		const result = await activitypub.actors.assert([actorUri]);
+		assert.equal(result, false);
+	});
+});
+
+// ============================================================================
+
+describe('Mocks.profile canonical handle', () => {
+	beforeEach(Helpers.reset);
+
+	it('uses canonical domain when _canonicalHandle is set', async () => {
+		const { domainA, username, actorUri } = Helpers.genSplitDomain();
+		const actor = Helpers.seedActor(actorUri, { preferredUsername: username });
+		actor._canonicalHandle = `${username}@${domainA}`;
+		const profile = await activitypub.mocks.profile([actor]);
+		assert.ok(profile[0]);
+		assert.equal(profile[0].username, `${username}@${domainA}`);
+		assert.equal(profile[0].userslug, `${username}@${domainA}`);
+		assert.equal(profile[0].webfinger, `acct:${username}@${domainA}`);
+	});
+
+	it('uses actor id domain when _canonicalHandle is not set', async () => {
+		const { username, actorUri } = Helpers.genSplitDomain();
+		const hostname = new URL(actorUri).hostname;
+		const actor = Helpers.seedActor(actorUri, { preferredUsername: username });
+		const profile = await activitypub.mocks.profile([actor]);
+		assert.ok(profile[0]);
+		assert.equal(profile[0].username, `${username}@${hostname}`);
+		assert.equal(profile[0].userslug, `${username}@${hostname}`);
+		assert.equal(profile[0].webfinger, undefined);
+	});
+});
+
+// ============================================================================
+
+describe('Mocks.category canonical handle', () => {
+	beforeEach(Helpers.reset);
+
+	it('uses canonical domain when _canonicalHandle is set', async () => {
+		const { domainA, username, actorUri } = Helpers.genSplitDomain();
+		const groupActor = {
+			'@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+			id: actorUri, url: actorUri, type: 'Group',
+			name: 'Mod Team', preferredUsername: username, summary: 'Moderators',
+			publicKey: { id: `${actorUri}#key`, owner: actorUri, publicKeyPem: 'test-key' },
+			endpoints: {},
+			_canonicalHandle: `${username}@${domainA}`,
+		};
+		const cats = await activitypub.mocks.category([groupActor]);
+		assert.ok(cats[0]);
+		assert.equal(cats[0].handle, `${username}@${domainA}`);
+		assert.equal(cats[0].slug, `${username}@${domainA}`);
+		assert.equal(cats[0].webfinger, `acct:${username}@${domainA}`);
+	});
+
+	it('uses actor id domain when _canonicalHandle is not set', async () => {
+		const { username, actorUri } = Helpers.genSplitDomain();
+		const hostname = new URL(actorUri).hostname;
+		const groupActor = {
+			'@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+			id: actorUri, url: actorUri, type: 'Group',
+			name: 'Staff', preferredUsername: username, summary: 'Admins',
+			publicKey: { id: `${actorUri}#key`, owner: actorUri, publicKeyPem: 'test-key' },
+			endpoints: {},
+		};
+		const cats = await activitypub.mocks.category([groupActor]);
+		assert.ok(cats[0]);
+		assert.equal(cats[0].handle, `${username}@${hostname}`);
+		assert.equal(cats[0].slug, `${username}@${hostname}`);
+		assert.equal(cats[0].webfinger, undefined);
+	});
+});
+
+// ============================================================================
+
+describe('Split-Domain: Integration - full flow', () => {
+	beforeEach(Helpers.reset);
+
+	it('should pass through split-domain resolve -> verify -> profile', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
+		const queryResult = await activitypub.helpers.query(`${username}@${domainA}`, { strict: false });
+		assert.ok(queryResult);
+		assert.equal(queryResult.splitDomain, true);
+
+		const actor = Helpers.seedActor(actorUri, { preferredUsername: username });
+		const verdict = await activitypub.helpers.verifyActorWebfinger(
+			actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.ok(verdict.ok);
+		assert.equal(verdict.splitDomain, true);
+		assert.equal(verdict.canonicalHandle, `${username}@${domainA}`);
+
+		actor._canonicalHandle = verdict.canonicalHandle;
+		const profile = await activitypub.mocks.profile([actor]);
+		assert.equal(profile[0].username, `${username}@${domainA}`);
+		assert.equal(profile[0].userslug, `${username}@${domainA}`);
+		assert.equal(profile[0].webfinger, `acct:${username}@${domainA}`);
+	});
+});

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const nconf = require('nconf');
+const meta = require('../../src/meta');
 const utils = require('../../src/utils');
 
 const activitypub = require('../../src/activitypub');
@@ -64,7 +65,9 @@ Helpers.reset = () => {
 	activitypub._cache.reset();
 	activitypub.helpers._webfingerCache.reset();
 	nconf.set('activitypubAllowSplitDomain', 1);
+	meta.config.activitypubAllowSplitDomain = 1;
 	nconf.set('activitypubAllowLoopback', 0);
+	meta.config.activitypubAllowLoopback = 0;
 };
 
 // ============================================================================
@@ -197,7 +200,7 @@ describe('verifyActorWebfinger', () => {
 		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
 		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
 		Helpers.seedActor(actorUri, { preferredUsername: username });
-		nconf.set('activitypubAllowSplitDomain', 0);
+		meta.config.activitypubAllowSplitDomain = 0;
 		const verdict = await activitypub.helpers.verifyActorWebfinger(
 			actorUri, activitypub._cache.get(`0;${actorUri}`));
 		assert.ok(verdict);
@@ -209,19 +212,19 @@ describe('verifyActorWebfinger', () => {
 		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
 		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
 		Helpers.seedActor(actorUri, { preferredUsername: username });
-		const origCheck = activitypub.instances._blocklists.check;
-		activitypub.instances._blocklists.check = async (domain) => {
+		const origCheck = activitypub.blocklists.check;
+		activitypub.blocklists.check = async (domain) => {
 			if (domain === domainA) {
 				return { allowed: false, severity: 'filter', listUrl: 'https://bad.example' };
 			}
-			return origCheck.call(activitypub.instances._blocklists, domain);
+			return origCheck.call(activitypub.blocklists, domain);
 		};
 		const verdict = await activitypub.helpers.verifyActorWebfinger(
 			actorUri, activitypub._cache.get(`0;${actorUri}`));
 		assert.ok(verdict);
 		assert.equal(verdict.ok, false);
 		assert.equal(verdict.reason, 'canonical-blocked');
-		activitypub.instances._blocklists.check = origCheck;
+		activitypub.blocklists.check = origCheck;
 	});
 });
 
@@ -262,9 +265,11 @@ describe('Actors.assert - hostname mismatch', () => {
 		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
 		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
 		Helpers.seedActor(actorUri, { preferredUsername: username });
-		nconf.set('activitypubAllowSplitDomain', 0);
+		const orig = meta.config.activitypubAllowSplitDomain;
+		meta.config.activitypubAllowSplitDomain = 0;
 		const result = await activitypub.actors.assert([actorUri]);
-		assert.equal(result, false);
+		meta.config.activitypubAllowSplitDomain = orig;
+		assert.equal(result.length, 0);
 	});
 });
 
@@ -344,7 +349,7 @@ describe('Split-Domain: Integration - full flow', () => {
 	it('should pass through split-domain resolve -> verify -> profile', async () => {
 		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
 		Helpers.seedWebfinger(domainA, domainB, username, actorUri);
-		const queryResult = await activitypub.helpers.query(`${username}@${domainA}`, { strict: false });
+		const queryResult = await activitypub.helpers.query(`${username}@${domainB}`, { strict: false });
 		assert.ok(queryResult);
 		assert.equal(queryResult.splitDomain, true);
 


### PR DESCRIPTION
Implements split-domain ActivityPub support, allowing NodeBB to federate with actors whose canonical domain differs from their queried domain. Replaces the dead `verifyActorWebfinger` stub with real two-way WebFinger validation that checks both backreference and forward WebFinger resolution, gated by the `activitypubAllowSplitDomain` configuration (enabled by default). Fixes security regression gh#13352 by adding unconditional hostname mismatch rejection in `Actors.assert` and `Actors.assertGroup` to prevent spoofed actor ID overwrites. Migrates from legacy `_queriedHostname`/`_splitDomain`/`_queriedId` fields to a unified `_canonicalHandle` property on actor objects, and adds a comprehensive test suite covering query strictness, WebFinger verification verdicts, hostname mismatch protection, mock formatting, and integration flows.