### PR TITLE
feat: expose topic lock state to filter:privileges.posts.edit

### DIFF
--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -175,19 +175,22 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
 	}
 
-	const isLocked = await topics.isLocked(results.postData.tid);
-	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
-	}
-
-	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
-	}
-
+	results.isLocked = await topics.isLocked(results.postData.tid);
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;
 	results.uid = uid;
 
+	// Fired ahead of the lock and deleted-post gates, so that plugins can grant
+	// edit access inside a locked topic by unsetting `isLocked`.
 	const result = await plugins.hooks.fire('filter:privileges.posts.edit', results);
+
+	if (!result.isMod && result.isLocked) {
+		return { flag: false, message: '[[error:topic-locked]]' };
+	}
+
+	if (!result.isMod && result.postData.deleted && parseInt(uid, 10) !== parseInt(result.postData.deleterUid, 10)) {
+		return { flag: false, message: '[[error:post-deleted]]' };
+	}
+
 	return {
 		flag: result.edit && (result.isOwner || result.isEditor || result.isGroupEditor || result.isMod),
 		message: '[[error:no-privileges]]',

--- a/test/posts.js
+++ b/test/posts.js
@@ -16,6 +16,7 @@ const categories = require('../src/categories');
 const privileges = require('../src/privileges');
 const user = require('../src/user');
 const groups = require('../src/groups');
+const plugins = require('../src/plugins');
 const socketPosts = require('../src/socket.io/posts');
 const apiPosts = require('../src/api/posts');
 const apiTopics = require('../src/api/topics');
@@ -1390,6 +1391,47 @@ describe('Post\'s', () => {
 
 			const { groups: groupNames } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
 			assert.deepStrictEqual(groupNames, []);
+		});
+	});
+
+	describe('editing posts in locked topics', () => {
+		let ownerUid;
+		let pid;
+
+		before(async () => {
+			ownerUid = await user.create({ username: 'locked topic owner' });
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic that gets locked',
+				content: 'Some text here for the OP',
+			});
+			pid = topic.postData.pid;
+			await topics.setTopicField(topic.topicData.tid, 'locked', 1);
+		});
+
+		it('should not allow the owner to edit a post in a locked topic', async () => {
+			const { flag, message } = await privileges.posts.canEdit(pid, ownerUid);
+			assert.strictEqual(flag, false);
+			assert.strictEqual(message, '[[error:topic-locked]]');
+		});
+
+		it('should let a plugin grant edit access by unsetting isLocked', async () => {
+			const method = (data) => {
+				assert.strictEqual(data.isLocked, true);
+				data.isLocked = false;
+				return data;
+			};
+			plugins.hooks.register('test-edit-locked', {
+				hook: 'filter:privileges.posts.edit',
+				method: method,
+			});
+			try {
+				const { flag } = await privileges.posts.canEdit(pid, ownerUid);
+				assert.strictEqual(flag, true);
+			} finally {
+				plugins.hooks.unregister('test-edit-locked', 'filter:privileges.posts.edit', method);
+			}
 		});
 	});
 


### PR DESCRIPTION
### Problem

`privileges.posts.canEdit` returns early with `[[error:topic-locked]]` **before** it fires `filter:privileges.posts.edit`:

https://github.com/NodeBB/NodeBB/blob/master/src/privileges/posts.js#L177-L180

So a plugin that wants to allow editing inside a locked topic (say, letting a trusted group fix a typo in their own post after a thread is closed) has no hook to do it from. The only way is to replace `privileges.posts.canEdit` wholesale and re-implement everything that happens after the lock gate — the deleted-post guard, the hook fire, the final flag — which then silently drifts out of sync on every upgrade.

### Change

Attach the lock state to the hook payload as `isLocked`, and evaluate the lock and deleted-post gates on the object the hook returns.

Nothing changes for existing listeners: the two gates keep the same order, the same conditions and the same error messages, and the only new thing on the payload is `isLocked`. A plugin can now unset it to allow the edit, and everything before the hook (admin short-circuit, edit-duration, newbie edit-duration, remote posts) still runs in core.

### Tests

Added to `test/posts.js`: a locked topic still refuses the owner's edit with `[[error:topic-locked]]`, and a listener that unsets `isLocked` gets the edit through.