### PR TITLE
fix(federation): resolve analytics lint errors

### DIFF
--- a/public/src/admin/federation/analytics.js
+++ b/public/src/admin/federation/analytics.js
@@ -81,7 +81,7 @@ async function renderActivitiesByTypeLegend() {
 	const total = Object.values(byType).reduce((sum, v) => sum + v, 0);
 
 	const entries = Object.entries(byType)
-		.filter(([type, count]) => count > 0)
+		.filter(([, count]) => count > 0)
 		.sort(([, a], [, b]) => b - a);
 
 	const items = entries.map(([type, count], idx) => {
@@ -206,8 +206,9 @@ async function initializeCharts() {
 		labels: pieEntries.map(([type]) => type),
 		datasets: [{
 			data: pieEntries.map(([, count]) => count),
-			backgroundColor: pieEntries.map(([, count], idx) =>
-				pieColors[idx % pieColors.length]
+			backgroundColor: Array.from(
+				pieEntries.keys(),
+				idx => pieColors[idx % pieColors.length]
 			),
 		}],
 	};

--- a/src/controllers/admin/federation.js
+++ b/src/controllers/admin/federation.js
@@ -118,7 +118,7 @@ federationController.analytics = async function (req, res) {
 
 async function getActivitiesByType() {
 	const analyticsKeys = await db.getSortedSetRange('analyticsKeys', 0, -1);
-	const typeKeys = analyticsKeys.filter((key) => key.startsWith('activities:byType:'));
+	const typeKeys = analyticsKeys.filter(key => key.startsWith('activities:byType:'));
 
 	const results = await Promise.all(typeKeys.map(async (key) => {
 		const entries = await db.getSortedSetRangeWithScores(`analytics:${key}`, 0, -1);


### PR DESCRIPTION
Current `develop` CI currently stops at three ESLint errors introduced by the recent federation analytics changes:

- ignore the unused map entry in the non-zero filter
- generate pie-chart colors from entry keys without an unused count binding
- apply the repository's arrow-parens style in the controller

This is intentionally limited to lint-only changes. Full ESLint completes with zero errors; the three existing `no-await-in-loop` warnings in `src/activitypub/send.js` remain unchanged.

This also unblocks the current `develop` workflow and the otherwise isolated ActivityPub test PR #14584.