### PR TITLE
fix: hide imagedrop overlay when drag ends outside of it

### DIFF
--- a/public/src/modules/uploadHelpers.js
+++ b/public/src/modules/uploadHelpers.js
@@ -65,8 +65,23 @@ define('uploadHelpers', ['alerts'], function (alerts) {
 		const postContainer = options.container;
 		const drop = options.container.find('.imagedrop');
 
+		function onDocumentDragLeave(e) {
+			// relatedTarget is null when the drag left the window or was cancelled with esc
+			if (!e.originalEvent.relatedTarget) {
+				hideDrop();
+			}
+		}
+
+		function hideDrop() {
+			drop.hide();
+			drop.off('dragleave', hideDrop);
+			$(document)
+				.off('dragend drop', hideDrop)
+				.off('dragleave', onDocumentDragLeave);
+		}
+
 		postContainer.on('dragenter', function onDragEnter() {
-			if (draggingDocument) {
+			if (draggingDocument || drop.is(':visible')) {
 				return;
 			}
 			drop.css('top', '0px');
@@ -74,10 +89,12 @@ define('uploadHelpers', ['alerts'], function (alerts) {
 			drop.css('line-height', postContainer.height() + 'px');
 			drop.show();
 
-			drop.on('dragleave', function () {
-				drop.hide();
-				drop.off('dragleave');
-			});
+			drop.on('dragleave', hideDrop);
+			// the drag can end without dragleave/drop ever firing on the overlay
+			// (cancelled with esc, or dropped outside of it), leaving it stuck open
+			$(document)
+				.on('dragend drop', hideDrop)
+				.on('dragleave', onDocumentDragLeave);
 		});
 
 		drop.on('drop', function onDragDrop(e) {
@@ -98,7 +115,7 @@ define('uploadHelpers', ['alerts'], function (alerts) {
 				});
 			}
 
-			drop.hide();
+			hideDrop();
 			return false;
 		});
 
@@ -112,8 +129,8 @@ define('uploadHelpers', ['alerts'], function (alerts) {
 			.on('dragstart', function () {
 				draggingDocument = true;
 			})
-			.off('dragend')
-			.on('dragend, mouseup', function () {
+			.off('dragend mouseup')
+			.on('dragend mouseup', function () {
 				draggingDocument = false;
 			});
 


### PR DESCRIPTION
## Problem

The `.imagedrop` overlay ("Drag images here") shown while dragging files over the chat/composer is only hidden by `dragleave` or `drop` events fired **on the overlay itself**. If the drag ends any other way, the overlay stays visible with `display: block` and swallows all clicks — the page appears completely frozen until a full reload.

Ways to get it stuck:
- start dragging a file over the chat, then cancel with <kbd>Esc</kbd>
- drop the file outside the overlay (e.g. on the browser UI or another window)
- drag out of the window quickly before the pointer ever enters the overlay element

Reproduced on the `chats` page (harmony), but the same helper is used by the composer.

## Fix

- Bind `dragend`/`drop` on the document and `dragleave` (with `relatedTarget === null`, i.e. the drag left the window or was cancelled) while the overlay is shown, and hide the overlay from there. Handlers are removed again as soon as the overlay hides, so nothing accumulates.
- Guard `dragenter` so repeated events don't stack duplicate `dragleave` handlers on the overlay.
- Fix a pre-existing typo: `.on('dragend, mouseup', ...)` — jQuery separates event names with spaces, so the `dragend` handler was never actually bound (`dragend,` is not a valid event type).