### PR TITLE
feat: add bypass_lock category privilege

### DIFF
--- a/public/language/en-GB/admin/manage/privileges.json
+++ b/public/language/en-GB/admin/manage/privileges.json
@@ -37,6 +37,7 @@
 	"view-edit-history": "View Edit History",
 	"delete-posts": "Delete Posts",
 	"view-deleted": "View Deleted Posts",
+	"bypass-lock": "Bypass Lock",
 	"upvote-posts": "Upvote Posts",
 	"downvote-posts": "Downvote Posts",
 	"delete-topics": "Delete Topics",

--- a/public/src/client/topic/posts.js
+++ b/public/src/client/topic/posts.js
@@ -68,7 +68,7 @@ define('forum/topic/posts', [
 			post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 			post.display_move_tools = ajaxify.data.privileges.isAdminOrMod;
 			post.display_post_menu = ajaxify.data.privileges.isAdminOrMod ||
-				(post.selfPost && !ajaxify.data.locked && !post.deleted) ||
+				(post.selfPost && (!ajaxify.data.locked || ajaxify.data.privileges.bypass_lock) && !post.deleted) ||
 				(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(app.user.uid, 10)) ||
 				((app.user.uid || ajaxify.data.postSharing.length) && !post.deleted);
 		});

--- a/src/privileges/categories.js
+++ b/src/privileges/categories.js
@@ -33,6 +33,7 @@ const _privilegeMap = new Map([
 	['posts:downvote', { label: '[[admin/manage/privileges:downvote-posts]]', type: 'posting' }],
 	['topics:delete', { label: '[[admin/manage/privileges:delete-topics]]', type: 'posting' }],
 	['posts:view_deleted', { label: '[[admin/manage/privileges:view-deleted]]', type: 'moderation' }],
+	['bypass_lock', { label: '[[admin/manage/privileges:bypass-lock]]', type: 'moderation' }],
 	['purge', { label: '[[admin/manage/privileges:purge]]', type: 'moderation' }],
 	['moderate', { label: '[[admin/manage/privileges:moderate]]', type: 'moderation' }],
 ]);

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -148,6 +148,7 @@ privsPosts.canEdit = async function (pid, uid) {
 		isEditor: db.isSetMember(`pid:${pid}:editors`, uid),
 		isGroupEditor: isGroupEditor(pid, uid),
 		edit: privsPosts.can('posts:edit', pid, uid),
+		bypassLock: privsPosts.can('bypass_lock', pid, uid),
 		postData: posts.getPostFields(pid, ['tid', 'timestamp', 'deleted', 'deleterUid']),
 		userData: user.getUserFields(uid, ['reputation']),
 	});
@@ -183,7 +184,7 @@ privsPosts.canEdit = async function (pid, uid) {
 	// edit access inside a locked topic by unsetting `isLocked`.
 	const result = await plugins.hooks.fire('filter:privileges.posts.edit', results);
 
-	if (!result.isMod && result.isLocked) {
+	if (!result.isMod && result.isLocked && !result.bypassLock) {
 		return { flag: false, message: '[[error:topic-locked]]' };
 	}
 
@@ -211,6 +212,7 @@ privsPosts.canDelete = async function (pid, uid) {
 		isAdmin: user.isAdministrator(uid),
 		isMod: posts.isModerator([pid], uid),
 		isLocked: topics.isLocked(postData.tid),
+		bypassLock: privsPosts.can('bypass_lock', pid, uid),
 		isOwner: posts.isOwner(pid, uid),
 		'posts:delete': privsPosts.can('posts:delete', pid, uid),
 	});
@@ -219,7 +221,7 @@ privsPosts.canDelete = async function (pid, uid) {
 		return { flag: true };
 	}
 
-	if (!results.isMod && results.isLocked) {
+	if (!results.isMod && results.isLocked && !results.bypassLock) {
 		return { flag: false, message: '[[error:topic-locked]]' };
 	}
 

--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -175,19 +175,22 @@ privsPosts.canEdit = async function (pid, uid) {
 		return { flag: false, message: `[[error:post-edit-duration-expired, ${meta.config.newbiePostEditDuration}]]` };
 	}
 
-	const isLocked = await topics.isLocked(results.postData.tid);
-	if (!results.isMod && isLocked) {
-		return { flag: false, message: '[[error:topic-locked]]' };
-	}
-
-	if (!results.isMod && results.postData.deleted && parseInt(uid, 10) !== parseInt(results.postData.deleterUid, 10)) {
-		return { flag: false, message: '[[error:post-deleted]]' };
-	}
-
+	results.isLocked = await topics.isLocked(results.postData.tid);
 	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;
 	results.uid = uid;
 
+	// Fired ahead of the lock and deleted-post gates, so that plugins can grant
+	// edit access inside a locked topic by unsetting `isLocked`.
 	const result = await plugins.hooks.fire('filter:privileges.posts.edit', results);
+
+	if (!result.isMod && result.isLocked) {
+		return { flag: false, message: '[[error:topic-locked]]' };
+	}
+
+	if (!result.isMod && result.postData.deleted && parseInt(uid, 10) !== parseInt(result.postData.deleterUid, 10)) {
+		return { flag: false, message: '[[error:post-deleted]]' };
+	}
+
 	return {
 		flag: result.edit && (result.isOwner || result.isEditor || result.isGroupEditor || result.isMod),
 		message: '[[error:no-privileges]]',

--- a/src/privileges/topics.js
+++ b/src/privileges/topics.js
@@ -21,7 +21,7 @@ privsTopics.get = async function (tid, uid) {
 		'topics:reply', 'topics:read', 'topics:schedule', 'topics:tag',
 		'topics:delete', 'posts:edit', 'posts:history',
 		'posts:upvote', 'posts:downvote',
-		'posts:delete', 'posts:view_deleted', 'read', 'purge',
+		'posts:delete', 'posts:view_deleted', 'read', 'purge', 'bypass_lock',
 	];
 	const topicData = await topics.getTopicFields(tid, ['cid', 'uid', 'locked', 'deleted', 'scheduled', 'postcount']);
 	const [userPrivileges, isAdministrator, isModerator, disabled, topicTools] = await Promise.all([
@@ -62,14 +62,15 @@ privsTopics.get = async function (tid, uid) {
 		'topics:schedule': privData['topics:schedule'] || isAdministrator,
 		'topics:tag': privData['topics:tag'] || isAdministrator,
 		'topics:delete': (privData['topics:delete'] && (isOwner || isModerator)) || isAdministrator,
-		'posts:edit': (privData['posts:edit'] && (!topicData.locked || isModerator)) || isAdministrator,
+		'posts:edit': (privData['posts:edit'] && (!topicData.locked || isModerator || privData.bypass_lock)) || isAdministrator,
 		'posts:history': privData['posts:history'] || isAdministrator,
 		'posts:upvote': privData['posts:upvote'] || isAdministrator,
 		'posts:downvote': privData['posts:downvote'] || isAdministrator,
-		'posts:delete': (privData['posts:delete'] && (!topicData.locked || isModerator)) || isAdministrator,
+		'posts:delete': (privData['posts:delete'] && (!topicData.locked || isModerator || privData.bypass_lock)) || isAdministrator,
 		'posts:view_deleted': privData['posts:view_deleted'] || isAdministrator,
 		read: privData.read || isAdministrator,
 		purge: (privData.purge && (isOwner || isModerator)) || isAdministrator,
+		bypass_lock: privData.bypass_lock || isAdministrator,
 
 		view_thread_tools: editable || deletable || hasTools || canMoveOwnTopic,
 		editable: editable,

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -168,7 +168,7 @@ module.exports = function (Topics) {
 				post.display_moderator_tools = post.display_edit_tools || post.display_delete_tools;
 				post.display_move_tools = topicPrivileges.isAdminOrMod && post.index !== 0;
 				post.display_post_menu = topicPrivileges.isAdminOrMod ||
-					(post.selfPost && !topicData.locked && !post.deleted) ||
+					(post.selfPost && (!topicData.locked || topicPrivileges.bypass_lock) && !post.deleted) ||
 					(post.selfPost && post.deleted && parseInt(post.deleterUid, 10) === parseInt(topicPrivileges.uid, 10)) ||
 					((loggedIn || topicData.postSharing.length) && !post.deleted);
 

--- a/test/categories.js
+++ b/test/categories.js
@@ -720,6 +720,7 @@ describe('Categories', () => {
 					'posts:downvote': false,
 					purge: false,
 					'posts:view_deleted': false,
+					bypass_lock: false,
 					moderate: false,
 				});
 
@@ -774,6 +775,7 @@ describe('Categories', () => {
 					'groups:topics:read': true,
 					'groups:purge': false,
 					'groups:posts:view_deleted': false,
+					'groups:bypass_lock': false,
 					'groups:moderate': false,
 				});
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -1396,6 +1396,7 @@ describe('Post\'s', () => {
 
 	describe('editing posts in locked topics', () => {
 		let ownerUid;
+		let tid;
 		let pid;
 
 		before(async () => {
@@ -1406,8 +1407,9 @@ describe('Post\'s', () => {
 				title: 'a topic that gets locked',
 				content: 'Some text here for the OP',
 			});
+			tid = topic.topicData.tid;
 			pid = topic.postData.pid;
-			await topics.setTopicField(topic.topicData.tid, 'locked', 1);
+			await topics.setTopicField(tid, 'locked', 1);
 		});
 
 		it('should not allow the owner to edit a post in a locked topic', async () => {
@@ -1432,6 +1434,33 @@ describe('Post\'s', () => {
 			} finally {
 				plugins.hooks.unregister('test-edit-locked', 'filter:privileges.posts.edit', method);
 			}
+		});
+
+		it('should not allow the owner to delete a post in a locked topic', async () => {
+			const { flag, message } = await privileges.posts.canDelete(pid, ownerUid);
+			assert.strictEqual(flag, false);
+			assert.strictEqual(message, '[[error:topic-locked]]');
+		});
+
+		it('should allow editing and deleting once bypass_lock is granted', async () => {
+			await privileges.categories.give(['groups:bypass_lock'], cid, 'registered-users');
+			try {
+				assert.strictEqual((await privileges.posts.canEdit(pid, ownerUid)).flag, true);
+				assert.strictEqual((await privileges.posts.canDelete(pid, ownerUid)).flag, true);
+
+				const topicPrivileges = await privileges.topics.get(tid, ownerUid);
+				assert.strictEqual(topicPrivileges.bypass_lock, true);
+				assert.strictEqual(topicPrivileges['posts:edit'], true);
+				assert.strictEqual(topicPrivileges['posts:delete'], true);
+			} finally {
+				await privileges.categories.rescind(['groups:bypass_lock'], cid, 'registered-users');
+			}
+		});
+
+		it('should go back to blocking edits once bypass_lock is rescinded', async () => {
+			const { flag, message } = await privileges.posts.canEdit(pid, ownerUid);
+			assert.strictEqual(flag, false);
+			assert.strictEqual(message, '[[error:topic-locked]]');
 		});
 	});
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -16,6 +16,7 @@ const categories = require('../src/categories');
 const privileges = require('../src/privileges');
 const user = require('../src/user');
 const groups = require('../src/groups');
+const plugins = require('../src/plugins');
 const socketPosts = require('../src/socket.io/posts');
 const apiPosts = require('../src/api/posts');
 const apiTopics = require('../src/api/topics');
@@ -1390,6 +1391,47 @@ describe('Post\'s', () => {
 
 			const { groups: groupNames } = await socketPosts.getEditors({ uid: ownerUid }, { pid: pid });
 			assert.deepStrictEqual(groupNames, []);
+		});
+	});
+
+	describe('editing posts in locked topics', () => {
+		let ownerUid;
+		let pid;
+
+		before(async () => {
+			ownerUid = await user.create({ username: 'locked topic owner' });
+			const topic = await topics.post({
+				uid: ownerUid,
+				cid,
+				title: 'a topic that gets locked',
+				content: 'Some text here for the OP',
+			});
+			pid = topic.postData.pid;
+			await topics.setTopicField(topic.topicData.tid, 'locked', 1);
+		});
+
+		it('should not allow the owner to edit a post in a locked topic', async () => {
+			const { flag, message } = await privileges.posts.canEdit(pid, ownerUid);
+			assert.strictEqual(flag, false);
+			assert.strictEqual(message, '[[error:topic-locked]]');
+		});
+
+		it('should let a plugin grant edit access by unsetting isLocked', async () => {
+			const method = (data) => {
+				assert.strictEqual(data.isLocked, true);
+				data.isLocked = false;
+				return data;
+			};
+			plugins.hooks.register('test-edit-locked', {
+				hook: 'filter:privileges.posts.edit',
+				method: method,
+			});
+			try {
+				const { flag } = await privileges.posts.canEdit(pid, ownerUid);
+				assert.strictEqual(flag, true);
+			} finally {
+				plugins.hooks.unregister('test-edit-locked', 'filter:privileges.posts.edit', method);
+			}
 		});
 	});
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #14710 — the first commit here is that PR. Please review/merge it first; this PR's own change is the second commit. (GitHub won't let me set a cross-fork branch as the base.)

### Problem

Locking a topic blocks post edits and deletes for everyone except administrators and moderators:

https://github.com/NodeBB/NodeBB/blob/master/src/privileges/posts.js#L177-L180
https://github.com/NodeBB/NodeBB/blob/master/src/privileges/posts.js#L217-L219

There is no way to let a trusted group keep maintaining their own posts in a closed thread without handing them the full `moderate` privilege over the category. Locking a thread is a "stop the conversation" action, but it currently doubles as "freeze everyone's existing content", and those two aren't always wanted together — e.g. archived support threads where the author still needs to correct an outdated answer.

### Change

A new `bypass_lock` category privilege, in the moderation column next to `purge` and `moderate`, granted to nobody by default. Holders are exempt from the topic lock in `canEdit` and `canDelete`; every other rule (`posts:edit` / `posts:delete`, ownership, edit/delete duration, the deleted-post guard) still applies exactly as before.

Naming follows the existing bare moderation privileges (`purge`, `moderate`) rather than a `posts:` prefix, since it gates a topic-level state rather than a single post action.

`privileges.topics.get` already folds the lock into `posts:edit` and `posts:delete`, so the client-side tools follow from one condition on each; the only other display change is the `!locked` term in `display_post_menu`, server-side and in `forum/topic/posts`.

**The lock still applies to replies.** `canReply` gates on `isAdminOrMod` and is untouched — `bypass_lock` only covers a user's existing posts, so granting it doesn't reopen a closed thread.

### Tests

`test/posts.js`: edit and delete are refused with `[[error:topic-locked]]` in a locked topic, both are allowed once `groups:bypass_lock` is granted (along with the corresponding `privileges.topics.get` flags), and refused again once it's rescinded. `test/categories.js`: the two privilege-list assertions include the new privilege.