### PR TITLE
feat: shift-click range selection when selecting posts

### DIFF
--- a/public/src/modules/postSelect.js
+++ b/public/src/modules/postSelect.js
@@ -8,24 +8,38 @@ define('postSelect', ['components'], function (components) {
 	PostSelect.pids = [];
 
 	let allowMainPostSelect = false;
+	let lastSelectedPid;
 
 	PostSelect.init = function (_onSelect, options) {
 		PostSelect.pids.length = 0;
+		lastSelectedPid = null;
 		onSelect = _onSelect;
 		options = options || {};
 		allowMainPostSelect = options.allowMainPostSelect || false;
 		$('#content').on('click', '[component="topic"] [component="post"]', onPostClicked);
+		$('#content').on('selectstart', '[component="topic"] [component="post"]', preventSelectOnShift);
 		disableClicksOnPosts();
 	};
 
 	function onPostClicked(ev) {
 		ev.stopPropagation();
 		const pidClicked = $(this).attr('data-pid');
-		const postEls = $('[component="topic"] [data-pid="' + pidClicked + '"]');
-		if (!allowMainPostSelect && parseInt($(this).attr('data-index'), 10) === 0) {
+		if (!isSelectable($(this))) {
 			return;
 		}
-		PostSelect.togglePostSelection(postEls, pidClicked);
+
+		if (ev.shiftKey && lastSelectedPid && lastSelectedPid !== pidClicked) {
+			selectRange(pidClicked);
+		} else {
+			PostSelect.togglePostSelection(getPostEls(pidClicked), pidClicked);
+		}
+		lastSelectedPid = pidClicked;
+	}
+
+	function preventSelectOnShift(ev) {
+		if (ev.shiftKey) {
+			ev.preventDefault();
+		}
 	}
 
 	PostSelect.disable = function () {
@@ -34,28 +48,74 @@ define('postSelect', ['components'], function (components) {
 		});
 
 		$('#content').off('click', '[component="topic"] [component="post"]', onPostClicked);
+		$('#content').off('selectstart', '[component="topic"] [component="post"]', preventSelectOnShift);
 		enableClicksOnPosts();
 	};
 
 	PostSelect.togglePostSelection = function (postEls, pid) {
 		if (pid) {
-			const index = PostSelect.pids.indexOf(pid);
-			if (index === -1) {
-				PostSelect.pids.push(pid);
-				postEls.toggleClass('selected', true);
-			} else {
-				PostSelect.pids.splice(index, 1);
-				postEls.toggleClass('selected', false);
-			}
-
-			if (PostSelect.pids.length) {
-				PostSelect.pids.sort(function (a, b) { return a - b; });
-			}
-			if (typeof onSelect === 'function') {
-				onSelect();
-			}
+			setPostSelection(pid, PostSelect.pids.indexOf(pid) === -1, postEls);
+			onSelectionChanged();
 		}
 	};
+
+	function setPostSelection(pid, isSelected, postEls) {
+		const index = PostSelect.pids.indexOf(pid);
+		if (isSelected === (index !== -1)) {
+			return;
+		}
+
+		if (isSelected) {
+			PostSelect.pids.push(pid);
+		} else {
+			PostSelect.pids.splice(index, 1);
+		}
+		(postEls || getPostEls(pid)).toggleClass('selected', isSelected);
+	}
+
+	// selects/deselects every loaded post between the previously clicked post and this one
+	function selectRange(pidClicked) {
+		const postEls = getSelectablePostEls();
+		const start = indexOfPid(postEls, lastSelectedPid);
+		const end = indexOfPid(postEls, pidClicked);
+		if (start === -1 || end === -1) {
+			PostSelect.togglePostSelection(getPostEls(pidClicked), pidClicked);
+			return;
+		}
+
+		const isSelected = PostSelect.pids.indexOf(pidClicked) === -1;
+		postEls.slice(Math.min(start, end), Math.max(start, end) + 1).each(function () {
+			setPostSelection($(this).attr('data-pid'), isSelected, $(this));
+		});
+		onSelectionChanged();
+	}
+
+	function onSelectionChanged() {
+		if (PostSelect.pids.length) {
+			PostSelect.pids.sort(function (a, b) { return a - b; });
+		}
+		if (typeof onSelect === 'function') {
+			onSelect();
+		}
+	}
+
+	function isSelectable(postEl) {
+		return allowMainPostSelect || parseInt(postEl.attr('data-index'), 10) !== 0;
+	}
+
+	function getPostEls(pid) {
+		return $('[component="topic"] [data-pid="' + pid + '"]');
+	}
+
+	function getSelectablePostEls() {
+		return $('[component="topic"] [component="post"]').filter(function () {
+			return isSelectable($(this));
+		});
+	}
+
+	function indexOfPid(postEls, pid) {
+		return postEls.index(postEls.filter('[data-pid="' + pid + '"]').first());
+	}
 
 	function disableClicks() {
 		return false;


### PR DESCRIPTION
### Problem

`postSelect` — the module behind **Delete/Purge posts**, **Fork**, **Move posts** and **Change owner** — only lets you toggle one post at a time. Picking a long run of posts means clicking every single one.

Every other multi-select surface in NodeBB already supports shift-click ranges:

- topic selection in a category — `public/src/modules/topicSelect.js`
- the ACP user list — `public/src/admin/manage/users.js`
- the flags list — `public/src/client/flags/list.js`

### Change

Shift-clicking a post now applies the clicked post's new selection state to every loaded post between it and the previously clicked post, matching the behaviour of `topicSelect`. A plain click behaves exactly as before.

Details:

- `lastSelectedPid` tracks the anchor and is reset on `init()`.
- The range walks only *selectable* posts, so the main post is skipped unless `allowMainPostSelect` is set.
- `togglePostSelection()` keeps its existing signature and behaviour — the toggle/notify logic was split into `setPostSelection()` + `onSelectionChanged()` so a range updates the DOM once per post and fires the `onSelect` callback a single time.
- `selectstart` is suppressed while shift is held, so shift-clicking does not leave a blue text selection across the posts.
- If either end of the range is no longer in the DOM, it falls back to a plain toggle.

### Note

Posts are loaded lazily, so a range covers the posts currently rendered — same constraint the existing selection already has.
