### PR TITLE
fix(crossposts): pin and unpin the crossposted categories too

### DIFF
--- a/src/topics/tools.js
+++ b/src/topics/tools.js
@@ -163,29 +163,33 @@ module.exports = function (Topics) {
 			throw new Error('[[error:no-privileges]]');
 		}
 
+		// crossposted categories hold the same zsets, so they pin and unpin alongside the topic's own
+		const crossposts = await Topics.crossposts.get(tid);
+		const cids = [topicData.cid, ...crossposts.map(crosspost => crosspost.cid)];
+
 		const promises = [
 			Topics.setTopicField(tid, 'pinned', pin ? 1 : 0),
 			Topics.events.log(tid, { type: pin ? 'pin' : 'unpin', uid }),
 		];
 		if (pin) {
-			promises.push(db.sortedSetAdd(`cid:${topicData.cid}:tids:pinned`, Date.now(), tid));
-			promises.push(db.sortedSetsRemove([
-				`cid:${topicData.cid}:tids`,
-				`cid:${topicData.cid}:tids:create`,
-				`cid:${topicData.cid}:tids:posts`,
-				`cid:${topicData.cid}:tids:votes`,
-				`cid:${topicData.cid}:tids:views`,
-			], tid));
+			promises.push(db.sortedSetsAdd(cids.map(cid => `cid:${cid}:tids:pinned`), Date.now(), tid));
+			promises.push(db.sortedSetsRemove(cids.flatMap(cid => [
+				`cid:${cid}:tids`,
+				`cid:${cid}:tids:create`,
+				`cid:${cid}:tids:posts`,
+				`cid:${cid}:tids:votes`,
+				`cid:${cid}:tids:views`,
+			]), tid));
 		} else {
-			promises.push(db.sortedSetRemove(`cid:${topicData.cid}:tids:pinned`, tid));
+			promises.push(db.sortedSetsRemove(cids.map(cid => `cid:${cid}:tids:pinned`), tid));
 			promises.push(Topics.deleteTopicField(tid, 'pinExpiry'));
-			promises.push(db.sortedSetAddBulk([
-				[`cid:${topicData.cid}:tids`, topicData.lastposttime, tid],
-				[`cid:${topicData.cid}:tids:create`, topicData.timestamp, tid],
-				[`cid:${topicData.cid}:tids:posts`, topicData.postcount, tid],
-				[`cid:${topicData.cid}:tids:votes`, parseInt(topicData.votes, 10) || 0, tid],
-				[`cid:${topicData.cid}:tids:views`, topicData.viewcount, tid],
-			]));
+			promises.push(db.sortedSetAddBulk(cids.flatMap(cid => [
+				[`cid:${cid}:tids`, topicData.lastposttime, tid],
+				[`cid:${cid}:tids:create`, topicData.timestamp, tid],
+				[`cid:${cid}:tids:posts`, topicData.postcount, tid],
+				[`cid:${cid}:tids:votes`, parseInt(topicData.votes, 10) || 0, tid],
+				[`cid:${cid}:tids:views`, topicData.viewcount, tid],
+			])));
 			topicData.pinExpiry = undefined;
 			topicData.pinExpiryISO = undefined;
 		}

--- a/test/crossposts.js
+++ b/test/crossposts.js
@@ -61,6 +61,35 @@ describe('Crossposts', () => {
 		assert.strictEqual(scoreAfter, null, 'tag index should be cleaned up when the crosspost is removed');
 	});
 
+	it('should pin a crossposted topic in its crossposted categories too', async () => {
+		const { tid } = await createTopic();
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		await topics.tools.pin(tid, adminUid);
+
+		const [pinnedScore, tidsScore] = await Promise.all([
+			db.sortedSetScore(`cid:${targetCategory.cid}:tids:pinned`, tid),
+			db.sortedSetScore(`cid:${targetCategory.cid}:tids`, tid),
+		]);
+		assert(pinnedScore, 'pinning should reach the crossposted category');
+		assert.strictEqual(tidsScore, null, 'a pinned topic should not be left in the crossposted topic set');
+	});
+
+	it('should unpin a crossposted topic in its crossposted categories too', async () => {
+		const { tid } = await createTopic();
+		await topics.tools.pin(tid, adminUid);
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		await topics.tools.unpin(tid, adminUid);
+
+		const [pinnedScore, tidsScore] = await Promise.all([
+			db.sortedSetScore(`cid:${targetCategory.cid}:tids:pinned`, tid),
+			db.sortedSetScore(`cid:${targetCategory.cid}:tids`, tid),
+		]);
+		assert.strictEqual(pinnedScore, null, 'unpinning should clear the crossposted pinned set');
+		assert(tidsScore, 'an unpinned topic should be back in the crossposted topic set');
+	});
+
 	it('should bump the topic in crossposted categories when it is replied to', async () => {
 		const { tid } = await createTopic();
 		await topics.crossposts.add(tid, targetCategory.cid, uid);


### PR DESCRIPTION
First of the two PRs from https://github.com/NodeBB/NodeBB/issues/14659#issuecomment-5399904821.

`togglePin()` is cid-scoped:

https://github.com/NodeBB/NodeBB/blob/master/src/topics/tools.js#L246-L266

so pinned state diverges per category once a topic is crossposted:

- **crosspost a pinned topic, then unpin it** — the entry in `cid:<crossposted>:tids:pinned` is never removed, so it stays pinned in the crossposted category forever while being unpinned everywhere else.
- **pin a topic that is already crossposted** — it is removed from `cid:<own>:tids` but the crossposted `cid:<cid>:tids` entry survives, so it shows there as an ordinary topic at a stale score and never reaches `:tids:pinned`.

`Crossposts.add()`/`remove()` learned to keep these zsets in step in #14658; this does the same for pin/unpin. The crossposts are resolved unfiltered (no uid), since this is a state change rather than a read, and pinning is rare enough that the extra lookup is not worth guarding.

Two regression tests added to `test/crossposts.js`, one per direction.

Note: I could not run the suite locally (no mongod available on this machine at the moment), so these two tests have only been checked for lint — relying on CI here rather than claiming otherwise.
