### PR TITLE
fix: anchor the assets/uploads strip in routeTouchIcon

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -150,7 +150,11 @@ middleware.routeTouchIcon = function routeTouchIcon(req, res) {
 	let iconPath;
 	if (brandTouchIcon) {
 		const uploadPath = nconf.get('upload_path');
-		iconPath = path.join(uploadPath, brandTouchIcon.replace(/assets\/uploads/, ''));
+		// brand:touchIcon is stored as a public url path, e.g. /assets/uploads/system/touchicon-orig.png
+		const relativePath = path.normalize(brandTouchIcon)
+			.replace(/^[/\\]+/, '')
+			.replace(/^assets[/\\]uploads[/\\]?/, '');
+		iconPath = path.join(uploadPath, relativePath);
 		if (!file.isPathInside(uploadPath, iconPath)) {
 			return res.status(404).send('Not found');
 		}


### PR DESCRIPTION
`middleware.routeTouchIcon` turns the `brand:touchIcon` url path into a filesystem path like this:

```js
iconPath = path.join(uploadPath, brandTouchIcon.replace(/assets\/uploads/, ''));
```

The regex is neither anchored nor global, so it strips the *first* occurrence of `assets/uploads` wherever it happens to sit in the string, instead of removing the leading prefix. For a value like `/assets/uploads/assets/uploads/x.png` that leaves a mangled path, and for a value where the substring appears in the middle it removes the wrong segment.

The `file.isPathInside` check underneath does stop this from escaping `upload_path`, so this isn't a traversal — the parse is just wrong, and correctness here shouldn't rest on the guard below it.

Normalize the value first (so `..` segments are resolved before anything is stripped), then remove a leading separator run and an anchored `assets/uploads/` prefix. `isPathInside` stays as the final guard.

Both existing cases still behave the same: `/assets/uploads/system/touchicon-orig.png` resolves and serves (test/uploads.js), and `../../not/valid` 404s (test/controllers.js).