### PR TITLE
feat: link pinned message timestamp to its place in the conversation

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -106,6 +106,7 @@ define('forum/chats', [
 		Chats.addScrollHandler(roomId, ajaxify.data.uid, chatMessageContent);
 		Chats.addScrollBottomHandler(roomId, chatMessageContent);
 		Chats.addParentHandler(chatMainWrapper);
+		Chats.addPinnedTimestampHandler(chatMainWrapper);
 		Chats.addCharactersLeftHandler(chatMainWrapper);
 		Chats.addTextareaResizeHandler(chatMainWrapper);
 		Chats.addTypingHandler(chatMainWrapper, roomId);
@@ -197,10 +198,13 @@ define('forum/chats', [
 		});
 	};
 
-	function gotoMessage(event, timestampEl) {
-		const mid = timestampEl.parents('[data-parent-mid]').attr('data-parent-mid');
-		const containerEl = timestampEl.parents('[component="chat/message/content"]');
-		const messageEl = containerEl.find(`[component="chat/message"][data-mid="${mid}"]`);
+	function gotoMessage(event, timestampEl, mid) {
+		// :visible because the conversation is swapped out for the message search
+		// results, and there is nothing to scroll while those are shown
+		const contentEl = timestampEl
+			.closest('[component="chat/message/window"]')
+			.find('[component="chat/message/content"]:visible');
+		const messageEl = contentEl.find(`[component="chat/message"][data-mid="${mid}"]`);
 		if (messageEl.length) {
 			event.preventDefault();
 			messages.scrollToMessage(messageEl);
@@ -224,7 +228,25 @@ define('forum/chats', [
 		// deeper selector, so this runs before the collapse handler above
 		mainWrapper.off('click', '[component="chat/message/parent"] .chat-timestamp')
 			.on('click', '[component="chat/message/parent"] .chat-timestamp', function (ev) {
-				return gotoMessage(ev, $(this));
+				const timestampEl = $(this);
+				return gotoMessage(
+					ev, timestampEl, timestampEl.parents('[data-parent-mid]').attr('data-parent-mid')
+				);
+			});
+	};
+
+	// a pinned message is shown out of context, so its own timestamp links back to
+	// where it sits in the conversation
+	Chats.addPinnedTimestampHandler = function (mainWrapper) {
+		// scoped to .message-header, as the timestamp of a quoted parent rendered in
+		// the panel is already handled by addParentHandler
+		const selector = '[component="chat/messages/pinned"] .message-header .chat-timestamp';
+		mainWrapper.off('click', selector)
+			.on('click', selector, function (ev) {
+				const timestampEl = $(this);
+				return gotoMessage(
+					ev, timestampEl, timestampEl.parents('[component="chat/message"]').attr('data-mid')
+				);
 			});
 	};
 

--- a/public/src/client/chats/pinned-messages.js
+++ b/public/src/client/chats/pinned-messages.js
@@ -30,6 +30,7 @@ define('forum/chats/pinned-messages', ['api', 'alerts'], function (api, alerts) 
 				if (data && data.length) {
 					const html = await parseMessages(data);
 					container.find('[component="chat/messages/pinned"]').append(html);
+					html.find('.timeago').timeago();
 				}
 			}
 		}, 200));

--- a/src/views/partials/chats/pinned-messages-list.tpl
+++ b/src/views/partials/chats/pinned-messages-list.tpl
@@ -9,7 +9,7 @@
 		<a href="{config.relative_path}/user/{messages.fromUser.userslug}" class="text-decoration-none">{{buildAvatar(messages.fromUser, "18px", true, "not-responsive")}}</a>
 		<span class="chat-user fw-semibold"><a href="{config.relative_path}/user/{messages.fromUser.userslug}">{{txDisplayname(messages.fromUser)}}</a></span>
 
-		<span class="chat-timestamp text-muted timeago" title="{messages.timestampISO}"></span>
+		<a href="{config.relative_path}/message/{messages.messageId}" class="chat-timestamp text-muted timeago" title="{messages.timestampISO}"></a>
 		<div component="chat/message/edited" class="text-muted ms-auto {{{ if !messages.edited }}}hidden{{{ end }}}" title="{{tx("global:edited-timestamp", isoTimeToLocaleString(messages.editedISO, config.userLang))}}"><i class="fa fa-edit"></i></span></div>
 	</div>
 	<div class="message-body-wrapper">


### PR DESCRIPTION
Follow-up to #14697, as requested — thanks for pointing at the pinned template.

### What was actually missing

`pinned-messages-list.tpl` already picked up the linked timestamp for a **quoted parent**, since it imports the shared `partials/chats/parent.tpl` (line 5). What was still an inert `<span>` is the timestamp of the **pinned message itself** (line 12) — and that is arguably the one most worth linking, because a pinned message is the one shown furthest out of context.

So this points it at `/message/{messageId}`, the same permalink `copy-link` produces, and jumps to the message in place when it is already rendered.

### The jump needed a small generalisation

`gotoMessage` resolved the conversation with `parents('[component="chat/message/content"]')`. That is empty for the pinned panel — the panel is a *sibling* of the conversation (`message-window.tpl` lines 27 and 51), not an ancestor. It now resolves from the enclosing `[component="chat/message/window"]`, which holds both, and works unchanged on all three surfaces that bind these handlers:

| surface | `chat/message/window` | pinned panel |
| --- | --- | --- |
| full page (`message-window.tpl`) | line 1 | yes |
| popout modal (`chat.tpl`) | `.modal-content` | no |
| chat widget (`nodebb-widget-essentials`) | line 2 | no |

Widening the lookup meant it needed a `:visible` filter: `forum/chats/message-search` hides the conversation (`chatContent.addClass('hidden')`) while results are shown, and results render `message.tpl`, quotes included. There is nothing to scroll in that state, so a quote timestamp clicked in search results keeps following the permalink instead of scrolling a hidden list — same as before this change.

The new pinned handler is scoped to `.message-header .chat-timestamp` rather than a JS guard, because both timestamps in that template carry `.chat-timestamp` and jQuery runs both delegated handlers when one element matches two selectors on the same delegate root — `return false` only stops propagation to the *next* element, not to a sibling handler on the same one.

### One drive-by fix

`pinnedMessages.refreshList` renders timeago on its output but `handleInfiniteScroll` did not, so pinned messages paged in by scrolling had an empty timestamp. Pre-existing, but it matters now: an empty inline element has no box, so those messages would have had nothing to click. One line.

### Deliberately not changed

The message's own timestamp in `message.tpl` — there the message is already in its place in the conversation, and it would change every message header on every surface. Happy to do it if you'd like it for consistency.

### Testing

- Pin a message, open the pinned panel, click its timestamp → scrolls to it in the conversation and pulses it, no page load.
- Pin an old message outside the loaded window → the link loads the room at that message's index.
- Click a quoted parent's timestamp inside the pinned panel → now also scrolls the conversation, instead of reloading the room as it did before.
- Open message search, click a quote timestamp in the results → still follows the permalink; the hidden conversation is not scrolled.
- Pin enough messages to page the panel, scroll it → timestamps render and are clickable.
- Full page, popout modal and chat widget all still behave as they did for quoted-parent timestamps.
