### PR TITLE
fix: keep a readable name on converted pasted images

### DIFF
--- a/public/src/modules/uploadHelpers.js
+++ b/public/src/modules/uploadHelpers.js
@@ -162,12 +162,16 @@ define('uploadHelpers', ['alerts'], function (alerts) {
 						// eslint-disable-next-line no-await-in-loop
 						const convertedBlob = await convertImage(file, convertPastedImageTo, 0.9);
 						const ext = convertedBlob.type.split('/')[1];
-						const fileName = `${utils.generateUUID()}-image.${ext}`;
+						const uploadName = `${utils.generateUUID()}-image.${ext}`;
 
-						const convertedFile = new File([convertedBlob], fileName, {
+						// The uuid only has to keep the upload from colliding with others in
+						// the upload folder, so keep a readable name on the file itself, it is
+						// what the composer labels the image with
+						const baseName = (file.name || 'image').replace(/\.[^.]+$/, '');
+						const convertedFile = new File([convertedBlob], `${baseName}.${ext}`, {
 							type: convertedBlob.type,
 						});
-						addFile(convertedFile, fileName);
+						addFile(convertedFile, uploadName);
 					} else {
 						const fileName = utils.generateUUID() + '-' + file.name;
 						addFile(file, fileName);


### PR DESCRIPTION
### Problem

With `convertPastedImageTo` set, pasting an image into the composer inserts

```
![e2898ec6-b833-4581-8e60-497c1e4ac7af-image.webp](/assets/uploads/files/…)
```

The uuid is there so pasted uploads don't collide in the upload folder, but `handlePaste` also puts it on the `File` object, and consumers use the file's name as a label, not just as an upload name — the composer builds the markdown link text from it, and `ajaxSubmit` sets `uploads[i].filename` from it for the chat and quick reply.

The unconverted branch right next to it already does the right thing: the uuid name goes to `fileNames` (and so to the `FormData`), while the file keeps its own name.

### Fix

Name the converted file after the file it was converted from, and pass the uuid name as the upload name only.

### Notes

This is one of three places the same uuid leaks into what the reader sees; the other two are NodeBB/nodebb-plugin-composer-default#177 (composer preferring the upload name over the file's own name) and NodeBB/nodebb-plugin-markdown#246 (plaintext image teasers labelled with the stored filename).

### Testing

Set "Convert pasted images to" in the ACP, paste an image into the composer, and the inserted markdown is labelled with the image's name rather than a uuid. The uploaded file still lands under a uuid-prefixed name.