### PR TITLE
fix: user profile age calculated a few days early

### DIFF
--- a/src/controllers/accounts/helpers.js
+++ b/src/controllers/accounts/helpers.js
@@ -53,10 +53,7 @@ helpers.getUserDataByUserSlug = async function (userslug, callerUID, query = {})
 		delete userData.reputation;
 	}
 
-	userData.age = Math.max(
-		0,
-		userData.birthday ? Math.floor((new Date().getTime() - new Date(userData.birthday).getTime()) / 31536000000) : 0
-	);
+	userData.age = Math.max(0, calculateAge(userData.birthday));
 
 	userData = await user.hidePrivateData(userData, callerUID);
 	userData.emailHidden = !userSettings.showemail;
@@ -346,6 +343,23 @@ async function getProfileMenu(uid, callerUID) {
 		}
 	});
 	return data;
+}
+
+function calculateAge(birthday) {
+	if (!birthday) {
+		return 0;
+	}
+	const birthDate = new Date(birthday);
+	const today = new Date();
+	let age = today.getFullYear() - birthDate.getFullYear();
+	const hasHadBirthdayThisYear = (
+		today.getMonth() > birthDate.getMonth() ||
+		(today.getMonth() === birthDate.getMonth() && today.getDate() >= birthDate.getDate())
+	);
+	if (!hasHadBirthdayThisYear) {
+		age -= 1;
+	}
+	return age;
 }
 
 async function parseAboutMe(userData) {


### PR DESCRIPTION
The displayed age on a profile was computed by dividing the elapsed time since the birthday by a fixed 31536000000ms (exactly 365 days). Since a calendar year is actually about 365.24 days, the leap days accumulated over roughly 18 years add up to enough extra milliseconds that the floor division crosses the next integer several days before the person's real birthday.

Replaced it with a straightforward calendar-based calculation (compare year, then month/day) so the age only increments on the actual birthday.