### PR TITLE
fix: scroll chats list to the active room

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -68,7 +68,6 @@ define('forum/chats', [
 
 		Chats.addEventListeners();
 		Chats.setActive(ajaxify.data.roomId);
-		loadActiveRoomIntoNav(ajaxify.data.roomId);
 
 		if (env === 'md' || env === 'lg' || env === 'xl' || env === 'xxl') {
 			Chats.addHotkeys();
@@ -779,26 +778,6 @@ define('forum/chats', [
 
 		chatNavWrapper.attr('data-loaded', roomId ? '1' : '0');
 	};
-
-	// if the active room is not in the initially rendered list, keep
-	// loading more rooms until it is found, then highlight and reveal it
-	async function loadActiveRoomIntoNav(roomId) {
-		if (!roomId) {
-			return;
-		}
-		let chatEl = chatNavWrapper.find(`[data-roomid="${roomId}"]`);
-		while (!chatEl.length) {
-			// eslint-disable-next-line no-await-in-loop
-			const loadedMore = await recentChats.loadMore();
-			if (!loadedMore) {
-				return;
-			}
-			chatEl = chatNavWrapper.find(`[data-roomid="${roomId}"]`);
-		}
-		if (!chatEl.hasClass('active')) {
-			Chats.setActive(roomId);
-		}
-	}
 
 	return Chats;
 });

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -68,6 +68,7 @@ define('forum/chats', [
 
 		Chats.addEventListeners();
 		Chats.setActive(ajaxify.data.roomId);
+		loadActiveRoomIntoNav(ajaxify.data.roomId);
 
 		if (env === 'md' || env === 'lg' || env === 'xl' || env === 'xxl') {
 			Chats.addHotkeys();
@@ -762,6 +763,9 @@ define('forum/chats', [
 			socket.emit('modules.chats.enter', roomId);
 			const chatEl = chatNavWrapper.find(`[data-roomid="${roomId}"]`);
 			chatEl.addClass('active');
+			if (chatEl.length) {
+				chatEl[0].scrollIntoView({ block: 'nearest' });
+			}
 			if (chatEl.hasClass('unread')) {
 				api.del(`/chats/${roomId}/state`, {});
 				chatEl.removeClass('unread');
@@ -775,6 +779,26 @@ define('forum/chats', [
 
 		chatNavWrapper.attr('data-loaded', roomId ? '1' : '0');
 	};
+
+	// if the active room is not in the initially rendered list, keep
+	// loading more rooms until it is found, then highlight and reveal it
+	async function loadActiveRoomIntoNav(roomId) {
+		if (!roomId) {
+			return;
+		}
+		let chatEl = chatNavWrapper.find(`[data-roomid="${roomId}"]`);
+		while (!chatEl.length) {
+			// eslint-disable-next-line no-await-in-loop
+			const loadedMore = await recentChats.loadMore();
+			if (!loadedMore) {
+				return;
+			}
+			chatEl = chatNavWrapper.find(`[data-roomid="${roomId}"]`);
+		}
+		if (!chatEl.hasClass('active')) {
+			Chats.setActive(roomId);
+		}
+	}
 
 	return Chats;
 });

--- a/public/src/client/chats/recent.js
+++ b/public/src/client/chats/recent.js
@@ -19,49 +19,76 @@ define('forum/chats/recent', ['alerts', 'api', 'chat'], function (alerts, api, c
 					chat.toggleReadState(chatEl);
 				});
 
+			let previousScrollTop = $('[component="chat/recent"]').scrollTop();
 			$('[component="chat/recent"]').on('scroll', utils.debounce(function () {
 				const $this = $(this);
-				const bottom = ($this[0].scrollHeight - $this.height()) * 0.9;
-				if ($this.scrollTop() > bottom) {
-					loadMoreRecentChats();
+				const currentScrollTop = $this.scrollTop();
+				const direction = currentScrollTop > previousScrollTop ? 1 : -1;
+				previousScrollTop = currentScrollTop;
+				const scrollPercent = 100 * (currentScrollTop / ($this[0].scrollHeight - $this.height()));
+				if (direction === 1 && scrollPercent > 85) {
+					loadMoreRecentChats(direction);
+				} else if (direction === -1 && scrollPercent < 15) {
+					loadMoreRecentChats(direction);
 				}
 			}, 100));
 		});
 	};
 
-	async function loadMoreRecentChats() {
+	async function loadMoreRecentChats(direction) {
 		const recentChats = $('[component="chat/recent"]');
 		if (recentChats.attr('loading')) {
-			return false;
+			return;
+		}
+		const prevStart = parseInt(recentChats.attr('data-prevstart'), 10) || 0;
+		if (direction < 0 && prevStart <= 0) {
+			return;
+		}
+		const params = { uid: ajaxify.data.uid };
+		if (direction > 0) {
+			params.start = recentChats.attr('data-nextstart');
+		} else {
+			params.start = Math.max(0, prevStart - 30);
+			params.perPage = prevStart - params.start;
 		}
 		recentChats.attr('loading', 1);
 		try {
-			const { rooms, nextStart } = await api.get(`/chats`, {
-				uid: ajaxify.data.uid,
-				start: recentChats.attr('data-nextstart'),
-			});
+			const { rooms, nextStart } = await api.get(`/chats`, params);
 			if (rooms.length) {
-				await onRecentChatsLoaded({ rooms, nextStart });
-				recentChats.attr('data-nextstart', nextStart);
+				await onRecentChatsLoaded({ rooms, nextStart }, direction);
+				if (direction > 0) {
+					recentChats.attr('data-nextstart', nextStart);
+				} else {
+					recentChats.attr('data-prevstart', params.start);
+				}
 			}
-			return rooms.length > 0;
 		} catch (err) {
 			alerts.error(err);
-			return false;
 		} finally {
 			recentChats.removeAttr('loading');
 		}
 	}
 
-	recent.loadMore = loadMoreRecentChats;
-
-	async function onRecentChatsLoaded(data) {
+	async function onRecentChatsLoaded(data, direction) {
 		if (!data.rooms.length) {
 			return;
 		}
-		data.loadingMore = true;
+		if (direction > 0) {
+			data.loadingMore = true;
+		} else {
+			data.showBottomHr = true;
+		}
 		const html = await app.parseAndTranslate('chats', 'rooms', data);
-		$('[component="chat/recent"]').append(html);
+		const recentChats = $('[component="chat/recent"]');
+		if (direction > 0) {
+			recentChats.append(html);
+		} else {
+			// preserve the scroll position when prepending rooms above the viewport
+			const listEl = recentChats.get(0);
+			const previousHeight = listEl.scrollHeight;
+			recentChats.prepend(html);
+			listEl.scrollTop += listEl.scrollHeight - previousHeight;
+		}
 		html.find('.timeago').timeago();
 	}
 

--- a/public/src/client/chats/recent.js
+++ b/public/src/client/chats/recent.js
@@ -32,34 +32,37 @@ define('forum/chats/recent', ['alerts', 'api', 'chat'], function (alerts, api, c
 	async function loadMoreRecentChats() {
 		const recentChats = $('[component="chat/recent"]');
 		if (recentChats.attr('loading')) {
-			return;
+			return false;
 		}
 		recentChats.attr('loading', 1);
-		api.get(`/chats`, {
-			uid: ajaxify.data.uid,
-			start: recentChats.attr('data-nextstart'),
-		}).then(({ rooms, nextStart }) => {
+		try {
+			const { rooms, nextStart } = await api.get(`/chats`, {
+				uid: ajaxify.data.uid,
+				start: recentChats.attr('data-nextstart'),
+			});
 			if (rooms.length) {
-				onRecentChatsLoaded({ rooms, nextStart }, function () {
-					recentChats.removeAttr('loading');
-					recentChats.attr('data-nextstart', nextStart);
-				});
-			} else {
-				recentChats.removeAttr('loading');
+				await onRecentChatsLoaded({ rooms, nextStart });
+				recentChats.attr('data-nextstart', nextStart);
 			}
-		}).catch(alerts.error);
+			return rooms.length > 0;
+		} catch (err) {
+			alerts.error(err);
+			return false;
+		} finally {
+			recentChats.removeAttr('loading');
+		}
 	}
 
-	function onRecentChatsLoaded(data, callback) {
+	recent.loadMore = loadMoreRecentChats;
+
+	async function onRecentChatsLoaded(data) {
 		if (!data.rooms.length) {
-			return callback();
+			return;
 		}
 		data.loadingMore = true;
-		app.parseAndTranslate('chats', 'rooms', data, function (html) {
-			$('[component="chat/recent"]').append(html);
-			html.find('.timeago').timeago();
-			callback();
-		});
+		const html = await app.parseAndTranslate('chats', 'rooms', data);
+		$('[component="chat/recent"]').append(html);
+		html.find('.timeago').timeago();
 	}
 
 

--- a/src/controllers/accounts/chats.js
+++ b/src/controllers/accounts/chats.js
@@ -30,8 +30,16 @@ chatsController.get = async function (req, res, next) {
 	};
 	const isSwitch = res.locals.isAPI && parseInt(req.query.switch, 10) === 1;
 	if (!isSwitch) {
+		let start = 0;
+		if (req.params.roomid) {
+			const roomIndex = await db.sortedSetRevRank(`uid:${uid}:chat:rooms`, req.params.roomid);
+			if (roomIndex !== null) {
+				// render the list around the selected room so it is visible without paging from the top
+				start = Math.max(0, roomIndex - 2);
+			}
+		}
 		const [recentChats, publicRooms, privateRoomCount] = await Promise.all([
-			messaging.getRecentChats(req.uid, uid, 0, 29),
+			messaging.getRecentChats(req.uid, uid, start, start + 29),
 			messaging.getPublicRooms(req.uid, uid),
 			db.sortedSetCard(`uid:${uid}:chat:rooms`),
 		]);
@@ -40,6 +48,7 @@ chatsController.get = async function (req, res, next) {
 		}
 		payload.rooms = recentChats.rooms;
 		payload.nextStart = recentChats.nextStart;
+		payload.prevStart = start;
 		payload.publicRooms = publicRooms;
 		payload.privateRoomCount = privateRoomCount;
 	}

--- a/src/views/chats.tpl
+++ b/src/views/chats.tpl
@@ -46,7 +46,7 @@
 					</div>
 					{{{ end }}}
 
-					<div id="private-rooms" component="chat/recent" class="chats-list overflow-auto mb-0 pe-1 pb-5 pb-lg-0 collapse show ghost-scrollbar" data-nextstart="{nextStart}">
+					<div id="private-rooms" component="chat/recent" class="chats-list overflow-auto mb-0 pe-1 pb-5 pb-lg-0 collapse show ghost-scrollbar" data-nextstart="{nextStart}" data-prevstart="{prevStart}">
 						{{{ each rooms }}}
 						<!-- IMPORT partials/chats/recent_room.tpl -->
 						{{{ end }}}


### PR DESCRIPTION
## Problem

When opening a chat room directly (via URL or a notification link), the room list sidebar always starts scrolled to the top:

1. If the active room is further down the list, it is highlighted but out of view — the user has to scroll manually to find it.
2. If the room is beyond the initially rendered page of recent chats (position 31+), it does not appear in the list at all until the user happens to scroll far enough to trigger the infinite scroll.

## Fix

- `Chats.setActive` now scrolls the active room element into view (`scrollIntoView({ block: 'nearest' })`, so it is a no-op when the element is already visible — e.g. when switching rooms by clicking the list). This also keeps the active room visible when navigating with the ctrl+up/down hotkeys.
- On page load, if the active room is not in the rendered list, more recent chats are loaded page by page until the room appears, and it is then highlighted and revealed.
- `loadMoreRecentChats` in `forum/chats/recent` was refactored to async/await and exposed as `recent.loadMore`, returning whether more rooms were loaded (also stops re-requesting once the list is exhausted).