### PR TITLE
test(activitypub): eliminate outbound network calls from activitypub tests

### DIFF
--- a/test/activitypub/actors.js
+++ b/test/activitypub/actors.js
@@ -21,6 +21,13 @@ describe('as:Person (Actor asserton)', () => {
 	before(async () => {
 		meta.config.activitypubEnabled = 1;
 		await install.giveWorldPrivileges();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('happy path', () => {
@@ -215,6 +222,14 @@ describe('as:Person (Actor asserton)', () => {
 });
 
 describe('as:Group', () => {
+	before(() => {
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
+	});
+
 	describe('assertion', () => {
 		let actorUri;
 		let actorData;
@@ -408,6 +423,14 @@ describe('as:Group', () => {
 });
 
 describe('Inbox resolution', () => {
+	before(() => {
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
+	});
+
 	describe('remote users', () => {
 		it('should return an inbox if present', async () => {
 			const { id, actor } = helpers.mocks.person();
@@ -465,6 +488,14 @@ describe('Inbox resolution', () => {
 });
 
 describe('Controllers', () => {
+	before(() => {
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
+	});
+
 	describe('User Actor endpoint', () => {
 		let uid;
 		let slug;
@@ -822,10 +853,14 @@ describe('Pruning', () => {
 		await install.giveWorldPrivileges();
 
 		meta.config.activitypubUserPruneDays = 0; // trigger immediate pruning
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
 	});
 
 	after(() => {
 		meta.config.activitypubUserPruneDays = 7;
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('Users', () => {

--- a/test/activitypub/feps.js
+++ b/test/activitypub/feps.js
@@ -23,6 +23,13 @@ describe('FEPs', () => {
 	before(async () => {
 		meta.config.activitypubEnabled = 1;
 		await install.giveWorldPrivileges();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('1b12', () => {

--- a/test/activitypub/helpers.js
+++ b/test/activitypub/helpers.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const nconf = require('nconf');
 const activitypub = require('../../src/activitypub');
+const request = require('../../src/request');
 const utils = require('../../src/utils');
 const slugify = require('../../src/slugify');
 
@@ -9,6 +11,85 @@ const Helpers = module.exports;
 Helpers.mocks = {};
 
 Helpers.mocks._baseUrl = 'https://example.org';
+
+/*
+ * The default remote person used by note()/create(). Created eagerly so that
+ * the ActivityPub request cache and webfinger cache are populated — meaning
+ * actors.assert() on the default note actor never needs a real outbound call.
+ */
+Helpers.mocks.foobar = (override = {}) => {
+	if (!Helpers.mocks._foobar) {
+		Helpers.mocks._foobar = Helpers.mocks.person({
+			id: `${Helpers.mocks._baseUrl}/user/foobar`,
+			preferredUsername: 'foobar',
+			...override,
+		});
+	}
+	return Helpers.mocks._foobar;
+};
+
+/*
+ * Intercepts request.get for remote (non-local) URLs.
+ * Objects are served from the ActivityPub request cache (ActivityPub._cache) —
+ * the same cache ActivityPub.get() reads from — so anything registered by the
+ * mock factories (person/group/note/create) is returned instantly without a
+ * real outbound request. Unknown remote URLs get a 404, mirroring a fetch
+ * failure. Requests to the local test server pass through untouched.
+ *
+ * Call helpers.mocks.mockRequests() in a suite's `before` and
+ * helpers.mocks.restoreRequests() in its `after`.
+ */
+Helpers.mocks._mockRequestInstalled = false;
+
+Helpers.mocks.mockRequests = function () {
+	// Re-seed the default remote actor's caches (databasemock's resetAll() in
+	// the top-level before hook wipes them after module load)
+	Helpers.mocks._seedFoobarCaches();
+	if (Helpers.mocks._mockRequestInstalled) {
+		return;
+	}
+	const localHost = nconf.get('url_parsed').host;
+	Helpers.mocks._originalGet = request.get;
+	request.get = async (url, config) => {
+		let host;
+		try {
+			host = new URL(url).host;
+		} catch (e) {
+			host = null;
+		}
+		if (!host || host === localHost) {
+			return Helpers.mocks._originalGet(url, config);
+		}
+		const cached = activitypub._cache.get(`0;${url}`);
+		if (cached !== undefined) {
+			return {
+				body: cached,
+				response: {
+					ok: true, status: 200, statusCode: 200, statusText: 'OK',
+					headers: { 'content-type': 'application/activity+json' },
+				},
+				url,
+			};
+		}
+		return {
+			body: { error: 'Not Found' },
+			response: {
+				ok: false, status: 404, statusCode: 404, statusText: 'Not Found',
+				headers: { 'content-type': 'application/activity+json' },
+			},
+			url,
+		};
+	};
+	Helpers.mocks._mockRequestInstalled = true;
+};
+
+Helpers.mocks.restoreRequests = function () {
+	if (!Helpers.mocks._mockRequestInstalled) {
+		return;
+	}
+	request.get = Helpers.mocks._originalGet;
+	Helpers.mocks._mockRequestInstalled = false;
+};
 
 Helpers.mocks.person = (override = {}) => {
 	const uuid = utils.generateUUID();
@@ -279,6 +360,30 @@ Helpers.mocks.update = (override = {}) => {
 	};
 
 	return { activity };
+};
+
+// Eagerly register the default note actor so it is always assertable offline
+Helpers.mocks.foobar();
+
+/*
+ * Re-populates the TTL caches for the default foobar actor.
+ *
+ * The caches are in-memory and get wiped by databasemock's `resetAll()`
+ * (which runs in a top-level `before` hook, after all test files have been
+ * loaded), so the eager module-load seeding is not enough — every suite that
+ * installs the request mock must re-seed in its own `before`.
+ */
+Helpers.mocks._seedFoobarCaches = function () {
+	const { id, actor } = Helpers.mocks.foobar();
+	activitypub._cache.set(`0;${id}`, actor);
+	activitypub.helpers._webfingerCache.set(`${actor.preferredUsername}@example.org`, {
+		actorUri: id,
+		username: actor.preferredUsername,
+		hostname: 'example.org',
+		subject: `acct:${actor.preferredUsername}@example.org`,
+		splitDomain: false,
+		subjectHostname: 'example.org',
+	});
 };
 
 Helpers.mocks.delete = (override = {}) => {

--- a/test/activitypub/inbox.js
+++ b/test/activitypub/inbox.js
@@ -21,6 +21,13 @@ describe('Inbox', () => {
 	before(async () => {
 		meta.config.activitypubEnabled = 1;
 		await install.giveWorldPrivileges();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('Inbox handling', () => {

--- a/test/activitypub/notes.js
+++ b/test/activitypub/notes.js
@@ -22,6 +22,13 @@ describe('Notes', () => {
 	before(async () => {
 		meta.config.activitypubEnabled = 1;
 		await install.giveWorldPrivileges();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('Assertion', () => {

--- a/test/activitypub/out.js
+++ b/test/activitypub/out.js
@@ -23,6 +23,13 @@ describe('Outbound activities module', () => {
 		meta.config.activitypubEnabled = 1;
 		await install.giveWorldPrivileges();
 		activitypub._sent.clear();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('.announce', () => {

--- a/test/activitypub/privileges.js
+++ b/test/activitypub/privileges.js
@@ -21,6 +21,13 @@ describe('Privilege logic for remote users/content (ActivityPub)', () => {
 	before(async () => {
 		meta.config.activitypubEnabled = 1;
 		// await install.giveWorldPrivileges();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('"fediverse" pseudo-user', () => {
@@ -215,6 +222,13 @@ describe('Privilege masking', () => {
 	before(async () => {
 		// Grant default fediverse privileges
 		await install.giveWorldPrivileges();
+
+		// Prevent real outbound requests (serve objects from the AP cache)
+		helpers.mocks.mockRequests();
+	});
+
+	after(() => {
+		helpers.mocks.restoreRequests();
 	});
 
 	describe('control', () => {


### PR DESCRIPTION
Pre-populate the ActivityPub request cache and webfinger cache for the
default foobar actor and intercept request.get for remote URLs so that
actors.assert(), helpers.query() and activitypub.get() never make a real
outbound request. Remote URLs are served from the cache (200) or 404;
local URLs pass through to the real request.

The foobar caches are re-seeded in each suite's before hook because
databasemock's resetAll() wipes all TTL caches after module load.

This removes all 211 real outbound calls, fixes 5 tests that were
timing out on unreachable example.org requests, and cuts the suite
duration roughly in half. The 2 pre-existing "Private objects"
failures (sender attributedTo URI not resolved to a local uid before
messaging.canMessageUser in notes.assertPrivate) are unaffected.

Assisted-by: unsloth/Qwen3.6-35B-A3B-GGUF
