### PR TITLE
fix: do not expose raw content of deleted chat messages

### DIFF
--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -410,7 +410,7 @@ chatsAPI.getRawMessage = async (caller, { mid, roomId } = {}) => {
 	}
 
 	const { content, deleted, fromuid } = await messaging.getMessageFields(mid, ['content', 'deleted', 'fromuid']);
-	const isSender = parseInt(caller.uid, 10) === parseInt(fromuid, 10);
+	const isSender = String(caller.uid) === String(fromuid);
 	if (deleted && !isSender && !isAdminOrGlobalMod) {
 		throw new Error('[[error:not-allowed]]');
 	}

--- a/src/api/chats.js
+++ b/src/api/chats.js
@@ -399,17 +399,22 @@ chatsAPI.getRawMessage = async (caller, { mid, roomId } = {}) => {
 		throw new Error('[[error:invalid-data]]');
 	}
 
-	const [isAdmin, canViewMessage, inRoom] = await Promise.all([
-		user.isAdministrator(caller.uid),
+	const [isAdminOrGlobalMod, canViewMessage, inRoom] = await Promise.all([
+		user.isAdminOrGlobalMod(caller.uid),
 		messaging.canViewMessage(mid, roomId, caller.uid),
 		messaging.isUserInRoom(caller.uid, roomId),
 	]);
 
-	if (!isAdmin && (!inRoom || !canViewMessage)) {
+	if (!isAdminOrGlobalMod && (!inRoom || !canViewMessage)) {
 		throw new Error('[[error:not-allowed]]');
 	}
 
-	const content = await messaging.getMessageField(mid, 'content');
+	const { content, deleted, fromuid } = await messaging.getMessageFields(mid, ['content', 'deleted', 'fromuid']);
+	const isSender = parseInt(caller.uid, 10) === parseInt(fromuid, 10);
+	if (deleted && !isSender && !isAdminOrGlobalMod) {
+		throw new Error('[[error:not-allowed]]');
+	}
+
 	return { content };
 };
 

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -476,6 +476,34 @@ describe('Messaging Library', () => {
 			);
 		});
 
+		it('should not return the raw content of a deleted message to other users', async () => {
+			const otherUid = await User.create({ username: 'chatdeletereader' });
+			const { body: roomBody } = await callv3API('post', '/chats', {
+				uids: [otherUid],
+			}, 'bar');
+			const deleteRoomId = roomBody.response.roomId;
+
+			const { body: msgBody } = await callv3API('post', `/chats/${deleteRoomId}`, {
+				roomId: deleteRoomId, message: 'this message will be deleted',
+			}, 'bar');
+			const { messageId } = msgBody.response;
+
+			await callv3API('delete', `/chats/${deleteRoomId}/messages/${messageId}`, {}, 'bar');
+
+			await assert.rejects(
+				api.chats.getRawMessage(
+					{ uid: otherUid }, { mid: messageId, roomId: deleteRoomId }
+				),
+				{ message: '[[error:not-allowed]]' }
+			);
+
+			// the sender can still read their own deleted message
+			const { content } = await api.chats.getRawMessage(
+				{ uid: mocks.users.bar.uid }, { mid: messageId, roomId: deleteRoomId }
+			);
+			assert.equal(content, 'this message will be deleted');
+		});
+
 		it('should return not allowed error if user is not in room', async () => {
 			const uids = await User.create({ username: 'dummy' });
 			let { body } = await callv3API('post', '/chats', { uids: [uids] }, 'baz');


### PR DESCRIPTION
### Problem

`GET /api/v3/chats/:roomId/messages/:mid/raw` (`chatsAPI.getRawMessage`) reads the message content straight out of the database without ever looking at the message's `deleted` flag:

```js
const content = await messaging.getMessageField(mid, 'content');
return { content };
```

Its only gate is `isAdmin || (inRoom && canViewMessage)`, and `Messaging.canViewMessage()` checks room membership and timestamps only — not deletion. Since chat deletion is a soft delete (`Messaging.setMessageField(mid, 'deleted', state)`), the mid stays in `chat:room:<id>:mids` and the content stays in the hash.

The normal read path does mask it — `parseMessages()` replaces the body with `[[modules:chat.message-deleted]]` for anyone who is not the sender — so the raw route is the only way to recover the text. Any member of the room can run:

```js
const [api] = await app.require(['api']);
await api.get(`/chats/${roomId}/messages/${mid}/raw`);
```

and read the full content of a message another user deleted.

(`/raw` is also the only message route in `src/routes/write/chats.js` that does not go through `middleware.assert.message`.)

### Fix

Fetch `deleted` and `fromuid` along with the content and reject when the message is deleted and the caller is neither the sender nor an admin/global moderator — the same permission model `Messaging.canEdit()` uses. The membership gate is widened from `isAdministrator` to `isAdminOrGlobalMod` so both checks use one value.

For comparison, the post equivalent already does this in `postsAPI.getRaw`:

```js
if (postData.deleted && !(userPrivilege.isAdminOrMod || selfPost)) {
    return null;
}
```

### Test

Added a case to `test/messaging.js`: a user deletes their own message, another room member gets `[[error:not-allowed]]` from the raw route, and the sender still reads their own content. It fails on master (`Missing expected rejection`) and passes with the fix. Full `test/messaging.js` suite is green.
