### PR TITLE
feat(crossposts): reconcile stale sort scores on topic read

### DIFF
--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -2,6 +2,7 @@
 
 const nconf = require('nconf');
 const path = require('path');
+const winston = require('winston');
 const qs = require('querystring');
 const validator = require('validator');
 
@@ -155,6 +156,11 @@ topicsController.get = async function getTopic(req, res, next) {
 	topicData.author = author;
 	topicData.crossposts = crossposts;
 	topicData.canCrosspost = canCrosspost;
+
+	// not awaited on purpose so topic loading is not blocked
+	topics.crossposts.syncCrosspostedTopicCids(crossposts, topicData)
+		.catch(err => winston.error(err.stack));
+
 	topicData.pagination = pagination.create(currentPage, pageCount, req.query);
 	topicData.pagination.rel.forEach((rel) => {
 		rel.href = `${url}/topic/${topicData.slug}${rel.href}`;

--- a/src/topics/crossposts.js
+++ b/src/topics/crossposts.js
@@ -55,6 +55,45 @@ Crossposts.get = async function (tids, uid) {
 	return isArray ? crossposts : crossposts[0];
 };
 
+Crossposts.syncCrosspostedTopicCids = async function (crossposts, topicData) {
+	// `:tids:posts`, `:tids:votes` and `:tids:views` are only written for the topic's own
+	// category, so crossposted categories keep the values they were seeded with. Reconcile
+	// them when the topic is read, which is cheap and only runs for crossposted topics.
+	// Pinned topics are absent from these zsets by design, so they are skipped.
+	if (!crossposts.length || topicData.pinned) {
+		return;
+	}
+
+	const cids = crossposts.map(crosspost => crosspost.cid);
+	const count = cids.length;
+	const scores = await db.sortedSetsScore([
+		...cids.map(cid => `cid:${cid}:tids:posts`),
+		...cids.map(cid => `cid:${cid}:tids:votes`),
+		...cids.map(cid => `cid:${cid}:tids:views`),
+	], topicData.tid);
+
+	const postcounts = scores.slice(0, count);
+	const votes = scores.slice(count, count * 2);
+	const viewcounts = scores.slice(count * 2);
+
+	const bulkAdd = [];
+	cids.forEach((cid, index) => {
+		if (topicData.postcount !== postcounts[index]) {
+			bulkAdd.push([`cid:${cid}:tids:posts`, topicData.postcount, topicData.tid]);
+		}
+		if (topicData.votes !== votes[index]) {
+			bulkAdd.push([`cid:${cid}:tids:votes`, topicData.votes, topicData.tid]);
+		}
+		if (topicData.viewcount !== viewcounts[index]) {
+			bulkAdd.push([`cid:${cid}:tids:views`, topicData.viewcount, topicData.tid]);
+		}
+	});
+
+	if (bulkAdd.length) {
+		await db.sortedSetAddBulk(bulkAdd);
+	}
+};
+
 Crossposts.add = async function (tid, cid, uid) {
 	/**
 	 * NOTE: If uid is 0, the assumption is that it is a "system" crosspost, not a guest!

--- a/test/crossposts.js
+++ b/test/crossposts.js
@@ -73,6 +73,51 @@ describe('Crossposts', () => {
 		assert.strictEqual(after, timestamp);
 	});
 
+	it('should reconcile stale post, vote and view scores in crossposted categories', async () => {
+		const { tid } = await createTopic();
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		// posts/votes/views are only ever written for the topic's own category,
+		// so stand in for the drift that accumulates there
+		await db.sortedSetAddBulk([
+			[`cid:${targetCategory.cid}:tids:posts`, 0, tid],
+			[`cid:${targetCategory.cid}:tids:votes`, -5, tid],
+			[`cid:${targetCategory.cid}:tids:views`, 0, tid],
+		]);
+
+		const [crossposts, topicData] = await Promise.all([
+			topics.crossposts.get(tid),
+			topics.getTopicData(tid),
+		]);
+		await topics.crossposts.syncCrosspostedTopicCids(crossposts, topicData);
+
+		const scores = await db.sortedSetsScore([
+			`cid:${targetCategory.cid}:tids:posts`,
+			`cid:${targetCategory.cid}:tids:votes`,
+			`cid:${targetCategory.cid}:tids:views`,
+		], tid);
+		assert.deepStrictEqual(scores, [topicData.postcount, topicData.votes, topicData.viewcount]);
+	});
+
+	it('should leave a pinned topic out of the reconciled zsets', async () => {
+		const { tid } = await createTopic();
+		await topics.tools.pin(tid, adminUid);
+		await topics.crossposts.add(tid, targetCategory.cid, uid);
+
+		const [crossposts, topicData] = await Promise.all([
+			topics.crossposts.get(tid),
+			topics.getTopicData(tid),
+		]);
+		await topics.crossposts.syncCrosspostedTopicCids(crossposts, topicData);
+
+		const scores = await db.sortedSetsScore([
+			`cid:${targetCategory.cid}:tids:posts`,
+			`cid:${targetCategory.cid}:tids:votes`,
+			`cid:${targetCategory.cid}:tids:views`,
+		], tid);
+		assert(scores.every(score => score === null), 'a pinned topic should not be re-added to these sets');
+	});
+
 	it('should remove the topic from the destination sets when uncrossposted', async () => {
 		const { tid } = await createTopic();
 		await topics.crossposts.add(tid, targetCategory.cid, uid);


### PR DESCRIPTION
Second of the two PRs from https://github.com/NodeBB/NodeBB/issues/14659#issuecomment-5399904821, implementing @barisusakli's sketch.

`:tids:posts`, `:tids:votes` and `:tids:views` are written cid-scoped ([onNewPostMade](https://github.com/NodeBB/NodeBB/blob/master/src/categories/topics.js#L191), [votes](https://github.com/NodeBB/NodeBB/blob/master/src/posts/votes.js#L300), [views](https://github.com/NodeBB/NodeBB/blob/master/src/topics/posts.js#L341)), so a crossposted category keeps the values it was seeded with and `most_posts` / `most_votes` / `most_views` order crossposted topics by a snapshot that never moves.

`Crossposts.syncCrosspostedTopicCids(crossposts, topicData)` lives in `crossposts.js` and is called from the topic controller, which already resolves the crossposts. One `sortedSetsScore` for the three keys per crossposted cid, and only the drifted ones are written back — a topic whose counts have not moved costs a read and no writes. Pinned topics are skipped, since `togglePin()` keeps them out of these zsets by design.

The call is not awaited, matching the `activitypub.notes.backfill()` precedent a few lines below it: this is a background repair and should not sit in front of the render.

Two notes on the shape, both deliberate but worth being explicit about:

- The controller's `crossposts` list is privilege-filtered by the viewer's uid, so a viewer who cannot `find` one of the crossposted categories will not reconcile that cid. It converges as soon as anyone who can see it opens the topic, and fetching an unfiltered list would defeat the point of reusing what the controller already loaded.
- `viewcount` is the one field where the "only write what drifted" guard rarely holds, since it moves on nearly every load — so in practice a trafficked crossposted topic writes once per render. If you would rather avoid that, views could instead be written to the crossposted cids inside `Topics.increaseViewCount()`, which already does a `sortedSetsAdd` to `cid:<cid>:tids:views` and is already session-throttled, and dropped from this helper. Left as-is here to match your sketch; happy to switch it.

Tests cover reconciliation of drifted scores and the pinned skip.

Note: I could not run the suite locally (no mongod available on this machine at the moment), so the new tests have only been linted — relying on CI rather than claiming otherwise.
