### PR TITLE
fix: check upload folder containment in admin uploadFile

### DIFF
--- a/src/controllers/admin/uploads.js
+++ b/src/controllers/admin/uploads.js
@@ -233,7 +233,9 @@ uploadsController.uploadFile = async function (req, res, next) {
 		return next(new Error('[[error:invalid-json]]'));
 	}
 
-	if (!await file.exists(path.join(nconf.get('upload_path'), params.folder))) {
+	const uploadPath = nconf.get('upload_path');
+	const targetFolder = path.join(uploadPath, params.folder || '');
+	if (!file.isPathInside(uploadPath, targetFolder) || !await file.exists(targetFolder)) {
 		return next(new Error('[[error:invalid-path]]'));
 	}
 

--- a/test/uploads.js
+++ b/test/uploads.js
@@ -692,6 +692,17 @@ describe('Upload Controllers', () => {
 			assert.strictEqual(body.error, '[[error:invalid-path]]');
 		});
 
+		it('should fail to upload regular file to an existing directory outside of upload_path', async () => {
+			const { response, body } = await helpers.uploadFile(`${nconf.get('url')}/api/admin/upload/file`, path.join(__dirname, '../test/files/test.png'), {
+				params: JSON.stringify({
+					folder: '../',
+				}),
+			}, jar, csrf_token);
+
+			assert.equal(response.statusCode, 500);
+			assert.strictEqual(body.error, '[[error:invalid-path]]');
+		});
+
 		it('should fail to upload regular file if directory does not exist', async () => {
 			const { response, body } = await helpers.uploadFile(`${nconf.get('url')}/api/admin/upload/file`, path.join(__dirname, '../test/files/test.png'), {
 				params: JSON.stringify({


### PR DESCRIPTION
`uploadsController.uploadFile` validates `params.folder` by checking only that the joined path *exists*:

```js
if (!await file.exists(path.join(nconf.get('upload_path'), params.folder))) {
	return next(new Error('[[error:invalid-path]]'));
}
```

Any traversal that lands on an existing ancestor directory passes that check — `folder: "../"` is always satisfied, since the parent of `upload_path` exists by definition. Containment is currently only enforced one layer down, by the `isPathInside` check inside `file.saveFileToLocal`, plus the incidental fact that `saveFileToLocal` slugifies each dot-separated part of the filename, which neuters `..`.

`uploadsController.get` in the same file already does this properly, so this brings `uploadFile` in line with it:

- validate the target folder with `file.isPathInside` before touching the filesystem
- default `params.folder` to `''`, so a request omitting `folder` no longer throws out of `path.join` (it previously produced a `TypeError` rather than `[[error:invalid-path]]`)

Added a test covering `folder: "../"`, which the existing `folder: "../../system"` case does not reach — that one is rejected by the `exists` check before containment ever matters.