### PR TITLE
perf: only hydrate chat rooms that match the search query

### DIFF
--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -220,33 +220,42 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 	}
 
 	const roomIds = await db.getSortedSetRevRange(`uid:${uid}:chat:rooms`, 0, -1);
+
+	// First pass loads only what the query is actually matched against, so the
+	// expensive hydration (teasers, unread counts, membership, ...) can be limited
+	// to the rooms that matched instead of running over the user's entire chat list.
+	const [names, users] = await Promise.all([
+		Messaging.getRoomsData(roomIds, ['roomName']),
+		getUsers(roomIds, uid),
+	]);
+
+	const lowerQuery = String(query).toLowerCase();
+	const matchedIndices = roomIds.reduce((matched, roomId, idx) => {
+		const roomName = names[idx] && names[idx].roomName;
+		const titleMatch = roomName && roomName.toLowerCase().includes(lowerQuery);
+
+		const usernameMatch = !titleMatch && (users[idx] || []).some(user => user && (
+			(user.displayname && user.displayname.toLowerCase().includes(lowerQuery)) ||
+			(user.username && user.username.toLowerCase().includes(lowerQuery))
+		));
+
+		if (titleMatch || usernameMatch) {
+			matched.push(idx);
+		}
+		return matched;
+	}, []);
+
+	const matchedRoomIds = matchedIndices.map(idx => roomIds[idx]);
 	const results = await utils.promiseParallel({
-		roomData: Messaging.getRoomsData(roomIds),
-		unread: db.isSortedSetMembers(`uid:${uid}:chat:rooms:unread`, roomIds),
-		inRoom: Messaging.isUserInRoom(uid, roomIds),
-		users: getUsers(roomIds, uid),
-		teasers: Messaging.getTeasers(uid, roomIds),
+		roomData: Messaging.getRoomsData(matchedRoomIds),
+		unread: db.isSortedSetMembers(`uid:${uid}:chat:rooms:unread`, matchedRoomIds),
+		inRoom: Messaging.isUserInRoom(uid, matchedRoomIds),
+		teasers: Messaging.getTeasers(uid, matchedRoomIds),
 	});
+	// reuse the user lists already fetched for matching, kept aligned with roomData
+	results.users = matchedIndices.map(idx => users[idx]);
 
 	results.roomData = await modifyChatRooms(uid, results);
-
-	// Filter rooms based on query
-	results.roomData = results.roomData
-		.filter((room, idx) => {
-			if (!room) return false;
-
-			// Search in room title
-			const titleMatch = room.roomName && room.roomName.toLowerCase().includes(query.toLowerCase());
-
-			// Search in usernames
-			const users = results.users[idx] || [];
-			const usernameMatch = users.some(user => user && (
-				(user.displayname && user.displayname.toLowerCase().includes(query.toLowerCase())) ||
-				(user.username && user.username.toLowerCase().includes(query.toLowerCase()))
-			));
-
-			return titleMatch || usernameMatch;
-		});
 
 	return await plugins.hooks.fire('filter:messaging.searchRecentChats', {
 		rooms: results.roomData,
@@ -387,27 +396,28 @@ Messaging.getTeasers = async (uid, roomIds) => {
 };
 
 Messaging.getLatestUndeletedMessage = async (uid, roomId) => {
-	let done = false;
-	let latestMid = null;
+	// Walk backwards in batches; one message at a time meant two round trips per
+	// deleted/system message, and this runs once per room in the chat list.
+	const batchSize = 10;
 	let index = 0;
-	let mids;
+	let done = false;
 
 	while (!done) {
 		/* eslint-disable no-await-in-loop */
-		mids = await getMessageIds(roomId, uid, index, index);
-		if (mids.length) {
-			const states = await Messaging.getMessageFields(mids[0], ['deleted', 'system']);
-			done = !states.deleted && !states.system;
-			if (done) {
-				latestMid = mids[0];
-			}
-			index += 1;
-		} else {
-			done = true;
+		const mids = await getMessageIds(roomId, uid, index, index + batchSize - 1);
+		if (!mids.length) {
+			return null;
 		}
+		const states = await Messaging.getMessagesFields(mids, ['deleted', 'system']);
+		const matchIndex = states.findIndex(state => state && !state.deleted && !state.system);
+		if (matchIndex !== -1) {
+			return mids[matchIndex];
+		}
+		index += mids.length;
+		done = mids.length < batchSize; // short read means we hit the start of the room
 	}
 
-	return latestMid;
+	return null;
 };
 
 Messaging.canMessageUser = async (uid, toUid) => {


### PR DESCRIPTION
### Motivation

`Messaging.searchRecentChats` loads the user's **entire** chat room list (`0, -1`, no pagination) and fully hydrates every room — `getRoomsData`, unread flags, `isUserInRoom`, user lists and `getTeasers` — *before* applying the query filter. Everything computed for non-matching rooms is discarded. This runs on every keystroke in the chat list search box (300ms debounce, `public/src/client/chats/search.js`), so for a user with a few hundred rooms it is hundreds of DB round trips per keystroke.

### Changes

**1. Filter first, hydrate second.** A cheap first pass loads only what the query is actually matched against — `getRoomsData(roomIds, ['roomName'])` (a single mget) plus the user lists, which `getUsers` already batches. The expensive hydration then runs on the matched subset only, reusing the user lists already fetched instead of re-requesting them.

**2. Fixes an index misalignment in the old filter.** The filter ran over the array returned by `modifyChatRooms`, which ends in `filter(Boolean)` and therefore compacts indices, while `results.users[idx]` was still indexed by the *uncompacted* position. One dangling room in the list shifted every subsequent username match onto the wrong room. Matching now happens against `roomIds` positions, before any compaction.

**3. Batches `getLatestUndeletedMessage`.** This runs once per room via `getTeasers`, so it is on the regular chat list's hot path as well, not just search. It walked backwards one message at a time — two sequential round trips per deleted/system message, and each `getMessageIds` call additionally does a `public` field lookup plus, in private rooms, a join-timestamp lookup. It now fetches 10 mids and their states per iteration, so a room ending in a run of join/leave system messages costs two calls instead of roughly thirty.

### Notes

- No behaviour change to the results themselves — same matching rules (room name, and username/displayname of the up-to-10 users returned by `getUsers`), same ordering, same `filter:messaging.searchRecentChats` payload. I deliberately did **not** add a result cap, since the client replaces the whole list in one go with no paging and a cap would silently truncate.
- The dangling-room self-heal in `modifyChatRooms` now runs over the matched rooms rather than the whole list when searching. `getRecentChats` performs the same self-heal on the loaded page, so coverage is unaffected in practice.
- There is currently no test coverage for `searchRecentChats`; happy to add some if you'd like it in this PR.
