### PR TITLE
feat: add filter:privileges.posts.delete, fired ahead of the lock gate

### DIFF
--- a/src/privileges/posts.js
+++ b/src/privileges/posts.js
@@ -219,16 +219,24 @@ privsPosts.canDelete = async function (pid, uid) {
 		return { flag: true };
 	}
 
-	if (!results.isMod && results.isLocked) {
+	results.pid = utils.isNumber(pid) ? parseInt(pid, 10) : pid;
+	results.uid = uid;
+	results.postData = postData;
+
+	// Fired ahead of the lock and delete-duration gates, so that plugins can
+	// grant delete access inside a locked topic by unsetting `isLocked`.
+	const result = await plugins.hooks.fire('filter:privileges.posts.delete', results);
+
+	if (!result.isMod && result.isLocked) {
 		return { flag: false, message: '[[error:topic-locked]]' };
 	}
 
 	const { postDeleteDuration } = meta.config;
-	if (!results.isMod && postDeleteDuration && (Date.now() - postData.timestamp > postDeleteDuration * 1000)) {
+	if (!result.isMod && postDeleteDuration && (Date.now() - postData.timestamp > postDeleteDuration * 1000)) {
 		return { flag: false, message: `[[error:post-delete-duration-expired, ${meta.config.postDeleteDuration}]]` };
 	}
 	const { deleterUid } = postData;
-	const flag = results['posts:delete'] && ((results.isOwner && (deleterUid === 0 || deleterUid === postData.uid)) || results.isMod);
+	const flag = result['posts:delete'] && ((result.isOwner && (deleterUid === 0 || deleterUid === postData.uid)) || result.isMod);
 	return { flag: flag, message: '[[error:no-privileges]]' };
 };
 

--- a/test/posts.js
+++ b/test/posts.js
@@ -1433,6 +1433,30 @@ describe('Post\'s', () => {
 				plugins.hooks.unregister('test-edit-locked', 'filter:privileges.posts.edit', method);
 			}
 		});
+
+		it('should not allow the owner to delete a post in a locked topic', async () => {
+			const { flag, message } = await privileges.posts.canDelete(pid, ownerUid);
+			assert.strictEqual(flag, false);
+			assert.strictEqual(message, '[[error:topic-locked]]');
+		});
+
+		it('should let a plugin grant delete access by unsetting isLocked', async () => {
+			const method = (data) => {
+				assert.strictEqual(data.isLocked, true);
+				data.isLocked = false;
+				return data;
+			};
+			plugins.hooks.register('test-delete-locked', {
+				hook: 'filter:privileges.posts.delete',
+				method: method,
+			});
+			try {
+				const { flag } = await privileges.posts.canDelete(pid, ownerUid);
+				assert.strictEqual(flag, true);
+			} finally {
+				plugins.hooks.unregister('test-delete-locked', 'filter:privileges.posts.delete', method);
+			}
+		});
 	});
 
 	describe('Topic Backlinks', () => {


### PR DESCRIPTION
Follow-up to #14710, as suggested by @barisusakli in https://github.com/NodeBB/NodeBB/pull/14711#issuecomment-5479850539 — giving `privileges.posts.canDelete` the same treatment `canEdit` received.

### Problem

`canDelete` rejects with `[[error:topic-locked]]` (and `[[error:post-delete-duration-expired]]`) before any hook fires, so a plugin that wants to allow deletes inside a locked topic has to replace the method wholesale and re-implement everything after the lock gate.

### Change

Fire a new `filter:privileges.posts.delete` hook after the admin short-circuit, and evaluate the lock and delete-duration gates on the object it returns. Same pattern as #14710:

- the gates keep the same order, conditions and error messages, so behaviour is unchanged when no listener touches the payload;
- the payload mirrors the edit hook — `isLocked`, `isOwner`, `isMod`, `'posts:delete'`, `postData`, `pid`, `uid` — and a plugin unsets `isLocked` to allow the delete.

### Tests

Added alongside the #14710 tests in `test/posts.js`: a locked topic still refuses the owner's delete with `[[error:topic-locked]]`, and a listener that unsets `isLocked` gets the delete through.
