### PR TITLE
feat: update chat room url with message index on scroll

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -339,6 +339,40 @@ define('forum/chats', [
 		});
 	};
 
+	function getTopVisibleMessageIndex(el) {
+		const containerTop = el.offset().top;
+		let index = 0;
+		el.children('[data-index]').each(function () {
+			const msgEl = $(this);
+			const msgIndex = parseInt(msgEl.attr('data-index'), 10);
+			// live-received messages don't carry an index; skip them
+			if (!isNaN(msgIndex) && msgEl.offset().top + msgEl.outerHeight() > containerTop) {
+				index = msgIndex + 1;
+				return false;
+			}
+		});
+		return index;
+	}
+
+	function updateUrlWithMessageIndex(roomId, el) {
+		if (
+			!ajaxify.data.template.chats || !history.replaceState ||
+			String(ajaxify.data.roomId) !== String(roomId) || !ajaxify.data.userslug
+		) {
+			return;
+		}
+		const index = messages.isAtBottom(el) ? 0 : getTopVisibleMessageIndex(el);
+		const newUrl = `user/${ajaxify.data.userslug}/chats/${roomId}${index > 0 ? `/${index}` : ''}`;
+		const fullPath = `${config.relative_path}/${newUrl}`;
+		if (fullPath === window.location.pathname) {
+			return;
+		}
+		const search = window.location.search || '';
+		history.replaceState({
+			url: newUrl + search,
+		}, null, `${window.location.protocol}//${window.location.host}${fullPath}${search}`);
+	}
+
 	Chats.addScrollHandler = function (roomId, uid, el) {
 		let loading = false;
 		let previousScrollTop = el.scrollTop();
@@ -349,6 +383,7 @@ define('forum/chats', [
 			isAtBottom = messages.isAtBottom(el);
 		});
 		el.on('scroll', utils.debounce(async function () {
+			updateUrlWithMessageIndex(roomId, el);
 			if (parseInt(el.attr('data-ignore-next-scroll'), 10) === 1) {
 				el.removeAttr('data-ignore-next-scroll');
 				previousScrollTop = el.scrollTop();


### PR DESCRIPTION
## Summary

Chat rooms already support an `/:index` suffix in the URL (`/user/:userslug/chats/:roomid/:index`) — the controller loads a window of messages around that index and the client scrolls to it (this is how `/message/:mid` permalinks work). However, nothing ever *writes* that index while the user scrolls, so navigating away from a chat and pressing the browser back button always lands at the bottom of the room, losing the user's place in the history.

Topics don't have this problem: `Topic.navigatorCallback` rewrites the address bar with the current post index via `history.replaceState` as the user scrolls, so back-navigation restores the reading position.

This PR mirrors that behaviour for chat rooms:

- On (debounced) scroll, the index of the top-most visible message (`data-index` + 1) is written into the URL with `history.replaceState` — no history entries added, no network requests.
- When the user is at the bottom of the room, the index is stripped so the URL stays canonical and a return visit loads the newest messages, exactly as today.
- Guarded to the full `chats` template and the active room only, so chat modals/popouts on other pages never touch the address bar.
- Live-received (socket) messages don't carry a `data-index`; they are skipped when determining the top-most visible message.

A pleasant side effect: copying the address bar mid-scroll now yields a link that lands on the message currently being read.

## Test plan

- Open a chat room with more than one page of messages, scroll up through the history → the URL updates to `/user/<slug>/chats/<roomId>/<index>`.
- Navigate to another page and press back → the room reopens scrolled to (and highlighting) the message that was at the top of the viewport.
- Scroll back to the bottom → the index is removed from the URL; leaving and returning lands at the newest message as before.
- Chat modal (popout on other pages) → address bar unaffected.
- `eslint` passes on the changed file.