### PR TITLE
feat: link chat reply quote timestamp to the quoted message

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -79,12 +79,6 @@ define('forum/chats', [
 			messages.toggleScrollUpAlert(chatContentEl);
 			const scrollToEl = chatContentEl.find(`[data-index="${ajaxify.data.scrollToIndex - 1}"]`);
 			messages.scrollToMessageAfterImageLoad(chatContentEl, scrollToEl);
-			if (scrollToEl) {
-				scrollToEl.addClass('highlight-pulse');
-				setTimeout(() => {
-					scrollToEl.removeClass('highlight-pulse');
-				}, 5000);
-			}
 		} else {
 			messages.scrollToBottomAfterImageLoad(chatContentEl);
 		}
@@ -203,6 +197,17 @@ define('forum/chats', [
 		});
 	};
 
+	function gotoMessage(event, timestampEl) {
+		const mid = timestampEl.parents('[data-parent-mid]').attr('data-parent-mid');
+		const containerEl = timestampEl.parents('[component="chat/message/content"]');
+		const messageEl = containerEl.find(`[component="chat/message"][data-mid="${mid}"]`);
+		if (messageEl.length) {
+			event.preventDefault();
+			messages.scrollToMessage(messageEl);
+			return false;
+		}
+	}
+
 	Chats.addParentHandler = function (mainWrapper) {
 		mainWrapper.off('click', '[component="chat/message/parent"]')
 			.on('click', '[component="chat/message/parent"]', function () {
@@ -214,6 +219,12 @@ define('forum/chats', [
 				if (chatContent.length && messages.isAtBottom(chatContent)) {
 					messages.scrollToBottom(chatContent);
 				}
+			});
+
+		// deeper selector, so this runs before the collapse handler above
+		mainWrapper.off('click', '[component="chat/message/parent"] .chat-timestamp')
+			.on('click', '[component="chat/message/parent"] .chat-timestamp', function (ev) {
+				return gotoMessage(ev, $(this));
 			});
 	};
 

--- a/public/src/client/chats/messages.js
+++ b/public/src/client/chats/messages.js
@@ -161,8 +161,18 @@ define('forum/chats/messages', [
 		if (containerEl.length && msgEl.length) {
 			const msgBodyEls = containerEl[0].querySelectorAll('[component="chat/message/body"]');
 			imagesLoaded(msgBodyEls, () => {
-				msgEl[0].scrollIntoView(true);
+				messages.scrollToMessage(msgEl);
 			});
+		}
+	};
+
+	messages.scrollToMessage = function (msgEl) {
+		if (msgEl && msgEl.length) {
+			msgEl[0].scrollIntoView(true);
+			msgEl.addClass('highlight-pulse');
+			setTimeout(() => {
+				msgEl.removeClass('highlight-pulse');
+			}, 5000);
 		}
 	};
 

--- a/src/views/partials/chats/parent.tpl
+++ b/src/views/partials/chats/parent.tpl
@@ -5,7 +5,7 @@
 				<a href="{config.relative_path}/user/{messages.parent.user.userslug}" class="text-decoration-none lh-1">{{buildAvatar(messages.parent.user, "14px", true, "not-responsive align-middle")}}</a>
 				<a class="chat-user fw-semibold text-truncate" style="max-width: 150px;" href="{config.relative_path}/user/{messages.parent.user.userslug}">{{txDisplayname(messages.parent.user)}}</a>
 			</div>
-			<span class="chat-timestamp text-muted timeago text-nowrap hidden" title="{messages.parent.timestampISO}"></span>
+			<a href="{config.relative_path}/message/{messages.parent.mid}" class="chat-timestamp text-muted timeago text-nowrap hidden" title="{messages.parent.timestampISO}"></a>
 		</div>
 		<div component="chat/message/parent/content" class="text-muted line-clamp-1 text-break w-100">{{{ if messages.parent.txContent }}}{{tx(messages.parent.content)}}{{{ else }}}{{messages.parent.content}}{{{ end }}}</div>
 	</div>


### PR DESCRIPTION
### Problem

In topics, the timestamp on a reply's quoted parent is a link to that post, and clicking it scrolls straight to the post when it is already rendered (`gotoPost` in `forum/topic`). So from a reply you can always get back to the full text of what it quotes.

Chat replies render the same quote block, but the timestamp there is an inert `<span>` — there is no way to get from a quote back to the message it quotes. The permalink already exists (the `copy-link` message action produces `/message/{mid}`), it just was not wired to anything clickable in the quote.

### Change

Give the chat quote timestamp the same behaviour as the topic one:

- `src/views/partials/chats/parent.tpl` — the timestamp becomes an `<a href="/message/{messages.parent.mid}">`, the same permalink `copy-link` produces, which redirects to the room at the quoted message's index.
- `public/src/client/chats.js` — when the quoted message is already in the rendered window, intercept the click and scroll to it in place instead of reloading the room. Otherwise the link is followed normally.

The click handler is registered on the deeper `.chat-timestamp` selector so it runs before the existing collapse/expand handler on the quote block and stops it, mirroring how `forum/topic` orders those same two handlers.

`gotoMessage` resolves the target only within the clicked quote's own `[component="chat/message/content"]`, so a quote shown in the pinned-messages panel (which is not inside that container) falls through to the permalink rather than scrolling to the wrong copy of the message. It also works in the popout chat modal, where `addParentHandler` is bound to the content element itself.

### Refactor

Highlighting on jump moves into a new `messages.scrollToMessage`, shared by this path and the existing `scrollToIndex` path on room load. That also drops a truthiness check on a jQuery object in the latter (`if (scrollToEl)`), which was always true.

### Testing

- Reply to a message in a room, expand the quote, click the timestamp → scrolls to the quoted message in place and pulses it, without a page load.
- Reply to a message far enough back that it is outside the loaded window → the link loads the room at that message's index, same as the copy-link permalink.
- Clicking the quote body (not the timestamp) still collapses/expands as before.
- Verified in the full chat page and in the popout chat modal.
- No theme overrides `partials/chats/parent.tpl`, so harmony/persona/lavender/peace all pick this up.
