### PR TITLE
fix: scope chat modal delete-room handler to room controls

### DIFF
--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -441,7 +441,7 @@ define('chat', [
 				Chats.addActionHandlers(chatModal.find('[component="chat/message/window"]'), roomId);
 				Chats.addRenameHandler(roomId, chatModal.find('[data-action="rename"]'));
 				Chats.addLeaveHandler(roomId, chatModal.find('[data-action="leave"]'));
-				Chats.addDeleteHandler(roomId, chatModal.find('[data-action="delete"]'));
+				Chats.addDeleteHandler(roomId, chatModal.find('[component="chat/controls"] [data-action="delete"]'));
 				Chats.addSendHandlers(roomId, chatModal.find('.chat-input'), chatModal.find('[data-action="send"]'));
 				Chats.addManageHandler(roomId, chatModal.find('[data-action="manage"]'));
 


### PR DESCRIPTION
## Problem

In the chat modal, deleting a chat message sometimes triggers a **second** confirm dialog asking whether to delete the entire chat room (for admins in public rooms).

## Cause

In `public/src/modules/chat.js`, the delete-room handler is bound with:

```js
Chats.addDeleteHandler(roomId, chatModal.find('[data-action="delete"]'));
```

This selector matches not only the "Delete Room" item in the room controls dropdown (`partials/chats/options.tpl`), but also every per-message delete menu item (`partials/chats/message.tpl`) present in the DOM when the modal is created. Clicking such a message's delete action then fires both the message-delete confirm (via the delegated handler in `Chats.addActionHandlers`) and the room-delete confirm.

It only reproduces in the chat modal (the full `/chats` page already scopes the lookup to `[component="chat/controls"]` in `public/src/client/chats.js`), and only for messages already rendered at modal load — messages added later never get the direct binding — which is why it appears intermittent.

## Fix

Scope the modal's lookup to the room controls, matching the chats page:

```js
chatModal.find('[component="chat/controls"] [data-action="delete"]')
```