### PR TITLE
send rfc 9421

### DIFF
--- a/src/activitypub/sendWorker.js
+++ b/src/activitypub/sendWorker.js
@@ -4,6 +4,7 @@ const { fetch, Agent } = require('undici');
 const { check, lookup } = require('../ssrf');
 const Signatures = require('./signatures');
 const nconf = require('nconf');
+const winston = require('winston');
 const { version } = require('../../package.json');
 
 const agent = new Agent({
@@ -15,6 +16,50 @@ const agent = new Agent({
 });
 
 const MAX_BODY_SIZE = 10 * 1024 * 1024; // 10MB response limit
+
+async function post({ uri, headers, payload, userAgent }) {
+	// POST — redirect: 'manual' prevents SSRF via HTTP redirect
+	// 10s timeout to prevent stuck tasks
+	const timeoutSignal = AbortSignal.timeout(10000);
+
+	const response = await fetch(uri, {
+		method: 'POST',
+		headers: {
+			...headers,
+			'content-type': 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
+			'user-agent': userAgent,
+		},
+		body: payload,
+		signal: timeoutSignal,
+		redirect: 'manual',
+		dispatcher: agent,
+	});
+
+	// Validate Content-Length to prevent memory exhaustion
+	const contentLength = response.headers.get('content-length');
+	if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
+		return { success: false, error: 'Response body exceeds 10MB limit' };
+	}
+
+	if (String(response.status).startsWith('2')) {
+		return { success: true };
+	}
+
+	let bodyText = '';
+	try {
+		bodyText = await response.text();
+	} catch (e) { /* ignore */ }
+
+	return { success: false, error: `HTTP ${response.status}: ${bodyText}` };
+}
+
+async function attemptSend({ uri, headers, payload, userAgent }) {
+	try {
+		return await post({ uri, headers, payload, userAgent });
+	} catch (e) {
+		return { success: false, error: e.message || 'unknown error' };
+	}
+}
 
 async function send({ id, uri, payload, digest, key, keyId }) {
 	const userAgent = `NodeBB/${version.split('.').shift()}.x (${nconf.get('url')})`;
@@ -31,42 +76,22 @@ async function send({ id, uri, payload, digest, key, keyId }) {
 			return { id, success: false, error: 'SSRF check failed — reserved IP address' };
 		}
 
-		// Sign
-		const headers = await Signatures.sign({ key, keyId }, uri, 'POST', digest);
-
-		// POST — redirect: 'manual' prevents SSRF via HTTP redirect
-		// 10s timeout to prevent stuck tasks
-		const timeoutSignal = AbortSignal.timeout(10000);
-
-		const response = await fetch(uri, {
-			method: 'POST',
-			headers: {
-				...headers,
-				'content-type': 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"',
-				'user-agent': userAgent,
-			},
-			body: payload,
-			signal: timeoutSignal,
-			redirect: 'manual',
-			dispatcher: agent,
-		});
-
-		// Validate Content-Length to prevent memory exhaustion
-		const contentLength = response.headers.get('content-length');
-		if (contentLength && parseInt(contentLength, 10) > MAX_BODY_SIZE) {
-			return { id, success: false, error: 'Response body exceeds 10MB limit' };
-		}
-
-		if (String(response.status).startsWith('2')) {
+		// Sign with RFC 9421
+		const rfcHeaders = await Signatures.signRfc9421({ key, keyId }, uri, 'POST', digest);
+		const rfcResult = await attemptSend({ uri, headers: rfcHeaders, payload, userAgent });
+		if (rfcResult.success) {
 			return { id, success: true };
 		}
 
-		let bodyText = '';
-		try {
-			bodyText = await response.text();
-		} catch (e) { /* ignore */ }
+		// Fall back to signing with the draft method if the RFC 9421 request failed
+		winston.warn(`[activitypub/sendWorker] RFC 9421 request failed (${rfcResult.error}); retrying with draft signature`);
+		const draftHeaders = await Signatures.sign({ key, keyId }, uri, 'POST', digest);
+		const draftResult = await attemptSend({ uri, headers: draftHeaders, payload, userAgent });
+		if (draftResult.success) {
+			return { id, success: true };
+		}
 
-		return { id, success: false, error: `HTTP ${response.status}: ${bodyText}` };
+		return { id, success: false, error: draftResult.error };
 	} catch (e) {
 		return { id, success: false, error: e.message || 'unknown error' };
 	}

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -170,6 +170,25 @@ function getDraftAlgoString(key) {
 	return 'rsa-sha256';
 }
 
+// Verifies a Content-Digest header in RFC 9530 format (sha-256=:base64:)
+// Mitra and other RFC 9530 implementations use Content-Digest instead of Digest
+function verifyContentDigest(bodyData, contentDigestHeader) {
+	if (!contentDigestHeader) return true; // no header to verify
+	// RFC 9530: sha-256=:base64:  (Mitra uses sha-256=:base64==)
+	const match = contentDigestHeader.match(/^sha-256=:(.+)[=:]$/i);
+	if (!match) {
+		winston.warn('[activitypub/signatures] Invalid Content-Digest format');
+		return false;
+	}
+	const expectedB64 = match[1];
+	const computedB64 = createHash('sha256').update(bodyData).digest('base64');
+	if (expectedB64 !== computedB64) {
+		winston.warn('[activitypub/signatures] Content-Digest mismatch during request verification');
+		return false;
+	}
+	return true;
+}
+
 Signatures.verify = async (req, fetchPublicKeyFn) => {
 	try {
 		const { headers } = req;
@@ -181,19 +200,31 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 		}
 
 		const hasBody = req.rawBody || req.body;
-		if (hasBody && !headers.digest) {
-			winston.warn('[activitypub/signatures] Digest header required for requests with a body');
+		// Accept Digest (RFC 3230) or Content-Digest (RFC 9530) headers
+		const hasDigest = headers.digest || headers['content-digest'];
+		if (hasBody && !hasDigest) {
+			winston.warn('[activitypub/signatures] Digest/Content-Digest header required for requests with a body');
 			return false;
 		}
 
-		if (headers.digest) {
+		if (hasBody && (headers.digest || headers['content-digest'])) {
 			const bodyData = req.rawBody || (typeof req.body === 'string' ? req.body : JSON.stringify(req.body));
 			if (!bodyData) return false;
 
-			const computedDigest = Signatures.calculateDigest(bodyData);
-			if (headers.digest !== computedDigest) {
-				winston.warn('[activitypub/signatures] Digest mismatch during request verification');
-				return false;
+			// Verify RFC 3230 Digest header (SHA-256=base64)
+			if (headers.digest) {
+				const computedDigest = Signatures.calculateDigest(bodyData);
+				if (headers.digest !== computedDigest) {
+					winston.warn('[activitypub/signatures] Digest mismatch during request verification');
+					return false;
+				}
+			}
+
+			// Verify RFC 9530 Content-Digest header (sha-256=:base64:)
+			if (headers['content-digest']) {
+				if (!verifyContentDigest(bodyData, headers['content-digest'])) {
+					return false;
+				}
 			}
 		}
 
@@ -278,10 +309,13 @@ async function tryVerifyDraft(req, fetchPublicKeyFn) {
 			return false;
 		}
 
-		if (req.headers.digest) {
+		// Check digest/content-digest coverage in signed headers
+		const hasAnyDigest = req.headers.digest || req.headers['content-digest'];
+		if (hasAnyDigest) {
 			const signedHeaders = (parsed.value.params?.headers ?? [])
 				.map(h => h.toLowerCase());
-			if (!signedHeaders.includes('digest')) {
+			const hasDigestSigned = signedHeaders.includes('digest') || signedHeaders.includes('content-digest');
+			if (!hasDigestSigned) {
 				winston.warn('[activitypub/signatures] Digest header present but not included in signed headers (draft)');
 				return false;
 			}
@@ -348,11 +382,14 @@ async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
 				continue;
 			}
 
-			// When Digest header is present, it must be covered by the signature.
+			// When Digest/Content-Digest header is present, it must be covered by the signature.
 			// In RFC 9421 the signed components are the first element of the value array.
-			if (req.headers.digest) {
+			// Mitra uses content-digest, others use digest.
+			const hasAnyDigest = req.headers.digest || req.headers['content-digest'];
+			if (hasAnyDigest) {
 				const signedHeaders = components.map(([name]) => name.toLowerCase());
-				if (!signedHeaders.includes('digest')) {
+				const hasDigestSigned = signedHeaders.includes('digest') || signedHeaders.includes('content-digest');
+				if (!hasDigestSigned) {
 					continue; // this signature doesn't cover the digest; try the next one
 				}
 			}

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -236,7 +236,7 @@ Signatures.getKeyId = (headers) => {
 	return null;
 };
 
-function getRequestUrl(req) {
+function getRequestUrl(req, { useHostHeader = false } = {}) {
 	const relativePath = nconf.get('relative_path') || '';
 	let requestPath = req.originalUrl || req.url || req.path || '/';
 
@@ -244,7 +244,16 @@ function getRequestUrl(req) {
 		requestPath = `${relativePath}${requestPath.startsWith('/') ? '' : '/'}${requestPath}`;
 	}
 
-	const origin = nconf.get('url_parsed') ? nconf.get('url_parsed').origin : nconf.get('url');
+	let origin = nconf.get('url_parsed') ? nconf.get('url_parsed').origin : nconf.get('url');
+	// RFC 9421: reconstruct the target URI from the request itself (scheme +
+	// Host header + request-target). Prefer the Host header so verification
+	// also succeeds when the dialed host differs from the configured URL
+	// (reverse proxies, www vs non-www, port changes)
+	if (useHostHeader && req.headers && req.headers.host) {
+		const { protocol } = nconf.get('url_parsed') || { protocol: 'https:' };
+		origin = `${protocol}//${req.headers.host}`;
+	}
+
 	return new URL(requestPath, origin).href;
 }
 
@@ -301,7 +310,7 @@ async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
 			return false;
 		}
 
-		const fullUrl = getRequestUrl(req);
+		const fullUrl = getRequestUrl(req, { useHostHeader: true });
 		const requestObj = {
 			method: req.method,
 			url: fullUrl,

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -8,15 +8,17 @@ const {
 	genDraftSignatureHeader,
 	genDraftSigningString,
 	importPrivateKey,
+	importPublicKey,
 	verifyDraftSignature,
 	parseDraftRequest,
-	parseRFC9421Request,
-	verifyRFC9421Signature,
 	RFC9421SignatureBaseFactory,
 	getWebcrypto,
 } = require('@misskey-dev/node-http-message-signatures');
 
 const Signatures = module.exports;
+
+// Clock skew tolerance for RFC 9421 created/expires parameters (seconds)
+const RFC9421_CLOCK_SKEW = 300;
 
 // Calculates RFC 9530 Digest header string for request payloads.
 Signatures.calculateDigest = (body) => {
@@ -115,7 +117,7 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 
 		// Sign
 		const signatureBuffer = await (await getWebcrypto()).subtle.sign(
-			getSignAlgorithm(privateKey),
+			getKeyAlgorithm(privateKey),
 			privateKey,
 			new TextEncoder().encode(signatureBase),
 		);
@@ -126,7 +128,8 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 			date,
 			...(digest && { digest }),
 			'signature-input': signatureInput,
-			signature: `sig1=("${signature}")`,
+			// RFC 9421 2.3: the Signature value is an unquoted base64 byte sequence
+			signature: `sig1=${signature}`,
 		};
 	} catch (err) {
 		winston.error(`[activitypub/signatures] Sign (RFC 9421) error: ${err.message}`);
@@ -134,13 +137,13 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 	}
 };
 
-function getSignAlgorithm(key) {
+function getKeyAlgorithm(key) {
 	const { name, namedCurve } = key.algorithm;
-	if (name === 'RSASSA-PKCS1-v1_5') {
-		return { name, hash: 'SHA-256' };
+	if (name === 'RSASSA-PKCS1-v1_5' || name === 'RSA') {
+		return { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' };
 	}
-	if (name === 'ECDSA') {
-		return { name, hash: 'SHA-256', namedCurve };
+	if (name === 'ECDSA' || name === 'EC') {
+		return { name: 'ECDSA', hash: 'SHA-256', namedCurve };
 	}
 	if (name === 'Ed25519' || name === 'Ed448') {
 		return { name };
@@ -150,11 +153,14 @@ function getSignAlgorithm(key) {
 
 function getDraftAlgoString(key) {
 	const { name } = key.algorithm;
-	if (name === 'RSA') {
+	if (name === 'RSASSA-PKCS1-v1_5' || name === 'RSA') {
 		return 'rsa-sha256';
 	}
-	if (name === 'EC') {
+	if (name === 'ECDSA' || name === 'EC') {
 		return 'ecdsa-p256-sha256';
+	}
+	if (name === 'Ed25519' || name === 'Ed448') {
+		return 'ed25519-sha512';
 	}
 	return 'rsa-sha256';
 }
@@ -201,6 +207,30 @@ Signatures.verify = async (req, fetchPublicKeyFn) => {
 		winston.warn(`[activitypub/signatures] Verification failed: ${err.message}`);
 		return false;
 	}
+};
+
+// Extracts the key identifier from request signature headers.
+// Supports both the draft `keyId` parameter (last occurrence wins, matching
+// the draft parser) and the RFC 9421 `keyid` parameter in Signature-Input.
+Signatures.getKeyId = (headers) => {
+	if (headers['signature-input']) {
+		const match = String(headers['signature-input']).match(/keyid\s*=\s*"((?:[^"\\]|\\.)*)"/i);
+		if (match) {
+			return match[1];
+		}
+	}
+
+	if (headers.signature) {
+		const segments = String(headers.signature).split(',');
+		for (let i = segments.length - 1; i >= 0; i--) {
+			const match = segments[i].match(/^\s*keyId\s*=\s*"((?:[^"\\]|\\.)*)"\s*$/i);
+			if (match) {
+				return match[1];
+			}
+		}
+	}
+
+	return null;
 };
 
 function getRequestUrl(req) {
@@ -275,38 +305,108 @@ async function tryVerifyRFC9421(req, fetchPublicKeyFn) {
 			headers: req.headers,
 		};
 
-		// Parse RFC 9421 request signature
-		const parsed = parseRFC9421Request(requestObj);
-		const keyId = parsed?.value?.keyId || parsed?.keyId;
-
-		if (!parsed || !keyId) {
+		// The base factory parses the Signature-Input structured field (a
+		// dictionary of label → [component list, parameters]) on construction
+		const base = new RFC9421SignatureBaseFactory(requestObj);
+		const signatures = parseSignatureHeader(req.headers.signature);
+		if (!signatures.size) {
 			return false;
 		}
 
-		if (req.headers.digest) {
-			const signedHeaders = ((parsed.value?.params?.headers ?? []) || [])
-				.map(h => h.toLowerCase());
-			if (!signedHeaders.includes('digest')) {
-				winston.warn('[activitypub/signatures] Digest header present but not included in signed headers (RFC 9421)');
-				return false;
+
+		const now = Math.floor(Date.now() / 1000);
+
+		// Verify each labeled signature — any one verifying is sufficient
+		for (const [label, [components, params = new Map()]] of base.requestSignatureInput) {
+			// Parameter values are stored bare (no nested params for sig parameters)
+			const keyid = params.get('keyid');
+			if (typeof keyid !== 'string' || !keyid) {
+				continue;
+			}
+
+			// RFC 9421 2.6.1: check created/expires within clock skew
+			const created = params.get('created');
+			if (typeof created === 'number' && (Math.abs(now - created) > RFC9421_CLOCK_SKEW)) {
+				continue;
+			}
+			const expires = params.get('expires');
+			if (typeof expires === 'number' && (expires + RFC9421_CLOCK_SKEW < now)) {
+				continue;
+			}
+
+			// When Digest header is present, it must be covered by the signature.
+			// In RFC 9421 the signed components are the first element of the value array.
+			if (req.headers.digest) {
+				const signedHeaders = components.map(([name]) => name.toLowerCase());
+				if (!signedHeaders.includes('digest')) {
+					continue; // this signature doesn't cover the digest; try the next one
+				}
+			}
+
+			const signature = signatures.get(label);
+			if (!signature) {
+				continue;
+			}
+
+			// Fetch public key PEM
+			// eslint-disable-next-line no-await-in-loop
+			const publicKeyPem = await fetchPublicKeyFn(keyid, req.ip);
+			if (!publicKeyPem) {
+				throw new Error(`Public key not found for keyId: ${keyid}`);
+			}
+
+			// eslint-disable-next-line no-await-in-loop
+			const verified = await verifySignatureValue({
+				signatureBase: base.generate(label),
+				signature,
+				publicKeyPem,
+			});
+			if (verified) {
+				return true;
 			}
 		}
 
-		// Fetch public key PEM
-		const publicKeyPem = await fetchPublicKeyFn(keyId, req.ip);
-		if (!publicKeyPem) {
-			throw new Error(`Public key not found for keyId: ${keyId}`);
-		}
-
-		const result = await verifyRFC9421Signature(
-			parsed,
-			publicKeyPem,
-			msg => winston.warn(`[activitypub/signatures] verifyRFC9421Signature error: ${msg}`)
-		);
-
-		return !!result;
+		return false;
 	} catch (err) {
 		winston.debug(`[activitypub/signatures] RFC 9421 verification failed: ${err.message}`);
 		return false;
 	}
+}
+
+// Verifies an RFC 9421 signature value against a signature base using WebCrypto
+async function verifySignatureValue({ signatureBase, signature, publicKeyPem }) {
+	const publicKey = await importPublicKey(publicKeyPem, ['verify']);
+	const webcrypto = await getWebcrypto();
+	return await webcrypto.subtle.verify(
+		getKeyAlgorithm(publicKey),
+		publicKey,
+		Buffer.from(signature, 'base64'),
+		new TextEncoder().encode(signatureBase),
+	);
+}
+
+// Parses the Signature header (an RFC 8941 dictionary of label → base64 value)
+// into a Map of label → signature value
+function parseSignatureHeader(headerValue) {
+	const signatures = new Map();
+	for (const member of String(headerValue).split(',')) {
+		const eq = member.indexOf('=');
+		if (eq <= 0) {
+			continue;
+		}
+		const label = member.slice(0, eq).trim();
+		let value = member.slice(eq + 1).trim();
+		if (value.startsWith('"')) {
+			const end = value.indexOf('"', 1);
+			if (end === -1) {
+				continue;
+			}
+			value = value.slice(1, end);
+		}
+		if (!/^[0-9A-Za-z+/]*={0,2}$/.test(value)) {
+			continue;
+		}
+		signatures.set(label, value);
+	}
+	return signatures;
 }

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -94,7 +94,9 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 	}
 
 	// Determine signed components list
-	const components = ['@request-target', 'host', 'date'];
+	// @method + @target-uri (not @request-target) so that verifiers requiring
+	// those components explicitly (e.g. Mitra) can validate the signature
+	const components = ['@method', '@target-uri', 'host', 'date'];
 	if (digest) {
 		components.push('digest');
 	}
@@ -128,8 +130,9 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 			date,
 			...(digest && { digest }),
 			'signature-input': signatureInput,
-			// RFC 9421 2.3: the Signature value is an unquoted base64 byte sequence
-			signature: `sig1=${signature}`,
+			// RFC 9421 2.3: the Signature value is a structured-field byte
+			// sequence (":base64:" per RFC 8941/9651)
+			signature: `sig1=:${signature}:`,
 		};
 	} catch (err) {
 		winston.error(`[activitypub/signatures] Sign (RFC 9421) error: ${err.message}`);
@@ -396,7 +399,10 @@ function parseSignatureHeader(headerValue) {
 		}
 		const label = member.slice(0, eq).trim();
 		let value = member.slice(eq + 1).trim();
-		if (value.startsWith('"')) {
+		// RFC 8941/9651 byte sequence (colon-delimited base64) — the format RFC 9421 senders use
+		if (value.startsWith(':') && value.endsWith(':') && value.length > 2) {
+			value = value.slice(1, -1);
+		} else if (value.startsWith('"')) {
 			const end = value.indexOf('"', 1);
 			if (end === -1) {
 				continue;

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -93,6 +93,9 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 		headersToSign.digest = digest;
 	}
 
+	// Import private key early to determine algorithm for Signature-Input
+	const privateKey = await importPrivateKey(key, ['sign']);
+
 	// Determine signed components list
 	// @method + @target-uri (not @request-target) so that verifiers requiring
 	// those components explicitly (e.g. Mitra) can validate the signature
@@ -102,13 +105,12 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 	}
 
 	// Build Signature-Input header
-	const signatureInput = `sig1=("${components.join('" "')}");created=${created};keyid="${keyId}"`;
+	// RFC 9421 Section 2.2: algorithm parameter is required
+	const algorithm = getDraftAlgoString(privateKey);
+	const signatureInput = `sig1=("${components.join('" "')}");algorithm="${algorithm}";created=${created};keyid="${keyId}"`;
 	headersToSign['signature-input'] = signatureInput;
 
 	try {
-		// Import private key
-		const privateKey = await importPrivateKey(key, ['sign']);
-
 		// Build signature base
 		const base = new RFC9421SignatureBaseFactory({
 			method,

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -12,6 +12,8 @@ const {
 	parseDraftRequest,
 	parseRFC9421Request,
 	verifyRFC9421Signature,
+	RFC9421SignatureBaseFactory,
+	getWebcrypto,
 } = require('@misskey-dev/node-http-message-signatures');
 
 const Signatures = module.exports;
@@ -73,6 +75,78 @@ Signatures.sign = async ({ key, keyId }, url, method = 'GET', digest = null) => 
 		throw err;
 	}
 };
+
+Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = null) => {
+	const parsedUrl = new URL(url);
+	const date = new Date().toUTCString();
+	const created = Math.floor(Date.now() / 1000);
+
+	// Headers required for signing
+	const headersToSign = {
+		date,
+		host: parsedUrl.host,
+	};
+
+	if (digest) {
+		headersToSign.digest = digest;
+	}
+
+	// Determine signed components list
+	const components = ['@request-target', 'host', 'date'];
+	if (digest) {
+		components.push('digest');
+	}
+
+	// Build Signature-Input header
+	const signatureInput = `sig1=("${components.join('" "')}");created=${created};keyid="${keyId}"`;
+	headersToSign['signature-input'] = signatureInput;
+
+	try {
+		// Import private key
+		const privateKey = await importPrivateKey(key, ['sign']);
+
+		// Build signature base
+		const base = new RFC9421SignatureBaseFactory({
+			method,
+			url: parsedUrl.href,
+			headers: headersToSign,
+		});
+		const signatureBase = base.generate('sig1');
+
+		// Sign
+		const signatureBuffer = await (await getWebcrypto()).subtle.sign(
+			getSignAlgorithm(privateKey),
+			privateKey,
+			new TextEncoder().encode(signatureBase),
+		);
+
+		const signature = Buffer.from(signatureBuffer).toString('base64');
+
+		return {
+			date,
+			...(digest && { digest }),
+			'signature-input': signatureInput,
+			signature: `sig1=("${signature}")`,
+		};
+	} catch (err) {
+		winston.error(`[activitypub/signatures] Sign (RFC 9421) error: ${err.message}`);
+		throw err;
+	}
+};
+
+function getSignAlgorithm(key) {
+	const { name, namedCurve } = key.algorithm;
+	if (name === 'RSASSA-PKCS1-v1_5') {
+		return { name, hash: 'SHA-256' };
+	}
+	if (name === 'ECDSA') {
+		return { name, hash: 'SHA-256', namedCurve };
+	}
+	if (name === 'Ed25519' || name === 'Ed448') {
+		return { name };
+	}
+	throw new Error(`Unsupported key algorithm: ${name}`);
+}
 
 function getDraftAlgoString(key) {
 	const { name } = key.algorithm;

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -283,11 +283,22 @@ function getRequestUrl(req, { useHostHeader = false } = {}) {
 	// also succeeds when the dialed host differs from the configured URL
 	// (reverse proxies, www vs non-www, port changes)
 	if (useHostHeader && req.headers && req.headers.host) {
-		const { protocol } = nconf.get('url_parsed') || { protocol: 'https:' };
+		const protocol = getRequestProtocol(req);
 		origin = `${protocol}//${req.headers.host}`;
 	}
 
 	return new URL(requestPath, origin).href;
+}
+
+// Determines the scheme of the dialed request. The Host header carries no
+// scheme, so use the request's own protocol (express's req.protocol honors
+// trust proxy and X-Forwarded-Proto), falling back to the configured URL
+function getRequestProtocol(req) {
+	if (req && typeof req.protocol === 'string' && (req.protocol === 'http' || req.protocol === 'https')) {
+		return `${req.protocol}:`;
+	}
+	const { protocol } = nconf.get('url_parsed') || { protocol: 'https:' };
+	return protocol;
 }
 
 async function tryVerifyDraft(req, fetchPublicKeyFn) {

--- a/src/middleware/activitypub.js
+++ b/src/middleware/activitypub.js
@@ -58,10 +58,10 @@ middleware.verify = async function (req, res, next) {
 			return next();
 		}
 
-		// Set calling user
-		const keyId = req.headers.signature.split(',').filter(line => line.trim().startsWith('keyId="'));
-		if (keyId.length) {
-			req.uid = keyId.at(-1).trim().slice(7, -1).replace(/#.*$/, '');
+		// Set calling user (keyId may be a draft `keyId` or RFC 9421 `keyid` parameter)
+		const keyId = activitypub.signatures.getKeyId(req.headers);
+		if (keyId) {
+			req.uid = keyId.replace(/#.*$/, '');
 		}
 
 		activitypub.helpers.log('[middleware/activitypub] HTTP signature verification passed.');
@@ -142,12 +142,7 @@ middleware.assertPayload = helpers.try(async function (req, res, next) {
 	], ['id']);
 	compare = compare.reduce((keyId, { id }) => keyId || id || '', '').replace(/#[\w-]+$/, '');
 
-	const { signature } = req.headers;
-	let keyId = new Map(signature.split(',').filter(Boolean).map((v) => {
-		const index = v.indexOf('=');
-		return [v.substring(0, index).trim(), v.slice(index + 1)];
-	})).get('keyId');
-	keyId = (keyId || '').slice(1, -1).replace(/#[\w-]+$/, '');
+	const keyId = (activitypub.signatures.getKeyId(req.headers) || '').replace(/#[\w-]+$/, '');
 	if (compare !== keyId) {
 		activitypub.helpers.log('[middleware/activitypub] Key ownership cross-check failed.');
 		return res.sendStatus(403);

--- a/test/activitypub/middleware.js
+++ b/test/activitypub/middleware.js
@@ -98,6 +98,24 @@ describe('middleware.verify', () => {
 			assert.strictEqual(response.statusCode, 400);
 		});
 
+		it('should call next() and set req.uid when an RFC 9421 signature is valid', async () => {
+			const path = `/user/${username}/inbox`;
+			const body = { foo: 'bar' };
+			const endpoint = `${nconf.get('url')}${path}`;
+			const hash = createHash('sha256');
+			hash.update(JSON.stringify(body));
+			const checksum = `SHA-256=${hash.digest('base64')}`;
+			const signedHeaders = await activitypub.signatures.signRfc9421(keyData, endpoint, 'POST', checksum);
+			const req = buildReq('POST', path, signedHeaders);
+			req.body = body;
+			const res = buildRes();
+			const { nextCalled, res: response } = await runMiddleware(req, res);
+
+			assert.strictEqual(nextCalled, true);
+			assert.strictEqual(response.statusCode, null);
+			assert.strictEqual(req.uid, `${nconf.get('url')}/uid/${uid}`);
+		});
+
 		it('should reject with 401 when no signature is present', async () => {
 			const path = `/user/${username}/inbox`;
 			const req = buildReq('POST', path, {});

--- a/test/activitypub/mitra-interop-sim.js
+++ b/test/activitypub/mitra-interop-sim.js
@@ -1,0 +1,182 @@
+'use strict';
+
+// Simulates an incoming RFC 9421 request EXACTLY as Mitra builds it
+// (see apx_core/src/http_signatures/create.rs) and runs it through
+// NodeBB's real verification path.
+
+const assert = require('assert');
+const { createHash, generateKeyPairSync, webcrypto } = require('crypto');
+
+require('../mocks/databasemock');
+const nconf = require('nconf');
+const signatures = require('../../src/activitypub/signatures');
+
+describe('Mitra-style incoming RFC 9421 request (interop simulation)', () => {
+	let kp;
+	let pubPem;
+	let signingKey;
+
+	before(async () => {
+		kp = generateKeyPairSync('rsa', { modulusLength: 2048, publicExponent: 0x10001 });
+		pubPem = kp.publicKey.export({ format: 'pem', type: 'spki' }).toString();
+		// This Node build requires importKey with DER (KeyObject not accepted by subtle.sign)
+		signingKey = await webcrypto.subtle.importKey(
+			'pkcs8',
+			kp.privateKey.export({ format: 'der', type: 'pkcs8' }),
+			{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+			false,
+			['sign'],
+		);
+	});
+
+	it('should verify a request built exactly like Mitra builds it', async () => {
+		const url = `${nconf.get('url')}/uid/1/inbox`;
+		const body = JSON.stringify({
+			id: 'https://mitra.example/activities/123',
+			type: 'Announce',
+			actor: 'https://mitra.example/users/alice',
+			object: 'https://mitra.example/statuses/abc',
+		});
+		const bodyBuf = Buffer.from(body, 'utf8');
+
+		// Content-Digest: sha-256=:<b64>:  (RFC 9530 style, create_content_digest_header)
+		const digestB64 = createHash('sha256').update(bodyBuf).digest('base64');
+		const contentDigest = `sha-256=:${digestB64}=`;
+
+		const keyId = 'https://mitra.example/users/alice#main-key';
+		const created = Math.floor(Date.now() / 1000);
+		const alg = 'rsa-v1_5-sha256';
+
+		// Signature-Input: sig1=("@method" "@target-uri" "content-digest");keyid="...";created=N;alg="..."
+		// (sfv IndexMap insertion order: keyid, created, alg)
+		const signatureInput = `sig1=("@method" "@target-uri" "content-digest");keyid="${keyId}";created=${created};alg="${alg}"`;
+
+		// Signature base (create_http_signature_rfc9421):
+		const base = [
+			'"@method": POST',
+			`"@target-uri": ${url}`,
+			`"content-digest": ${contentDigest}`,
+			`"@signature-params": ("@method" "@target-uri" "content-digest");keyid="${keyId}";created=${created};alg="${alg}"`,
+		].join('\n');
+
+		const sig = await webcrypto.subtle.sign(
+			{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+			signingKey,
+			new TextEncoder().encode(base),
+		);
+		const sigB64 = Buffer.from(sig).toString('base64');
+
+		// Mitra sends: Content-Digest, Signature, Signature-Input (reqwest adds Host)
+		const req = {
+			method: 'POST',
+			originalUrl: '/uid/1/inbox',
+			url: '/uid/1/inbox',
+			ip: '203.0.113.7',
+			rawBody: bodyBuf,
+			body: JSON.parse(body),
+			headers: {
+				'content-type': 'application/activity+json',
+				// Real requests always have a Host header matching the dialed URL
+				host: nconf.get('url_parsed').host,
+				'content-digest': contentDigest,
+				'signature-input': signatureInput,
+				signature: `sig1=:${sigB64}:`,
+			},
+		};
+
+		const fetchPublicKeyFn = async (uri) => {
+			assert.strictEqual(uri, keyId);
+			return pubPem;
+		};
+
+		const verified = await signatures.verify(req, fetchPublicKeyFn);
+		assert.strictEqual(verified, true, 'NodeBB failed to verify a Mitra-style RFC 9421 request');
+	});
+
+	it('should verify a Mitra-style request whose created param is 4 minutes old (within clock skew)', async () => {
+		const url = `${nconf.get('url')}/uid/1/inbox`;
+		const body = JSON.stringify({ id: 'https://mitra.example/activities/124', type: 'Announce', actor: 'https://mitra.example/users/alice', object: 'https://mitra.example/statuses/abc' });
+		const bodyBuf = Buffer.from(body, 'utf8');
+		const digestB64 = createHash('sha256').update(bodyBuf).digest('base64');
+		const contentDigest = `sha-256=:${digestB64}=`;
+
+		const keyId = 'https://mitra.example/users/alice#main-key';
+		const created = Math.floor(Date.now() / 1000) - 240; // 4 minutes ago
+		const alg = 'rsa-v1_5-sha256';
+		const signatureInput = `sig1=("@method" "@target-uri" "content-digest");keyid="${keyId}";created=${created};alg="${alg}"`;
+		const base = [
+			'"@method": POST',
+			`"@target-uri": ${url}`,
+			`"content-digest": ${contentDigest}`,
+			`"@signature-params": ("@method" "@target-uri" "content-digest");keyid="${keyId}";created=${created};alg="${alg}"`,
+		].join('\n');
+		const sig = await webcrypto.subtle.sign(
+			{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+			signingKey,
+			new TextEncoder().encode(base),
+		);
+		const req = {
+			method: 'POST',
+			originalUrl: '/uid/1/inbox',
+			url: '/uid/1/inbox',
+			ip: '203.0.113.7',
+			rawBody: bodyBuf,
+			body: JSON.parse(body),
+			headers: {
+				'content-type': 'application/activity+json',
+				host: nconf.get('url_parsed').host,
+				'content-digest': contentDigest,
+				'signature-input': signatureInput,
+				signature: `sig1=:${Buffer.from(sig).toString('base64')}:`,
+			},
+		};
+
+		const verified = await signatures.verify(req, async () => pubPem);
+		assert.strictEqual(verified, true);
+	});
+
+	it('should verify when the signed @target-uri host differs from the configured URL (host mismatch)', async () => {
+		// Mitra signs the URL it dialed. If that differs from NodeBB's configured
+		// origin (reverse proxy, port, www vs. non-www, IP vs. domain), the
+		// target URI is reconstructed from the Host header instead
+		const dialedUrl = 'https://nodebb.example/uid/1/inbox';
+		const body = JSON.stringify({ id: 'https://mitra.example/activities/125', type: 'Announce', actor: 'https://mitra.example/users/alice', object: 'https://mitra.example/statuses/abc' });
+		const bodyBuf = Buffer.from(body, 'utf8');
+		const digestB64 = createHash('sha256').update(bodyBuf).digest('base64');
+		const contentDigest = `sha-256=:${digestB64}=`;
+
+		const keyId = 'https://mitra.example/users/alice#main-key';
+		const created = Math.floor(Date.now() / 1000);
+		const alg = 'rsa-v1_5-sha256';
+		const signatureInput = `sig1=("@method" "@target-uri" "content-digest");keyid="${keyId}";created=${created};alg="${alg}"`;
+		const base = [
+			'"@method": POST',
+			`"@target-uri": ${dialedUrl}`,
+			`"content-digest": ${contentDigest}`,
+			`"@signature-params": ("@method" "@target-uri" "content-digest");keyid="${keyId}";created=${created};alg="${alg}"`,
+		].join('\n');
+		const sig = await webcrypto.subtle.sign(
+			{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+			signingKey,
+			new TextEncoder().encode(base),
+		);
+		const req = {
+			method: 'POST',
+			originalUrl: '/uid/1/inbox',
+			url: '/uid/1/inbox',
+			ip: '203.0.113.7',
+			rawBody: bodyBuf,
+			body: JSON.parse(body),
+			headers: {
+				'content-type': 'application/activity+json',
+				host: 'nodebb.example',
+				'content-digest': contentDigest,
+				'signature-input': signatureInput,
+				signature: `sig1=:${Buffer.from(sig).toString('base64')}:`,
+			},
+		};
+
+		const verified = await signatures.verify(req, async () => pubPem);
+		assert.strictEqual(verified, true, 'verification failed despite a valid Host-header-based target URI');
+	});
+});

--- a/test/activitypub/mitra-interop-sim.js
+++ b/test/activitypub/mitra-interop-sim.js
@@ -138,8 +138,12 @@ describe('Mitra-style incoming RFC 9421 request (interop simulation)', () => {
 	it('should verify when the signed @target-uri host differs from the configured URL (host mismatch)', async () => {
 		// Mitra signs the URL it dialed. If that differs from NodeBB's configured
 		// origin (reverse proxy, port, www vs. non-www, IP vs. domain), the
-		// target URI is reconstructed from the Host header instead
-		const dialedUrl = 'https://nodebb.example/uid/1/inbox';
+		// target URI is reconstructed from the Host header instead. The scheme
+		// comes from the (simulated) connection protocol, not the configured URL,
+		// so this stays correct for any test config (http or https, with or
+		// without a relative path)
+		const relativePath = nconf.get('relative_path') || '';
+		const dialedUrl = `https://nodebb.example${relativePath}/uid/1/inbox`;
 		const body = JSON.stringify({ id: 'https://mitra.example/activities/125', type: 'Announce', actor: 'https://mitra.example/users/alice', object: 'https://mitra.example/statuses/abc' });
 		const bodyBuf = Buffer.from(body, 'utf8');
 		const digestB64 = createHash('sha256').update(bodyBuf).digest('base64');
@@ -164,6 +168,8 @@ describe('Mitra-style incoming RFC 9421 request (interop simulation)', () => {
 			method: 'POST',
 			originalUrl: '/uid/1/inbox',
 			url: '/uid/1/inbox',
+			// Simulates a TLS-terminated dialed connection (express req.protocol)
+			protocol: 'https',
 			ip: '203.0.113.7',
 			rawBody: bodyBuf,
 			body: JSON.parse(body),

--- a/test/activitypub/sendWorker.js
+++ b/test/activitypub/sendWorker.js
@@ -94,7 +94,11 @@ describe('sendWorker', () => {
 					try {
 						if (entry.hasRfc) {
 							const base = new RFC9421SignatureBaseFactory({ method: req.method, url: fullUrl, headers: req.headers });
-							const sigB64 = req.headers.signature.match(/^sig1=\("(.*)"\)$/)[1];
+							// Signature values are unquoted base64 (RFC 9421 2.3); strip an optional quote for leniency
+							let sigB64 = String(req.headers.signature).replace(/^sig1=/, '');
+							if (sigB64.startsWith('"') && sigB64.endsWith('"')) {
+								sigB64 = sigB64.slice(1, -1);
+							}
 							const pub = await importPublicKey(pubPem, ['verify']);
 							entry.rfcValid = await webcrypto.subtle.verify(
 								{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },

--- a/test/activitypub/sendWorker.js
+++ b/test/activitypub/sendWorker.js
@@ -56,6 +56,7 @@ describe('sendWorker', () => {
 	describe('RFC 9421 signing with draft fallback', () => {
 		const http = require('http');
 		const { createHash, generateKeyPairSync, webcrypto } = require('crypto');
+		const sfv = require('structured-headers');
 		const {
 			RFC9421SignatureBaseFactory,
 			importPublicKey,
@@ -94,16 +95,18 @@ describe('sendWorker', () => {
 					try {
 						if (entry.hasRfc) {
 							const base = new RFC9421SignatureBaseFactory({ method: req.method, url: fullUrl, headers: req.headers });
-							// Signature values are unquoted base64 (RFC 9421 2.3); strip an optional quote for leniency
-							let sigB64 = String(req.headers.signature).replace(/^sig1=/, '');
-							if (sigB64.startsWith('"') && sigB64.endsWith('"')) {
-								sigB64 = sigB64.slice(1, -1);
+							// Parse the Signature header as a strict RFC 8941/9651 dictionary
+							// (like Mitra's sfv parser) — the value must be a byte sequence
+							const sigDict = sfv.parseDictionary(String(req.headers.signature));
+							const sigItem = sigDict.get('sig1');
+							if (!sigItem || !sfv.isByteSequence(sigItem[0])) {
+								throw new Error('Signature value is not a byte sequence');
 							}
 							const pub = await importPublicKey(pubPem, ['verify']);
 							entry.rfcValid = await webcrypto.subtle.verify(
 								{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
 								pub,
-								Buffer.from(sigB64, 'base64'),
+								Buffer.from(sigItem[0].base64Value, 'base64'),
 								new TextEncoder().encode(base.generate('sig1')),
 							);
 						} else if (entry.isDraft) {

--- a/test/activitypub/sendWorker.js
+++ b/test/activitypub/sendWorker.js
@@ -53,6 +53,137 @@ describe('sendWorker', () => {
 		});
 	});
 
+	describe('RFC 9421 signing with draft fallback', () => {
+		const http = require('http');
+		const { createHash, generateKeyPairSync, webcrypto } = require('crypto');
+		const {
+			RFC9421SignatureBaseFactory,
+			importPublicKey,
+			parseDraftRequest,
+			verifyDraftSignature,
+		} = require('@misskey-dev/node-http-message-signatures');
+
+		let innerPool;
+		let server;
+		let port;
+		let requests;
+		let pubPem;
+		let privPem;
+		const keyId = 'https://nodebb.test/actor#key';
+
+		before(async () => {
+			const kp = generateKeyPairSync('rsa', { modulusLength: 2048, publicExponent: 0x10001 });
+			privPem = kp.privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+			pubPem = kp.publicKey.export({ format: 'pem', type: 'spki' }).toString();
+		});
+
+		beforeEach(async () => {
+			requests = [];
+
+			server = http.createServer((req, res) => {
+				const chunks = [];
+				req.on('data', (c) => chunks.push(c));
+				req.on('end', async () => {
+					const raw = Buffer.concat(chunks);
+					const fullUrl = `http://127.0.0.1:${port}${req.url}`;
+					const entry = {
+						hasRfc: !!req.headers['signature-input'],
+						isDraft: typeof req.headers.signature === 'string' && req.headers.signature.includes('keyId="'),
+						digestOk: req.headers.digest === `SHA-256=${createHash('sha256').update(raw).digest('base64')}`,
+					};
+					try {
+						if (entry.hasRfc) {
+							const base = new RFC9421SignatureBaseFactory({ method: req.method, url: fullUrl, headers: req.headers });
+							const sigB64 = req.headers.signature.match(/^sig1=\("(.*)"\)$/)[1];
+							const pub = await importPublicKey(pubPem, ['verify']);
+							entry.rfcValid = await webcrypto.subtle.verify(
+								{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+								pub,
+								Buffer.from(sigB64, 'base64'),
+								new TextEncoder().encode(base.generate('sig1')),
+							);
+						} else if (entry.isDraft) {
+							const parsed = parseDraftRequest({ method: req.method, url: fullUrl, headers: req.headers });
+							entry.draftValid = await verifyDraftSignature(parsed.value, pubPem);
+						}
+					} catch (e) {
+						entry.verifyError = e.message;
+					}
+					requests.push(entry);
+					const accepted = (server.mode === 'rfc' && entry.hasRfc && entry.rfcValid === true) ||
+						(server.mode === 'draft' && entry.isDraft && entry.draftValid === true);
+					res.writeHead(accepted ? 202 : 401, { 'content-type': 'application/json' });
+					res.end(JSON.stringify({ accepted }));
+				});
+			});
+			await new Promise((resolve) => {
+				server.listen(0, '127.0.0.1', resolve);
+			});
+			port = server.address().port;
+
+			innerPool = workerpool.pool(path.join(__dirname, '../../src/activitypub/sendWorker.js'), {
+				minWorkers: 1,
+				maxWorkers: 1,
+				workerType: 'process',
+				forkOpts: {
+					silent: true,
+					execArgv: ['--require', require.resolve('./ssrf-allow-localhost')],
+				},
+			});
+		});
+
+		afterEach((done) => {
+			Promise.all([
+				innerPool ? innerPool.terminate(true, 1000) : Promise.resolve(),
+				new Promise((resolve) => server.close(resolve)),
+			]).then(() => done()).catch(() => done());
+		});
+
+		function task(mode) {
+			const payload = JSON.stringify({ id: 'https://nodebb.test/activities/1', type: 'Create' });
+			return {
+				id: `rfc-fallback-${mode}`,
+				uri: `http://127.0.0.1:${port}/inbox`,
+				payload,
+				digest: `SHA-256=${createHash('sha256').update(payload).digest('base64')}`,
+				key: privPem,
+				keyId,
+			};
+		}
+
+		it('should sign with RFC 9421 and not fall back when the server accepts it', async () => {
+			server.mode = 'rfc';
+			const result = await innerPool.exec('send', [task('rfc')], { timeout: 30000 });
+
+			assert.strictEqual(result.success, true);
+			assert.strictEqual(requests.length, 1);
+			assert(requests[0].hasRfc, 'request should carry a signature-input header');
+			assert.strictEqual(requests[0].rfcValid, true, 'RFC 9421 signature should verify');
+			assert.strictEqual(requests[0].digestOk, true, 'digest should match payload');
+		});
+
+		it('should fall back to a draft signature when the server rejects RFC 9421', async () => {
+			server.mode = 'draft';
+			const result = await innerPool.exec('send', [task('draft')], { timeout: 30000 });
+
+			assert.strictEqual(result.success, true);
+			assert.strictEqual(requests.length, 2);
+			assert(requests[0].hasRfc, 'first attempt should use RFC 9421');
+			assert(requests[1].isDraft, 'fallback attempt should use the draft signature');
+			assert.strictEqual(requests[1].draftValid, true, 'draft signature should verify');
+			assert.strictEqual(requests[1].digestOk, true, 'digest should match payload');
+		});
+
+		it('should fail when the server rejects both signature schemes', async () => {
+			server.mode = 'none';
+			const result = await innerPool.exec('send', [task('none')], { timeout: 30000 });
+
+			assert.strictEqual(result.success, false);
+			assert.strictEqual(requests.length, 2);
+			assert(result.error.includes('401'));
+		});
+	});
+
 	describe('SSRF protection', () => {
 		it('should reject localhost URLs', async () => {
 			const result = await pool.exec('send', [{

--- a/test/activitypub/signatures.js
+++ b/test/activitypub/signatures.js
@@ -257,9 +257,9 @@ describe('http signature signing and verification', () => {
 				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
 			const { host } = nconf.get('url_parsed');
 
-			const paramsMatch = signatureInput.match(/^sig1=(\([^)]*\));created=(\d+);keyid="([^"]*)"$/);
+			const paramsMatch = signatureInput.match(/^sig1=(\([^)]*\));algorithm="([^"]*)";created=(\d+);keyid="([^"]*)"$/);
 			assert(paramsMatch, `unexpected Signature-Input format: ${signatureInput}`);
-			const [, componentsInnerList, created, keyId] = paramsMatch;
+			const [, componentsInnerList, algorithm, created, keyId] = paramsMatch;
 			const componentIds = [...componentsInnerList.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
 			const componentValues = {
 				'@method': 'GET',
@@ -268,7 +268,7 @@ describe('http signature signing and verification', () => {
 				date,
 			};
 			const lines = componentIds.map((id) => `"${id}": ${componentValues[id]}`);
-			lines.push(`"@signature-params": ${componentsInnerList};created=${created};keyid="${keyId}"`);
+			lines.push(`"@signature-params": ${componentsInnerList};algorithm="${algorithm}";created=${created};keyid="${keyId}"`);
 			const expectedBase = lines.join('\n');
 
 			const publicKeyPem = await activitypub.getPublicKey('uid', uid);

--- a/test/activitypub/signatures.js
+++ b/test/activitypub/signatures.js
@@ -146,5 +146,132 @@ describe('http signature signing and verification', () => {
 			const verified = await activitypub.verify(req);
 			assert.strictEqual(verified, true);
 		});
+
+		it('should return true when a valid RFC 9421 signature is passed in', async () => {
+			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
+			const path = `/user/${username}/inbox`;
+			const keyData = await activitypub.getPrivateKey('uid', uid);
+			const { date, 'signature-input': signatureInput, signature } =
+				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
+			const { host } = nconf.get('url_parsed');
+			const req = {
+				...mockReqBase,
+				...{
+					url: path,
+					path,
+					headers: { date, 'signature-input': signatureInput, signature, host },
+				},
+			};
+
+			const verified = await activitypub.verify(req);
+			assert.strictEqual(verified, true);
+		});
+
+		it('should return true when an RFC 9421 signature with digest is passed in', async () => {
+			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
+			const path = `/user/${username}/inbox`;
+			const payload = { foo: 'bar' };
+			const keyData = await activitypub.getPrivateKey('uid', uid);
+			const hash = createHash('sha256');
+			hash.update(JSON.stringify(payload));
+			const checksum = `SHA-256=${hash.digest('base64')}`;
+			const { date, digest, 'signature-input': signatureInput, signature } =
+				await activitypub.signatures.signRfc9421(keyData, endpoint, 'POST', checksum);
+			const { host } = nconf.get('url_parsed');
+			const req = {
+				...mockReqBase,
+				...{
+					method: 'POST',
+					url: path,
+					path,
+					body: payload,
+					headers: { date, digest, 'signature-input': signatureInput, signature, host },
+				},
+			};
+
+			const verified = await activitypub.verify(req);
+			assert.strictEqual(verified, true);
+		});
+
+		it('should return false when an RFC 9421 signature does not verify', async () => {
+			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
+			const path = `/user/${username}/inbox`;
+			const keyData = await activitypub.getPrivateKey('uid', uid);
+			const { date, 'signature-input': signatureInput, signature } =
+				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
+			const { host } = nconf.get('url_parsed');
+			const req = {
+				...mockReqBase,
+				...{
+					url: path,
+					path,
+					headers: {
+						// Tamper with a covered component (date)
+						date: 'Wed, 01 Jan 2020 00:00:00 GMT',
+						'signature-input': signatureInput,
+						signature,
+						host,
+					},
+				},
+			};
+
+			const verified = await activitypub.verify(req);
+			assert.strictEqual(verified, false);
+		});
+	});
+
+	describe('.getKeyId()', () => {
+		it('should extract the keyId from a draft signature header', () => {
+			const headers = {
+				signature: 'keyId="https://example.org/user/test#key",algorithm="rsa-sha256",headers="(request-target) host date",signature="abc="',
+			};
+			assert.strictEqual(activitypub.signatures.getKeyId(headers), 'https://example.org/user/test#key');
+		});
+
+		it('should use the last keyId when a draft signature header contains duplicates', () => {
+			const headers = {
+				signature: 'keyId="https://example.org/a#key",keyId="https://example.org/b#key",signature="abc="',
+			};
+			assert.strictEqual(activitypub.signatures.getKeyId(headers), 'https://example.org/b#key');
+		});
+
+		it('should extract the keyid from an RFC 9421 Signature-Input header', () => {
+			const headers = {
+				'signature-input': 'sig1=("@request-target" "host" "date");created=1787933487;keyid="https://example.org/user/test#key"',
+				signature: 'sig1="abc="',
+			};
+			assert.strictEqual(activitypub.signatures.getKeyId(headers), 'https://example.org/user/test#key');
+		});
+
+		it('should return null when no key identifier is present', () => {
+			assert.strictEqual(activitypub.signatures.getKeyId({ signature: 'signature="abc="' }), null);
+			assert.strictEqual(activitypub.signatures.getKeyId({}), null);
+		});
+	});
+
+	describe('draft signatures with non-RSA keys', () => {
+		it('should sign and verify a draft signature made with an EC key', async () => {
+			const { generateKeyPairSync } = require('crypto');
+			const kp = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+			const privPem = kp.privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+			const pubPem = kp.publicKey.export({ format: 'pem', type: 'spki' }).toString();
+			const keyId = 'https://example.org/ec-actor#key';
+			const endpoint = `${nconf.get('url')}/uid/999/inbox`;
+			const headers = await activitypub.signatures.sign({ key: privPem, keyId }, endpoint, 'GET');
+
+			// The header must advertise an EC algorithm, not rsa-sha256
+			assert(headers.signature.includes('algorithm="ecdsa-p256-sha256"'),
+				`unexpected draft algorithm string: ${headers.signature}`);
+
+			const req = {
+				method: 'GET',
+				url: '/uid/999/inbox',
+				path: '/uid/999/inbox',
+				headers: { ...headers, host: nconf.get('url_parsed').host },
+			};
+
+			const verified = await activitypub.signatures.verify(req, async () => pubPem);
+			assert.strictEqual(verified, true);
+		});
 	});
 });

--- a/test/activitypub/signatures.js
+++ b/test/activitypub/signatures.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const nconf = require('nconf');
 const { createHash } = require('crypto');
+const { importPublicKey, getWebcrypto } = require('@misskey-dev/node-http-message-signatures');
 
 const db = require('../mocks/databasemock');
 const user = require('../../src/user');
@@ -217,6 +218,69 @@ describe('http signature signing and verification', () => {
 
 			const verified = await activitypub.verify(req);
 			assert.strictEqual(verified, false);
+		});
+	});
+
+	describe('.signRfc9421()', () => {
+		let uid;
+		const username = utils.generateUUID().slice(0, 10);
+
+		before(async () => {
+			uid = await user.create({ username });
+		});
+
+		it('should produce a structured-field byte sequence Signature header', async () => {
+			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
+			const keyData = await activitypub.getPrivateKey('uid', uid);
+			const { signature } = await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
+			// RFC 8941/9651 byte sequence: ":" + base64 + ":"
+			assert.match(signature, /^sig1=:[0-9A-Za-z+/]+={0,2}:$/);
+		});
+
+		it('should cover the @method and @target-uri components', async () => {
+			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
+			const keyData = await activitypub.getPrivateKey('uid', uid);
+			const { 'signature-input': signatureInput } =
+				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
+			const componentIds = [...signatureInput.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+			assert(componentIds.includes('@method'));
+			assert(componentIds.includes('@target-uri'));
+		});
+
+		it('should produce a signature that verifies against an independent signature base reconstruction', async () => {
+			// Reconstructs the signature base by hand per RFC 9421 2.5 (matching
+			// independent implementations such as Mitra) instead of trusting the
+			// base factory on both sides
+			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
+			const keyData = await activitypub.getPrivateKey('uid', uid);
+			const { date, 'signature-input': signatureInput, signature } =
+				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
+			const { host } = nconf.get('url_parsed');
+
+			const paramsMatch = signatureInput.match(/^sig1=(\([^)]*\));created=(\d+);keyid="([^"]*)"$/);
+			assert(paramsMatch, `unexpected Signature-Input format: ${signatureInput}`);
+			const [, componentsInnerList, created, keyId] = paramsMatch;
+			const componentIds = [...componentsInnerList.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+			const componentValues = {
+				'@method': 'GET',
+				'@target-uri': endpoint,
+				host,
+				date,
+			};
+			const lines = componentIds.map((id) => `"${id}": ${componentValues[id]}`);
+			lines.push(`"@signature-params": ${componentsInnerList};created=${created};keyid="${keyId}"`);
+			const expectedBase = lines.join('\n');
+
+			const publicKeyPem = await activitypub.getPublicKey('uid', uid);
+			const publicKey = await importPublicKey(publicKeyPem, ['verify']);
+			const webcrypto = await getWebcrypto();
+			const verified = await webcrypto.subtle.verify(
+				{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+				publicKey,
+				Buffer.from(signature.slice('sig1=:'.length, -1), 'base64'),
+				new TextEncoder().encode(expectedBase),
+			);
+			assert.strictEqual(verified, true);
 		});
 	});
 

--- a/test/activitypub/ssrf-allow-localhost.js
+++ b/test/activitypub/ssrf-allow-localhost.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// Preload for sendWorker test workers: allows the worker process to send to
+// localhost (SSRF bypass) so tests can use a local HTTP server.
+require(require('path').join(__dirname, '..', '..', 'src', 'ssrf')).allowList.add('127.0.0.1');


### PR DESCRIPTION
This is the other half of the RFC 9421 support piece. It fixes a bug with the first half (where verification for 9421-signed activities never actually worked), and now sends RFC 9421 signed activities with a double-knock fallback to draft cavage-12.

- **feat(activitypub): sign activities with rfc 9421, fall back to draft**
- **feat(activitypub): verify incoming rfc 9421 signatures**
