### PR TITLE
audit split domain

### DIFF
--- a/public/language/en-GB/admin/settings/activitypub.json
+++ b/public/language/en-GB/admin/settings/activitypub.json
@@ -14,7 +14,7 @@
 	"allowLoopback": "Allow loopback processing",
 	"allowLoopback-help": "Useful for debugging purposes only. You should probably leave this disabled.",
 	"allowSplitDomain": "Allow split-domain federation",
-	"allowSplitDomain-help": "Enable to allow actors whose WebFinger handle domain differs from their ActivityPub document domain. This is useful for instances that separate identity (WebFinger) from content hosting (ActivityPub).",
+	"allowSplitDomain-help": "Enable to allow actors whose WebFinger handle domain differs from their ActivityPub document domain. This is useful for instances that separate identity (WebFinger) from content hosting (ActivityPub). Note: the canonical (WebFinger) domain is the trust anchor — its WebFinger record must reference the actor document, and, when both sides publish a public key, the keys must match. Handles verified without a key match rely on the URL reference alone, so treat split-domain handles from domains with weak WebFinger hygiene with caution.",
 	"parentTraversalDepth": "Parent traversal depth",
 	"parentTraversalDepth-help": "Maximum number of times to traverse up the reply chain when building context. (Default: 50)",
 

--- a/src/activitypub/actors.js
+++ b/src/activitypub/actors.js
@@ -154,7 +154,13 @@ Actors.assert = async (ids, options = {}) => {
 			}
 
 			// Two-way WebFinger verification (includes backreference + optional split-domain forward check).
-			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor);
+			// The self-attested self-link fallback is only allowed for actors/groups
+			// with an existing persisted record (audit F-4)
+			const knownActor = await db.exists(`userRemote:${actor.id}`) ||
+				await db.exists(`categoryRemote:${actor.id}`);
+			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor, {
+				allowSelfLinkFallback: knownActor,
+			});
 			if (!verdict || !verdict.ok) {
 				activitypub.helpers.log(`[activitypub/actors] Webfinger verification failed (${verdict?.reason || 'unknown'}) for ${actor.id}`);
 				return null;
@@ -348,7 +354,12 @@ Actors.assertGroup = async (ids, options = {}) => {
 			}
 
 			// Two-way WebFinger verification (backreference check for security).
-			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor);
+			// The self-attested self-link fallback is only allowed for groups with an
+			// existing persisted record (audit F-4)
+			const knownGroup = await db.exists(`categoryRemote:${actor.id}`);
+			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor, {
+				allowSelfLinkFallback: knownGroup,
+			});
 			if (!verdict || !verdict.ok) {
 				activitypub.helpers.log(`[activitypub/actors] Webfinger verification failed (${verdict?.reason || 'unknown'}) for ${actor.id}`);
 				return null;

--- a/src/activitypub/actors.js
+++ b/src/activitypub/actors.js
@@ -154,8 +154,6 @@ Actors.assert = async (ids, options = {}) => {
 			}
 
 			// Two-way WebFinger verification (includes backreference + optional split-domain forward check).
-			// The self-attested self-link fallback is only allowed for actors/groups
-			// with an existing persisted record (audit F-4)
 			const knownActor = await db.exists(`userRemote:${actor.id}`) ||
 				await db.exists(`categoryRemote:${actor.id}`);
 			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor, {
@@ -354,8 +352,6 @@ Actors.assertGroup = async (ids, options = {}) => {
 			}
 
 			// Two-way WebFinger verification (backreference check for security).
-			// The self-attested self-link fallback is only allowed for groups with an
-			// existing persisted record (audit F-4)
 			const knownGroup = await db.exists(`categoryRemote:${actor.id}`);
 			const verdict = await activitypub.helpers.verifyActorWebfinger(actor.id, actor, {
 				allowSelfLinkFallback: knownGroup,

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -131,6 +131,20 @@ Helpers.isWebfinger = (value) => {
 	return false;
 };
 
+// Normalized webfinger cache key: username case is preserved (usernames may
+// be case-sensitive), hostname is lowercased (hostnames are case-insensitive;
+// URI ids normalize via the URL parser). All webfinger cache read/write paths
+// must use this so case variants can never produce divergent entries (audit F-7)
+Helpers._webfingerKey = (id) => {
+	if (Helpers.isUri(id)) {
+		const uri = new URL(id);
+		return `${uri.pathname || uri.href}@${uri.hostname}`;
+	}
+
+	const [username, hostname] = String(id).split('@');
+	return `${(username || '').trim()}@${(hostname || '').trim().toLowerCase()}`;
+};
+
 Helpers.query = async (id, { strict = true } = {}) => {
 	const isUri = Helpers.isUri(id);
 	// username@host ids use acct: URI schema
@@ -154,12 +168,15 @@ Helpers.query = async (id, { strict = true } = {}) => {
 		return false;
 	}
 
+	// Normalize the cache key (hostnames are case-insensitive, audit F-7)
+	const key = Helpers._webfingerKey(id);
+
 	// Short-circuit recent transport-level failures for this exact id (audit F-4)
-	if (failedWebfingerQueryCache.has(id)) {
+	if (failedWebfingerQueryCache.has(key)) {
 		return false;
 	}
 
-	const cached = webfingerCache.get(id);
+	const cached = webfingerCache.get(key);
 	// A cached entry that carries a hostname only answers queries for the domain
 	// it was fetched from — entries stored under this key while querying a
 	// different domain must not be served (cross-domain cache poisoning, audit
@@ -185,12 +202,12 @@ Helpers.query = async (id, { strict = true } = {}) => {
 			timeout: 5000,
 		}));
 	} catch (e) {
-		failedWebfingerQueryCache.set(id, true);
+		failedWebfingerQueryCache.set(key, true);
 		return false;
 	}
 
 	if (response.statusCode !== 200) {
-		failedWebfingerQueryCache.set(id, true);
+		failedWebfingerQueryCache.set(key, true);
 		return false;
 	}
 
@@ -273,7 +290,7 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	// let a response served by one domain answer WebFinger queries about a
 	// *different* domain's handle, which the non-strict backref read in
 	// verifyActorWebfinger would then trust (audit F-1)
-	webfingerCache.set(id, payload);
+	webfingerCache.set(key, payload);
 
 	return payload;
 };

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -29,11 +29,20 @@ const webfingerCache = ttl({
 	max: 5000,
 	ttl: 1000 * 60 * 60 * 24, // 24 hours
 });
+// Recent transport-level webfinger query failures (network error / non-200) —
+// a broken or revoked webfinger endpoint must not be re-queried on every
+// interaction (audit F-4)
+const failedWebfingerQueryCache = ttl({
+	name: 'ap-webfinger-query-failures',
+	max: 5000,
+	ttl: 1000 * 60 * 10, // 10 minutes
+});
 const sha256 = payload => crypto.createHash('sha256').update(payload).digest('hex');
 
 const Helpers = module.exports;
 
 Helpers._webfingerCache = webfingerCache; // exported for tests
+Helpers._failedWebfingerQueryCache = failedWebfingerQueryCache; // exported for tests
 
 Helpers._test = (method, args) => {
 	// because I am lazy and I probably wrote some variant of this below code 1000 times already
@@ -145,6 +154,11 @@ Helpers.query = async (id, { strict = true } = {}) => {
 		return false;
 	}
 
+	// Short-circuit recent transport-level failures for this exact id (audit F-4)
+	if (failedWebfingerQueryCache.has(id)) {
+		return false;
+	}
+
 	const cached = webfingerCache.get(id);
 	// A cached entry that carries a hostname only answers queries for the domain
 	// it was fetched from — entries stored under this key while querying a
@@ -171,10 +185,12 @@ Helpers.query = async (id, { strict = true } = {}) => {
 			timeout: 5000,
 		}));
 	} catch (e) {
+		failedWebfingerQueryCache.set(id, true);
 		return false;
 	}
 
 	if (response.statusCode !== 200) {
+		failedWebfingerQueryCache.set(id, true);
 		return false;
 	}
 
@@ -262,7 +278,7 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	return payload;
 };
 
-Helpers.verifyActorWebfinger = async (actorId, actor) => {
+Helpers.verifyActorWebfinger = async (actorId, actor, { allowSelfLinkFallback = false } = {}) => {
 	if (!Helpers.isUri(actorId)) {
 		return false;
 	}
@@ -282,9 +298,10 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 	let backref = await Helpers.query(`${preferredUsername}@${idHostname}`, { strict: false });
 
 	// Fallback for legacy actors (pre-split-domain): if WebFinger query fails, check
-	// the actor document for a self-link pointing to its own URI. This handles actors
-	// that were asserted before split-domain logic required WebFinger backreferences.
-	if (!backref && Helpers._hasValidSelfLink(actorId, actor)) {
+	// the actor document for a self-link pointing to its own URI. Self-attested,
+	// so only allowed for actors with a persisted record — first-time assertions
+	// require a live webfinger backref (audit F-4).
+	if (!backref && allowSelfLinkFallback && Helpers._hasValidSelfLink(actorId, actor)) {
 		backref = {
 			actorUri: actorId,
 			subject: `acct:${preferredUsername}@${idHostname}`,
@@ -337,6 +354,24 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'forward-mismatch' };
 	}
 
+	// Cross-check the key the identity domain published against the actor
+	// document's key. A mismatch means the canonical domain is vouching for a key
+	// it does not hold → reject. Absent keys cannot be compared (some split-domain
+	// deployments do not expose the content-domain key in the identity domain's
+	// webfinger) → proceed with keyVerified: false (audit F-3).
+	let keyVerified = false;
+	const forwardPem = forwardResult.publicKey?.publicKeyPem;
+	const actorPem = actor.publicKey?.publicKeyPem;
+	if (typeof forwardPem === 'string' && forwardPem.trim() &&
+		typeof actorPem === 'string' && actorPem.trim()) {
+		if (forwardPem.trim() !== actorPem.trim()) {
+			return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'key-mismatch' };
+		}
+		keyVerified = true;
+	} else {
+		winston.warn(`[activitypub] Split-domain actor ${actorId} verified without key comparison (key missing from forward webfinger or actor document)`);
+	}
+
 	const blocked = await activitypub.instances.isAllowed(normalizedSubjectHost);
 	if (!blocked.allowed) {
 		return {
@@ -352,6 +387,7 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 		splitDomain: true,
 		canonicalHandle: `${preferredUsername}@${normalizedSubjectHost}`,
 		reason: 'split-domain',
+		keyVerified,
 	};
 };
 

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -132,7 +132,13 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	hostname = hostname.trim();
 
 	const cached = webfingerCache.get(id);
-	if (cached !== undefined && !(strict && cached.splitDomain)) {
+	// A cached entry that carries a hostname only answers queries for the domain
+	// it was fetched from — entries stored under this key while querying a
+	// different domain must not be served (cross-domain cache poisoning, audit
+	// F-1). Entries without a hostname (legacy minimal entries) are served as before.
+	const fromSameHost = !cached?.hostname ||
+		(typeof cached.hostname === 'string' && cached.hostname.toLowerCase() === hostname.toLowerCase());
+	if (cached !== undefined && fromSameHost && !(strict && cached.splitDomain)) {
 		return cached;
 	}
 
@@ -230,16 +236,14 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	const payload = {
 		subject, username, hostname, actorUri, publicKey,
 		_raw: body,
-		subjectHostname: subjectUrl.protocol === 'acct:' ? subjectHostname : subjectHostname,
+		subjectHostname,
 		splitDomain,
 	};
-	const claimedId = subjectUrl.pathname;
-	// Always cache by the queried id so subsequent queries hit the cache
+	// Cache only by the queried id. Caching by the claimed subject (an "alias")
+	// let a response served by one domain answer WebFinger queries about a
+	// *different* domain's handle, which the non-strict backref read in
+	// verifyActorWebfinger would then trust (audit F-1)
 	webfingerCache.set(id, payload);
-	// Also cache by the claimed subject path for alias lookups
-	if (claimedId !== id) {
-		webfingerCache.set(claimedId, payload);
-	}
 
 	return payload;
 };
@@ -275,6 +279,17 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 	// The backreference self-link must point at this exact actor document.
 	if (backref.actorUri !== actorId) {
 		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'subject-mismatch' };
+	}
+
+	// The WebFinger record must be about the account that was queried — a record
+	// served for a different account cannot vouch for this actor (audit F-1)
+	if (typeof backref.subject === 'string' && backref.subject.startsWith('acct:')) {
+		const opaque = backref.subject.slice(5);
+		const subjectAt = opaque.lastIndexOf('@');
+		const subjectUser = subjectAt === -1 ? null : opaque.slice(0, subjectAt);
+		if (subjectUser !== null && subjectUser !== preferredUsername) {
+			return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'subject-mismatch' };
+		}
 	}
 
 	// The subject's hostname tells us the canonical domain (A).

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -21,17 +21,12 @@ const activitypub = require('.');
 
 // \w only matches ASCII, so match unicode letters/numbers/marks explicitly to support non-ASCII handles
 const webfingerRegex = /^(@|acct:)?[\p{L}\p{N}\p{M}_.-]+@.+$/u;
-// WebFinger username charset — used to validate actor.preferredUsername before it
-// is reflected into a WebFinger query target (audit F-2)
 const webfingerUserRegex = /^[\p{L}\p{N}\p{M}_.-]+$/u;
 const webfingerCache = ttl({
 	name: 'ap-webfinger-cache',
 	max: 5000,
 	ttl: 1000 * 60 * 60 * 24, // 24 hours
 });
-// Recent transport-level webfinger query failures (network error / non-200) —
-// a broken or revoked webfinger endpoint must not be re-queried on every
-// interaction (audit F-4)
 const failedWebfingerQueryCache = ttl({
 	name: 'ap-webfinger-query-failures',
 	max: 5000,
@@ -131,10 +126,6 @@ Helpers.isWebfinger = (value) => {
 	return false;
 };
 
-// Normalized webfinger cache key: username case is preserved (usernames may
-// be case-sensitive), hostname is lowercased (hostnames are case-insensitive;
-// URI ids normalize via the URL parser). All webfinger cache read/write paths
-// must use this so case variants can never produce divergent entries (audit F-7)
 Helpers._webfingerKey = (id) => {
 	if (Helpers.isUri(id)) {
 		const uri = new URL(id);
@@ -157,9 +148,6 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	username = username.trim();
 	hostname = hostname.trim();
 
-	// Reject hostnames that do not round-trip through the URL parser (ports, paths,
-	// spaces, ...) — otherwise they would steer the WebFinger request to an
-	// unintended host or path (audit F-2)
 	try {
 		if (new URL(`https://${hostname}/`).hostname.toLowerCase() !== hostname.toLowerCase()) {
 			return false;
@@ -168,27 +156,18 @@ Helpers.query = async (id, { strict = true } = {}) => {
 		return false;
 	}
 
-	// Normalize the cache key (hostnames are case-insensitive, audit F-7)
 	const key = Helpers._webfingerKey(id);
-
-	// Short-circuit recent transport-level failures for this exact id (audit F-4)
 	if (failedWebfingerQueryCache.has(key)) {
 		return false;
 	}
 
 	const cached = webfingerCache.get(key);
-	// A cached entry that carries a hostname only answers queries for the domain
-	// it was fetched from — entries stored under this key while querying a
-	// different domain must not be served (cross-domain cache poisoning, audit
-	// F-1). Entries without a hostname (legacy minimal entries) are served as before.
 	const fromSameHost = !cached?.hostname ||
 		(typeof cached.hostname === 'string' && cached.hostname.toLowerCase() === hostname.toLowerCase());
 	if (cached !== undefined && fromSameHost && !(strict && cached.splitDomain)) {
 		return cached;
 	}
 
-	// Build the resource from the raw id; URL serialization percent-encodes non-ASCII
-	// characters, which URLSearchParams would then encode a second time
 	const query = new URLSearchParams({ resource: isUri ? uri.href : `acct:${username}@${hostname}` });
 
 	// Make a webfinger query to retrieve routing information
@@ -211,8 +190,6 @@ Helpers.query = async (id, { strict = true } = {}) => {
 		return false;
 	}
 
-	// Validate content-type; most servers advertise jrd+json, but some (e.g. GitHub Pages)
-	// serve application/octet-stream — attempt to parse as JSON in that case.
 	const contentType = (response.headers?.['content-type'] || '').toLowerCase();
 	if (contentType && !contentType.includes('application/jrd+json') && !contentType.includes('application/json')) {
 		if (!contentType.includes('application/octet-stream')) {
@@ -286,10 +263,6 @@ Helpers.query = async (id, { strict = true } = {}) => {
 		subjectHostname,
 		splitDomain,
 	};
-	// Cache only by the queried id. Caching by the claimed subject (an "alias")
-	// let a response served by one domain answer WebFinger queries about a
-	// *different* domain's handle, which the non-strict backref read in
-	// verifyActorWebfinger would then trust (audit F-1)
 	webfingerCache.set(key, payload);
 
 	return payload;
@@ -301,9 +274,6 @@ Helpers.verifyActorWebfinger = async (actorId, actor, { allowSelfLinkFallback = 
 	}
 
 	const idHostname = new URL(actorId).hostname;
-	// preferredUsername is reflected verbatim into the WebFinger query target
-	// (`username@hostname`); restrict it to the WebFinger username charset so an
-	// attacker-supplied value cannot redirect the query to another host (audit F-2)
 	const preferredUsername = typeof actor.preferredUsername === 'string' ?
 		actor.preferredUsername.trim() : '';
 	if (!webfingerUserRegex.test(preferredUsername)) {
@@ -314,10 +284,6 @@ Helpers.verifyActorWebfinger = async (actorId, actor, { allowSelfLinkFallback = 
 	// This allows the WebFinger subject to point elsewhere (split-domain forward target).
 	let backref = await Helpers.query(`${preferredUsername}@${idHostname}`, { strict: false });
 
-	// Fallback for legacy actors (pre-split-domain): if WebFinger query fails, check
-	// the actor document for a self-link pointing to its own URI. Self-attested,
-	// so only allowed for actors with a persisted record — first-time assertions
-	// require a live webfinger backref (audit F-4).
 	if (!backref && allowSelfLinkFallback && Helpers._hasValidSelfLink(actorId, actor)) {
 		backref = {
 			actorUri: actorId,
@@ -336,8 +302,6 @@ Helpers.verifyActorWebfinger = async (actorId, actor, { allowSelfLinkFallback = 
 		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'subject-mismatch' };
 	}
 
-	// The WebFinger record must be about the account that was queried — a record
-	// served for a different account cannot vouch for this actor (audit F-1)
 	if (typeof backref.subject === 'string' && backref.subject.startsWith('acct:')) {
 		const opaque = backref.subject.slice(5);
 		const subjectAt = opaque.lastIndexOf('@');
@@ -371,11 +335,7 @@ Helpers.verifyActorWebfinger = async (actorId, actor, { allowSelfLinkFallback = 
 		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'forward-mismatch' };
 	}
 
-	// Cross-check the key the identity domain published against the actor
-	// document's key. A mismatch means the canonical domain is vouching for a key
-	// it does not hold → reject. Absent keys cannot be compared (some split-domain
-	// deployments do not expose the content-domain key in the identity domain's
-	// webfinger) → proceed with keyVerified: false (audit F-3).
+	// Cross-check the key the identity domain published against the actor document's key.
 	let keyVerified = false;
 	const forwardPem = forwardResult.publicKey?.publicKeyPem;
 	const actorPem = actor.publicKey?.publicKeyPem;

--- a/src/activitypub/helpers.js
+++ b/src/activitypub/helpers.js
@@ -21,6 +21,9 @@ const activitypub = require('.');
 
 // \w only matches ASCII, so match unicode letters/numbers/marks explicitly to support non-ASCII handles
 const webfingerRegex = /^(@|acct:)?[\p{L}\p{N}\p{M}_.-]+@.+$/u;
+// WebFinger username charset — used to validate actor.preferredUsername before it
+// is reflected into a WebFinger query target (audit F-2)
+const webfingerUserRegex = /^[\p{L}\p{N}\p{M}_.-]+$/u;
 const webfingerCache = ttl({
 	name: 'ap-webfinger-cache',
 	max: 5000,
@@ -130,6 +133,17 @@ Helpers.query = async (id, { strict = true } = {}) => {
 	}
 	username = username.trim();
 	hostname = hostname.trim();
+
+	// Reject hostnames that do not round-trip through the URL parser (ports, paths,
+	// spaces, ...) — otherwise they would steer the WebFinger request to an
+	// unintended host or path (audit F-2)
+	try {
+		if (new URL(`https://${hostname}/`).hostname.toLowerCase() !== hostname.toLowerCase()) {
+			return false;
+		}
+	} catch (e) {
+		return false;
+	}
 
 	const cached = webfingerCache.get(id);
 	// A cached entry that carries a hostname only answers queries for the domain
@@ -254,7 +268,14 @@ Helpers.verifyActorWebfinger = async (actorId, actor) => {
 	}
 
 	const idHostname = new URL(actorId).hostname;
-	const preferredUsername = actor.preferredUsername || 'user';
+	// preferredUsername is reflected verbatim into the WebFinger query target
+	// (`username@hostname`); restrict it to the WebFinger username charset so an
+	// attacker-supplied value cannot redirect the query to another host (audit F-2)
+	const preferredUsername = typeof actor.preferredUsername === 'string' ?
+		actor.preferredUsername.trim() : '';
+	if (!webfingerUserRegex.test(preferredUsername)) {
+		return { ok: false, splitDomain: false, canonicalHandle: null, reason: 'no-backreference' };
+	}
 
 	// Step 1: Backreference — non-strict query on domain B (the actor's id host).
 	// This allows the WebFinger subject to point elsewhere (split-domain forward target).

--- a/src/user/search.js
+++ b/src/user/search.js
@@ -50,9 +50,17 @@ module.exports = function (User) {
 					} else {
 						const assertion = await activitypub.actors.assert([handle || data.query]);
 						if (assertion === true) {
-							// Actor already exists; resolve UID from webfinger cache
-							const cached = handle ? activitypub.helpers._webfingerCache.get(handle) : null;
-							uids = cached ? [cached.actorUri] : [handle ? await User.getUidByUserslug(handle) : query];
+							// Actor already exists; prefer the persisted handle:uid mapping
+							// over the webfinger cache, which can hold a stale entry for a
+							// re-resolved handle (audit F-7)
+							const resolved = handle ? await db.getObjectField('handle:uid', handle.toLowerCase()) : null;
+							if (resolved) {
+								uids = [resolved];
+							} else {
+								const wfKey = handle ? activitypub.helpers._webfingerKey(handle) : false;
+								const cached = wfKey ? activitypub.helpers._webfingerCache.get(wfKey) : null;
+								uids = cached ? [cached.actorUri] : [handle ? await User.getUidByUserslug(handle) : query];
+							}
 						} else if (Array.isArray(assertion) && assertion.length) {
 							uids = assertion.map(u => u.id);
 						}

--- a/src/user/search.js
+++ b/src/user/search.js
@@ -50,9 +50,6 @@ module.exports = function (User) {
 					} else {
 						const assertion = await activitypub.actors.assert([handle || data.query]);
 						if (assertion === true) {
-							// Actor already exists; prefer the persisted handle:uid mapping
-							// over the webfinger cache, which can hold a stale entry for a
-							// re-resolved handle (audit F-7)
 							const resolved = handle ? await db.getObjectField('handle:uid', handle.toLowerCase()) : null;
 							if (resolved) {
 								uids = [resolved];

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -800,3 +800,24 @@ describe('Webfinger failure negative cache (audit F-4)', () => {
 		assert.equal(getCalled, 2);
 	});
 });
+
+// ============================================================================
+
+describe('Webfinger cache key normalization (audit F-7)', () => {
+	beforeEach(Helpers.reset);
+
+	it('serves cached entries for case variants of the hostname', async () => {
+		const { domainB, username, actorUri } = Helpers.genSplitDomain();
+		Helpers.seedSameDomainWebfinger(domainB, username, actorUri);
+		// Uppercase hostname variant of the same handle must hit the same key
+		const result = await activitypub.helpers.query(`${username}@${domainB.toUpperCase()}`);
+		assert.ok(result);
+		assert.equal(result.actorUri, actorUri);
+	});
+
+	it('normalizes keys with lowercase hostnames and preserved username case', () => {
+		assert.equal(activitypub.helpers._webfingerKey('User@EXAMPLE.com'), 'User@example.com');
+		assert.equal(activitypub.helpers._webfingerKey('user@example.com'), 'user@example.com');
+		assert.equal(activitypub.helpers._webfingerKey('https://Example.COM/user'), '/user@example.com');
+	});
+});

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -535,3 +535,84 @@ describe('WebFinger cache poisoning (audit F-1)', () => {
 		assert.equal(verdict.reason, 'subject-mismatch');
 	});
 });
+
+// ============================================================================
+
+describe('preferredUsername / hostname validation (audit F-2)', () => {
+	let originalGet;
+	let getCalled;
+
+	beforeEach(Helpers.reset);
+
+	afterEach(() => {
+		if (originalGet) {
+			request.get = originalGet;
+			originalGet = null;
+		}
+	});
+
+	const spyGet = () => {
+		getCalled = 0;
+		originalGet = request.get;
+		request.get = async () => {
+			getCalled += 1;
+			return {
+				body: {},
+				response: { statusCode: 404, headers: { 'content-type': 'application/jrd+json' } },
+			};
+		};
+	};
+
+	it('does not issue a webfinger request for an attacker-shaped preferredUsername', async () => {
+		const { actorUri } = Helpers.genSplitDomain();
+		// preferredUsername containing @ / port would put attacker-controlled
+		// values into the query's hostname slot
+		const actor = Helpers.seedActor(actorUri, { preferredUsername: 'x@other.example:8443' });
+		spyGet();
+
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, actor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'no-backreference');
+		assert.equal(getCalled, 0);
+	});
+
+	it('rejects missing or non-string preferredUsername without a webfinger request', async () => {
+		const { actorUri } = Helpers.genSplitDomain();
+		const noUsername = Helpers.seedActor(actorUri, { preferredUsername: undefined });
+		delete noUsername.preferredUsername;
+		const badType = Helpers.seedActor(actorUri, { preferredUsername: 12345 });
+		spyGet();
+
+		const verdictA = await activitypub.helpers.verifyActorWebfinger(actorUri, noUsername);
+		assert.ok(verdictA);
+		assert.equal(verdictA.ok, false);
+		assert.equal(verdictA.reason, 'no-backreference');
+
+		const verdictB = await activitypub.helpers.verifyActorWebfinger(actorUri, badType);
+		assert.ok(verdictB);
+		assert.equal(verdictB.ok, false);
+		assert.equal(verdictB.reason, 'no-backreference');
+		assert.equal(getCalled, 0);
+	});
+
+	it('query() rejects port-bearing and path-bearing hostnames before any request', async () => {
+		spyGet();
+		const r1 = await activitypub.helpers.query('user@target.example:8443', { strict: false });
+		const r2 = await activitypub.helpers.query('user@b/c', { strict: false });
+		const r3 = await activitypub.helpers.query('user@space host', { strict: false });
+		assert.equal(r1, false);
+		assert.equal(r2, false);
+		assert.equal(r3, false);
+		assert.equal(getCalled, 0);
+	});
+
+	it('query() still fetches normally for plain hostnames', async () => {
+		const { domainB } = Helpers.genSplitDomain();
+		spyGet();
+		const result = await activitypub.helpers.query(`user@${domainB}`, { strict: false });
+		// mock returns 404 → false, but the request must have been made
+		assert.equal(result, false);
+		assert.equal(getCalled, 1);
+	});
+});

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -5,6 +5,7 @@ const nconf = require('nconf');
 const meta = require('../../src/meta');
 const utils = require('../../src/utils');
 const request = require('../../src/request');
+const db = require('../../src/database');
 
 const activitypub = require('../../src/activitypub');
 
@@ -65,6 +66,7 @@ Helpers.seedActor = (actorUri, overrides = {}) => {
 Helpers.reset = () => {
 	activitypub._cache.reset();
 	activitypub.helpers._webfingerCache.reset();
+	activitypub.helpers._failedWebfingerQueryCache.reset();
 	nconf.set('activitypubAllowSplitDomain', 1);
 	meta.config.activitypubAllowSplitDomain = 1;
 	nconf.set('activitypubAllowLoopback', 0);
@@ -164,8 +166,10 @@ describe('verifyActorWebfinger', () => {
 		const { domainB, username, actorUri } = Helpers.genSplitDomain();
 		// Seed actor with a link array containing rel=self (simulates real AP actor docs)
 		const actor = Helpers.seedActor(actorUri, { preferredUsername: username, link: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] });
+		// allowSelfLinkFallback: true simulates an actor with a persisted record
+		// (first-time assertions require a live webfinger backref, audit F-4)
 		const verdict = await activitypub.helpers.verifyActorWebfinger(
-			actorUri, activitypub._cache.get(`0;${actorUri}`));
+			actorUri, activitypub._cache.get(`0;${actorUri}`), { allowSelfLinkFallback: true });
 		assert.ok(verdict);
 		assert.ok(verdict.ok);
 		assert.equal(verdict.canonicalHandle, `${username}@${domainB}`);
@@ -288,7 +292,10 @@ describe('Actors.assert - hostname mismatch', () => {
 	it('upgrades same-domain legacy actors via self-link fallback', async () => {
 		const { domainB, username, actorUri } = Helpers.genSplitDomain();
 		// Seed actor with link array (rel=self) — simulates real AP actor doc
-		const actor = Helpers.seedActor(actorUri, { preferredUsername: username, link: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] });
+		Helpers.seedActor(actorUri, { preferredUsername: username, link: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] });
+		// Persisted record — the actor was asserted before webfinger verification
+		// existed, so the self-attested fallback is allowed (audit F-4)
+		await db.setObject(`userRemote:${actorUri}`, { username: 'legacy_actor' });
 		const result = await activitypub.actors.assert([actorUri]);
 		assert.ok(Array.isArray(result));
 		assert.equal(result.length, 1);
@@ -614,5 +621,182 @@ describe('preferredUsername / hostname validation (audit F-2)', () => {
 		// mock returns 404 → false, but the request must have been made
 		assert.equal(result, false);
 		assert.equal(getCalled, 1);
+	});
+});
+
+// ============================================================================
+
+describe('Split-domain key cross-check (audit F-3)', () => {
+	beforeEach(Helpers.reset);
+
+	const seedKeys = (domainA, domainB, username, actorUri, forwardPem) => {
+		activitypub.helpers._webfingerCache.set(`${username}@${domainB}`, {
+			actorUri, username, hostname: domainB,
+			subject: `acct:${username}@${domainA}`, splitDomain: true, subjectHostname: domainA,
+			publicKey: forwardPem ? { id: `https://${domainA}/${username}#key`, owner: `acct:${username}@${domainA}`, publicKeyPem: forwardPem } : null,
+			_raw: { links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] },
+		});
+		activitypub.helpers._webfingerCache.set(`${username}@${domainA}`, {
+			actorUri, username, hostname: domainA,
+			subject: `acct:${username}@${domainA}`, splitDomain: false, subjectHostname: domainA,
+			publicKey: forwardPem ? { id: `https://${domainA}/${username}#key`, owner: `acct:${username}@${domainA}`, publicKeyPem: forwardPem } : null,
+			_raw: { links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] },
+		});
+	};
+
+	it('rejects when the forward webfinger key differs from the actor document key', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		seedKeys(domainA, domainB, username, actorUri, 'FORWARD-KEY-PEM');
+		const actor = Helpers.seedActor(actorUri, {
+			preferredUsername: username,
+			publicKey: { id: `${actorUri}#key`, owner: actorUri, publicKeyPem: 'ACTOR-DOC-KEY-PEM' },
+		});
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, actor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'key-mismatch');
+	});
+
+	it('accepts with keyVerified: true when the keys match', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		seedKeys(domainA, domainB, username, actorUri, 'SAME-KEY-PEM');
+		const actor = Helpers.seedActor(actorUri, {
+			preferredUsername: username,
+			publicKey: { id: `${actorUri}#key`, owner: actorUri, publicKeyPem: 'SAME-KEY-PEM' },
+		});
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, actor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, true);
+		assert.equal(verdict.reason, 'split-domain');
+		assert.equal(verdict.keyVerified, true);
+	});
+
+	it('accepts with keyVerified: false when the forward webfinger carries no key', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		seedKeys(domainA, domainB, username, actorUri, null);
+		const actor = Helpers.seedActor(actorUri, {
+			preferredUsername: username,
+			publicKey: { id: `${actorUri}#key`, owner: actorUri, publicKeyPem: 'ACTOR-DOC-KEY-PEM' },
+		});
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, actor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, true);
+		assert.equal(verdict.keyVerified, false);
+	});
+});
+
+// ============================================================================
+
+describe('Self-link fallback gating (audit F-4)', () => {
+	let originalGet;
+
+	beforeEach(Helpers.reset);
+
+	afterEach(() => {
+		if (originalGet) {
+			request.get = originalGet;
+			originalGet = null;
+		}
+	});
+
+	const seedSelfLinkedActor = (domainB, username, actorUri) => Helpers.seedActor(actorUri, {
+		preferredUsername: username,
+		link: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+	});
+
+	it('rejects first-time actors with a valid self-link when webfinger is unavailable', async () => {
+		const { domainB, username, actorUri } = Helpers.genSplitDomain();
+		const actor = seedSelfLinkedActor(domainB, username, actorUri);
+		originalGet = request.get;
+		request.get = async () => ({
+			body: {},
+			response: { statusCode: 404, headers: { 'content-type': 'application/jrd+json' } },
+		});
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, actor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'no-backreference');
+	});
+
+	it('accepts known actors via self-link fallback when webfinger is unavailable', async () => {
+		const { domainB, username, actorUri } = Helpers.genSplitDomain();
+		const actor = seedSelfLinkedActor(domainB, username, actorUri);
+		originalGet = request.get;
+		request.get = async () => ({
+			body: {},
+			response: { statusCode: 404, headers: { 'content-type': 'application/jrd+json' } },
+		});
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, actor, { allowSelfLinkFallback: true });
+		assert.ok(verdict);
+		assert.equal(verdict.ok, true);
+		assert.equal(verdict.splitDomain, false);
+		assert.equal(verdict.canonicalHandle, `${username}@${domainB}`);
+	});
+});
+
+// ============================================================================
+
+describe('Webfinger failure negative cache (audit F-4)', () => {
+	let originalGet;
+	let getCalled;
+
+	beforeEach(Helpers.reset);
+
+	afterEach(() => {
+		if (originalGet) {
+			request.get = originalGet;
+			originalGet = null;
+		}
+	});
+
+	it('short-circuits repeated queries after a transport failure', async () => {
+		const { domainB } = Helpers.genSplitDomain();
+		getCalled = 0;
+		originalGet = request.get;
+		request.get = async () => {
+			getCalled += 1;
+			return {
+				body: {},
+				response: { statusCode: 404, headers: { 'content-type': 'application/jrd+json' } },
+			};
+		};
+
+		const r1 = await activitypub.helpers.query(`user@${domainB}`, { strict: false });
+		assert.equal(r1, false);
+		assert.equal(getCalled, 1);
+
+		// Second query within the failure window: no additional network call
+		const r2 = await activitypub.helpers.query(`user@${domainB}`, { strict: false });
+		assert.equal(r2, false);
+		assert.equal(getCalled, 1);
+	});
+
+	it('does not negative-cache strict policy rejections of split-domain responses', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		getCalled = 0;
+		originalGet = request.get;
+		request.get = async () => {
+			getCalled += 1;
+			return {
+				body: {
+					subject: `acct:${username}@${domainA}`,
+					links: [{ rel: 'self', type: 'application/activity+json', href: actorUri }],
+					publicKey: null,
+				},
+				response: { statusCode: 200, headers: { 'content-type': 'application/jrd+json' } },
+			};
+		};
+
+		// Strict query rejects split-domain responses by policy (no cache write)
+		const r1 = await activitypub.helpers.query(`${username}@${domainB}`);
+		assert.equal(r1, false);
+		assert.equal(getCalled, 1);
+
+		// A subsequent non-strict query must still be answered (fresh fetch → payload),
+		// not short-circuited by a failure entry
+		const r2 = await activitypub.helpers.query(`${username}@${domainB}`, { strict: false });
+		assert.ok(r2);
+		assert.equal(r2.splitDomain, true);
+		assert.equal(getCalled, 2);
 	});
 });

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const nconf = require('nconf');
 const meta = require('../../src/meta');
 const utils = require('../../src/utils');
+const request = require('../../src/request');
 
 const activitypub = require('../../src/activitypub');
 
@@ -392,5 +393,145 @@ describe('Split-Domain: Integration - full flow', () => {
 		assert.equal(profile[0].username, `${username}@${domainA}`);
 		assert.equal(profile[0].userslug, `${username}@${domainA}`);
 		assert.equal(profile[0].webfinger, `acct:${username}@${domainA}`);
+	});
+});
+
+// ============================================================================
+
+describe('WebFinger cache poisoning (audit F-1)', () => {
+	let originalGet;
+
+	beforeEach(Helpers.reset);
+
+	afterEach(() => {
+		if (originalGet) {
+			request.get = originalGet;
+			originalGet = null;
+		}
+	});
+
+	it('a rejected split-domain backref must not seed an alias entry for the claimed handle', async () => {
+		const attacker = Helpers.genSplitDomain();
+		const victim = Helpers.genSplitDomain();
+		const attackerUri = `https://${attacker.domainB}/uid/${attacker.username}`;
+		const victimUri = `https://${victim.domainA}/uid/${victim.username}`;
+		const attackerActor = Helpers.seedActor(attackerUri, { preferredUsername: attacker.username });
+		const victimActor = Helpers.seedActor(victimUri, { preferredUsername: victim.username });
+
+		// domain B (attacker-controlled) WebFinger claims the victim's domain-A
+		// handle; domain A (honest) only serves the victim's own record
+		originalGet = request.get;
+		request.get = async (url) => {
+			const u = new URL(url);
+			if (u.host === attacker.domainB) {
+				return {
+					body: {
+						subject: `acct:${victim.username}@${victim.domainA}`,
+						links: [{ rel: 'self', type: 'application/activity+json', href: attackerUri }],
+						publicKey: null,
+					},
+					response: { statusCode: 200, headers: { 'content-type': 'application/jrd+json' } },
+				};
+			}
+			if (u.host === victim.domainA) {
+				const resource = new URLSearchParams(u.search.slice(1)).get('resource') || '';
+				if (resource === `acct:${victim.username}@${victim.domainA}`) {
+					return {
+						body: {
+							subject: `acct:${victim.username}@${victim.domainA}`,
+							links: [{ rel: 'self', type: 'application/activity+json', href: victimUri }],
+							publicKey: null,
+						},
+						response: { statusCode: 200, headers: { 'content-type': 'application/jrd+json' } },
+					};
+				}
+			}
+			return {
+				body: {},
+				response: { statusCode: 404, headers: { 'content-type': 'application/jrd+json' } },
+			};
+		};
+
+		// 1. Attacker's actor: domain B's record is about the victim's account,
+		//    not the queried one → rejected by the subject-user guard
+		const verdict = await activitypub.helpers.verifyActorWebfinger(attackerUri, attackerActor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'subject-mismatch');
+
+		// 2. The claimed handle must not exist in the webfinger cache (alias write removed)
+		assert.equal(activitypub.helpers._webfingerCache.get(`${victim.username}@${victim.domainA}`), undefined);
+
+		// 3. Victim's actor asserted by URI (the inbox path): backref reaches
+		//    domain A and verification succeeds
+		const victimVerdict = await activitypub.helpers.verifyActorWebfinger(victimUri, victimActor);
+		assert.ok(victimVerdict);
+		assert.equal(victimVerdict.ok, true);
+		assert.equal(victimVerdict.splitDomain, false);
+		assert.equal(victimVerdict.canonicalHandle, `${victim.username}@${victim.domainA}`);
+	});
+
+	it('does not serve a foreign-domain cache entry for a queried handle (hostname guard)', async () => {
+		const { domainA, domainB, username, actorUri } = Helpers.genSplitDomain();
+		const victimUri = `https://${domainA}/uid/${username}`;
+		const victimActor = Helpers.seedActor(victimUri, { preferredUsername: username });
+
+		// Simulate a legacy poisoned alias entry: key is the domain-A handle, but
+		// the payload was fetched from domain B
+		activitypub.helpers._webfingerCache.set(`${username}@${domainA}`, {
+			actorUri, username, hostname: domainB,
+			subject: `acct:${username}@${domainA}`, splitDomain: true, subjectHostname: domainA,
+			_raw: {
+				links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+				publicKey: null, subject: `acct:${username}@${domainA}`,
+			},
+		});
+
+		originalGet = request.get;
+		request.get = async (url) => {
+			const u = new URL(url);
+			if (u.host === domainA) {
+				return {
+					body: {
+						subject: `acct:${username}@${domainA}`,
+						links: [{ rel: 'self', type: 'application/activity+json', href: victimUri }],
+						publicKey: null,
+					},
+					response: { statusCode: 200, headers: { 'content-type': 'application/jrd+json' } },
+				};
+			}
+			return {
+				body: {},
+				response: { statusCode: 404, headers: { 'content-type': 'application/jrd+json' } },
+			};
+		};
+
+		// Despite the poisoned entry, verification must consult domain A itself
+		const verdict = await activitypub.helpers.verifyActorWebfinger(victimUri, victimActor);
+		assert.ok(verdict);
+		assert.equal(verdict.ok, true);
+		assert.equal(verdict.splitDomain, false);
+		assert.equal(verdict.canonicalHandle, `${username}@${domainA}`);
+	});
+
+	it('rejects backref records served for a different account (subject-user guard)', async () => {
+		const { domainB, username, actorUri } = Helpers.genSplitDomain();
+		const otherUser = `other_${username}`;
+
+		// domain B's WebFinger for `username` returns a record about `otherUser`
+		activitypub.helpers._webfingerCache.set(`${username}@${domainB}`, {
+			actorUri, username, hostname: domainB,
+			subject: `acct:${otherUser}@${domainB}`, splitDomain: false, subjectHostname: domainB,
+			_raw: {
+				links: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }],
+				publicKey: null, subject: `acct:${otherUser}@${domainB}`,
+			},
+		});
+		Helpers.seedActor(actorUri, { preferredUsername: username });
+
+		const verdict = await activitypub.helpers.verifyActorWebfinger(actorUri, activitypub._cache.get(`0;${actorUri}`));
+		assert.ok(verdict);
+		assert.equal(verdict.ok, false);
+		assert.equal(verdict.reason, 'subject-mismatch');
 	});
 });

--- a/test/activitypub/split-domain.js
+++ b/test/activitypub/split-domain.js
@@ -166,8 +166,6 @@ describe('verifyActorWebfinger', () => {
 		const { domainB, username, actorUri } = Helpers.genSplitDomain();
 		// Seed actor with a link array containing rel=self (simulates real AP actor docs)
 		const actor = Helpers.seedActor(actorUri, { preferredUsername: username, link: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] });
-		// allowSelfLinkFallback: true simulates an actor with a persisted record
-		// (first-time assertions require a live webfinger backref, audit F-4)
 		const verdict = await activitypub.helpers.verifyActorWebfinger(
 			actorUri, activitypub._cache.get(`0;${actorUri}`), { allowSelfLinkFallback: true });
 		assert.ok(verdict);
@@ -291,10 +289,7 @@ describe('Actors.assert - hostname mismatch', () => {
 
 	it('upgrades same-domain legacy actors via self-link fallback', async () => {
 		const { domainB, username, actorUri } = Helpers.genSplitDomain();
-		// Seed actor with link array (rel=self) — simulates real AP actor doc
 		Helpers.seedActor(actorUri, { preferredUsername: username, link: [{ rel: 'self', href: actorUri, type: 'application/activity+json' }] });
-		// Persisted record — the actor was asserted before webfinger verification
-		// existed, so the self-attested fallback is allowed (audit F-4)
 		await db.setObject(`userRemote:${actorUri}`, { username: 'legacy_actor' });
 		const result = await activitypub.actors.assert([actorUri]);
 		assert.ok(Array.isArray(result));
@@ -405,7 +400,7 @@ describe('Split-Domain: Integration - full flow', () => {
 
 // ============================================================================
 
-describe('WebFinger cache poisoning (audit F-1)', () => {
+describe('WebFinger cache poisoning', () => {
 	let originalGet;
 
 	beforeEach(Helpers.reset);
@@ -545,7 +540,7 @@ describe('WebFinger cache poisoning (audit F-1)', () => {
 
 // ============================================================================
 
-describe('preferredUsername / hostname validation (audit F-2)', () => {
+describe('preferredUsername / hostname validation', () => {
 	let originalGet;
 	let getCalled;
 
@@ -626,7 +621,7 @@ describe('preferredUsername / hostname validation (audit F-2)', () => {
 
 // ============================================================================
 
-describe('Split-domain key cross-check (audit F-3)', () => {
+describe('Split-domain key cross-check', () => {
 	beforeEach(Helpers.reset);
 
 	const seedKeys = (domainA, domainB, username, actorUri, forwardPem) => {
@@ -687,7 +682,7 @@ describe('Split-domain key cross-check (audit F-3)', () => {
 
 // ============================================================================
 
-describe('Self-link fallback gating (audit F-4)', () => {
+describe('Self-link fallback gating', () => {
 	let originalGet;
 
 	beforeEach(Helpers.reset);
@@ -736,7 +731,7 @@ describe('Self-link fallback gating (audit F-4)', () => {
 
 // ============================================================================
 
-describe('Webfinger failure negative cache (audit F-4)', () => {
+describe('Webfinger failure negative cache', () => {
 	let originalGet;
 	let getCalled;
 
@@ -803,7 +798,7 @@ describe('Webfinger failure negative cache (audit F-4)', () => {
 
 // ============================================================================
 
-describe('Webfinger cache key normalization (audit F-7)', () => {
+describe('Webfinger cache key normalization', () => {
 	beforeEach(Helpers.reset);
 
 	it('serves cached entries for case variants of the hostname', async () => {

--- a/test/user/search.js
+++ b/test/user/search.js
@@ -158,6 +158,30 @@ describe('User.search()', () => {
 			const hasRemote = result.users.some(u => u.uid === remoteActorUri);
 			assert.ok(hasRemote, 'exact webfinger should resolve to remote user');
 		});
+
+		it('prefers the persisted handle:uid mapping over a stale webfinger cache entry', async () => {
+			const hostname = new URL(remoteActorUri).hostname;
+			const webfinger = `charlie_remote@${hostname}`;
+			// A stale cache entry resolves the handle to a different, already-crawled URI
+			const staleUri = `https://${hostname}/uid/stale_charlie`;
+			await db.sortedSetAdd('usersRemote:lastCrawled', Date.now(), staleUri);
+			activitypub.helpers._webfingerCache.set(webfinger, {
+				actorUri: staleUri,
+				subject: `acct:charlie_remote@${hostname}`,
+				username: 'charlie_remote',
+				hostname,
+			});
+
+			const result = await user.search({
+				query: webfinger,
+				searchBy: 'username',
+				uid: localUid,
+			});
+
+			assert.ok(result.users.length >= 1, 'should find the user');
+			const hasRemote = result.users.some(u => u.uid === remoteActorUri);
+			assert.ok(hasRemote, 'stale webfinger cache entry must not override the persisted handle:uid mapping (audit F-7)');
+		});
 	});
 
 	describe('search by fullname', () => {

--- a/test/user/search.js
+++ b/test/user/search.js
@@ -180,7 +180,7 @@ describe('User.search()', () => {
 
 			assert.ok(result.users.length >= 1, 'should find the user');
 			const hasRemote = result.users.some(u => u.uid === remoteActorUri);
-			assert.ok(hasRemote, 'stale webfinger cache entry must not override the persisted handle:uid mapping (audit F-7)');
+			assert.ok(hasRemote, 'stale webfinger cache entry must not override the persisted handle:uid mapping');
 		});
 	});
 


### PR DESCRIPTION
- **fix(activitypub): prevent cross-domain webfinger cache poisoning**
- **fix(activitypub): harden webfinger query input validation**
- **fix(activitypub): harden split-domain vouching and self-link fallback**
- **fix(activitypub): normalize webfinger cache keys and search handles**
