### PR TITLE
feat: search chat message content across all rooms

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -75,18 +75,24 @@ define('forum/chats', [
 
 		const chatContentEl = chatMainWrapper.find('[component="chat/message/content"]');
 		messages.wrapImagesInLinks(chatContentEl);
-		if (ajaxify.data.scrollToIndex) {
-			messages.toggleScrollUpAlert(chatContentEl);
-			const scrollToEl = chatContentEl.find(`[data-index="${ajaxify.data.scrollToIndex - 1}"]`);
-			messages.scrollToMessageAfterImageLoad(chatContentEl, scrollToEl);
-		} else {
-			messages.scrollToBottomAfterImageLoad(chatContentEl);
-		}
+		scrollToInitialPosition(chatContentEl, ajaxify.data.scrollToIndex);
 		create.init();
 		search.init(document.getElementById('search-chats'), document.getElementById('private-rooms'));
 
 		hooks.fire('action:chat.loaded', $('.chats-full'));
 	};
+
+	// a room opened at a specific message -- a search hit, or a link to one -- lands
+	// on it, anything else opens at the latest message
+	function scrollToInitialPosition(contentEl, scrollToIndex) {
+		if (scrollToIndex) {
+			messages.toggleScrollUpAlert(contentEl);
+			const scrollToEl = contentEl.find(`[data-index="${scrollToIndex - 1}"]`);
+			messages.scrollToMessageAfterImageLoad(contentEl, scrollToEl);
+		} else {
+			messages.scrollToBottomAfterImageLoad(contentEl);
+		}
+	}
 
 	Chats.addEventListeners = function () {
 		const { roomId } = ajaxify.data;
@@ -668,7 +674,7 @@ define('forum/chats', [
 		}).catch(alerts.error);
 	};
 
-	Chats.switchChat = async function (roomId) {
+	Chats.switchChat = async function (roomId, index) {
 		// Allow empty arg for return to chat list/close chat
 		if (!roomId) {
 			roomId = '';
@@ -678,7 +684,8 @@ define('forum/chats', [
 
 		const params = new URL(document.location).searchParams;
 		params.set('switch', 1);
-		const url = `user/${ajaxify.data.userslug}/chats/${roomId}?${params.toString()}`;
+		const position = roomId && index ? `/${index}` : '';
+		const url = `user/${ajaxify.data.userslug}/chats/${roomId}${position}?${params.toString()}`;
 		const dataUrl = `/api/${url}`;
 		try {
 			const payload = await api.get(dataUrl);
@@ -703,8 +710,9 @@ define('forum/chats', [
 		Chats.setActive(roomId);
 		Chats.addEventListeners();
 		hooks.fire('action:chat.loaded', $('.chats-full'));
-		messages.scrollToBottomAfterImageLoad(
-			chatMainWrapper.find('[component="chat/message/content"]')
+		scrollToInitialPosition(
+			chatMainWrapper.find('[component="chat/message/content"]'),
+			ajaxify.data.scrollToIndex
 		);
 		if (history.pushState) {
 			history.pushState({

--- a/public/src/client/chats/recent.js
+++ b/public/src/client/chats/recent.js
@@ -11,7 +11,9 @@ define('forum/chats/recent', ['alerts', 'api', 'chat'], function (alerts, api, c
 					e.stopPropagation();
 					e.preventDefault();
 					const roomId = this.getAttribute('data-roomid');
-					Chats.switchChat(roomId);
+					// a search result carries the position of the message that
+					// matched, so the room opens on it instead of at the bottom
+					Chats.switchChat(roomId, this.getAttribute('data-index'));
 				})
 				.on('click', '.mark-read', function (e) {
 					e.stopPropagation();

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -288,11 +288,15 @@ async function searchMessageContent(uid, roomIds, rooms, query) {
 		return matches;
 	}
 
+	// results collapse to one row per room, so the cap has to leave room for a busy
+	// room contributing many hits. Search plugins that predate this field fall back
+	// to their own default.
 	const { ids } = await plugins.hooks.fire('filter:messaging.searchMessages', {
 		content: query,
 		roomId: roomIds,
 		uid: [],
 		matchWords: 'all',
+		limit: 500,
 		ids: [],
 	});
 	if (!Array.isArray(ids) || !ids.length) {
@@ -325,7 +329,7 @@ async function searchMessageContent(uid, roomIds, rooms, query) {
 	);
 
 	const inUserRooms = new Set(roomIds.map(String));
-	messages.forEach((msg) => {
+	messages.forEach((msg, idx) => {
 		if (!msg || !msg.fromuid) {
 			return;
 		}
@@ -340,6 +344,7 @@ async function searchMessageContent(uid, roomIds, rooms, query) {
 		if (!isPublic[roomId] && msg.timestamp <= joinTimestamps[roomId]) {
 			return;
 		}
+		msg.mid = parseInt(ids[idx], 10);
 		msg.roomId = parseInt(roomId, 10);
 		msg.content = utils.stripHTMLTags(utils.decodeHTMLEntities(msg.content));
 		matches.set(roomId, msg);
@@ -347,14 +352,22 @@ async function searchMessageContent(uid, roomIds, rooms, query) {
 
 	const teasers = Array.from(matches.values());
 	const uids = _.uniq(teasers.map(teaser => teaser.fromuid));
-	const userMap = _.zipObject(
-		uids,
-		await user.getUsersFields(uids, [
+	// the position the room has to be opened at to land on the matching message,
+	// the same one `/message/:mid` resolves to
+	const [userData, ranks] = await Promise.all([
+		user.getUsersFields(uids, [
 			'uid', 'username', 'userslug', 'picture', 'status', 'lastonline',
-		])
-	);
-	await Promise.all(teasers.map(async (teaser) => {
+		]),
+		db.sortedSetsRanks(
+			teasers.map(teaser => `chat:room:${teaser.roomId}:mids`),
+			teasers.map(teaser => teaser.mid)
+		),
+	]);
+
+	const userMap = _.zipObject(uids, userData);
+	await Promise.all(teasers.map(async (teaser, idx) => {
 		teaser.user = userMap[teaser.fromuid];
+		teaser.index = ranks[idx] === null ? null : parseInt(ranks[idx], 10) + 1;
 		const payload = await plugins.hooks.fire('filter:messaging.getTeaser', { teaser: teaser });
 		matches.set(String(teaser.roomId), payload.teaser);
 	}));

--- a/src/messaging/index.js
+++ b/src/messaging/index.js
@@ -224,14 +224,19 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 	// First pass loads only what the query is actually matched against, so the
 	// expensive hydration (teasers, unread counts, membership, ...) can be limited
 	// to the rooms that matched instead of running over the user's entire chat list.
-	const [names, users] = await Promise.all([
-		Messaging.getRoomsData(roomIds, ['roomName']),
+	const rooms = await Messaging.getRoomsData(roomIds, ['roomName', 'public']);
+	const [users, contentMatches] = await Promise.all([
 		getUsers(roomIds, uid),
+		searchMessageContent(uid, roomIds, rooms, query),
 	]);
 
 	const lowerQuery = String(query).toLowerCase();
-	const matchedIndices = roomIds.reduce((matched, roomId, idx) => {
-		const roomName = names[idx] && names[idx].roomName;
+	const matchedIndices = [];
+	// a room matched only by message content shows that message instead of its last
+	// one, otherwise the row would carry a teaser with no trace of the query in it
+	const teaserOverrides = [];
+	roomIds.forEach((roomId, idx) => {
+		const roomName = rooms[idx] && rooms[idx].roomName;
 		const titleMatch = roomName && roomName.toLowerCase().includes(lowerQuery);
 
 		const usernameMatch = !titleMatch && (users[idx] || []).some(user => user && (
@@ -239,18 +244,22 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 			(user.username && user.username.toLowerCase().includes(lowerQuery))
 		));
 
+		const contentMatch = contentMatches.get(String(roomId));
 		if (titleMatch || usernameMatch) {
-			matched.push(idx);
+			matchedIndices.push(idx);
+			teaserOverrides.push(null);
+		} else if (contentMatch) {
+			matchedIndices.push(idx);
+			teaserOverrides.push(contentMatch);
 		}
-		return matched;
-	}, []);
+	});
 
 	const matchedRoomIds = matchedIndices.map(idx => roomIds[idx]);
 	const results = await utils.promiseParallel({
 		roomData: Messaging.getRoomsData(matchedRoomIds),
 		unread: db.isSortedSetMembers(`uid:${uid}:chat:rooms:unread`, matchedRoomIds),
 		inRoom: Messaging.isUserInRoom(uid, matchedRoomIds),
-		teasers: Messaging.getTeasers(uid, matchedRoomIds),
+		teasers: getSearchTeasers(uid, matchedRoomIds, teaserOverrides),
 	});
 	// reuse the user lists already fetched for matching, kept aligned with roomData
 	results.users = matchedIndices.map(idx => users[idx]);
@@ -263,6 +272,112 @@ Messaging.searchRecentChats = async (callerUid, uid, query) => {
 		callerUid: callerUid,
 	});
 };
+
+// Matches the query against message content across every room the user is in.
+// The matching itself belongs to whichever plugin implements
+// `filter:messaging.searchMessages` (nodebb-plugin-dbsearch ships with core and
+// indexes chat messages); with no such plugin the hook yields nothing and search
+// degrades to matching room names and participants, as before.
+// Returns a map of roomId -> teaser for the best matching message in that room.
+async function searchMessageContent(uid, roomIds, rooms, query) {
+	const matches = new Map();
+	// the room list search fires on every keystroke, and a one or two character
+	// query matches too much to be worth an index lookup. Same floor the in-room
+	// message search uses.
+	if (!roomIds.length || String(query).length < 3) {
+		return matches;
+	}
+
+	const { ids } = await plugins.hooks.fire('filter:messaging.searchMessages', {
+		content: query,
+		roomId: roomIds,
+		uid: [],
+		matchWords: 'all',
+		ids: [],
+	});
+	if (!Array.isArray(ids) || !ids.length) {
+		return matches;
+	}
+
+	const isPublic = _.zipObject(
+		roomIds.map(String),
+		rooms.map(room => !!(room && room.public))
+	);
+	const [messages, blockedUids] = await Promise.all([
+		Messaging.getMessagesFields(ids, ['roomId', 'fromuid', 'content', 'timestamp']),
+		user.blocks.list(uid),
+	]);
+
+	// The search index carries no notion of chat privileges, so re-apply the cutoff
+	// `getMessageIds` enforces: in a private room a member cannot see what was said
+	// before they joined. A missing score means no membership at all, in which case
+	// nothing is visible, so the cutoff is pushed past every possible timestamp.
+	const privateRoomIds = _.uniq(
+		messages
+			.filter(msg => msg && !isPublic[String(msg.roomId)])
+			.map(msg => String(msg.roomId))
+	);
+	const joinTimestamps = _.zipObject(
+		privateRoomIds,
+		(await db.sortedSetsScore(
+			privateRoomIds.map(roomId => `chat:room:${roomId}:uids`), uid
+		)).map(score => (score === null ? Infinity : score))
+	);
+
+	const inUserRooms = new Set(roomIds.map(String));
+	messages.forEach((msg) => {
+		if (!msg || !msg.fromuid) {
+			return;
+		}
+		const roomId = String(msg.roomId);
+		// ids come back ranked, so the first hit per room is the best one
+		if (!inUserRooms.has(roomId) || matches.has(roomId)) {
+			return;
+		}
+		if (blockedUids.includes(String(msg.fromuid))) {
+			return;
+		}
+		if (!isPublic[roomId] && msg.timestamp <= joinTimestamps[roomId]) {
+			return;
+		}
+		msg.roomId = parseInt(roomId, 10);
+		msg.content = utils.stripHTMLTags(utils.decodeHTMLEntities(msg.content));
+		matches.set(roomId, msg);
+	});
+
+	const teasers = Array.from(matches.values());
+	const uids = _.uniq(teasers.map(teaser => teaser.fromuid));
+	const userMap = _.zipObject(
+		uids,
+		await user.getUsersFields(uids, [
+			'uid', 'username', 'userslug', 'picture', 'status', 'lastonline',
+		])
+	);
+	await Promise.all(teasers.map(async (teaser) => {
+		teaser.user = userMap[teaser.fromuid];
+		const payload = await plugins.hooks.fire('filter:messaging.getTeaser', { teaser: teaser });
+		matches.set(String(teaser.roomId), payload.teaser);
+	}));
+
+	return matches;
+}
+
+// Rooms surfaced by a content match already carry the message to show, so only the
+// remaining ones pay for the (per-room) latest-undeleted-message lookup.
+async function getSearchTeasers(uid, roomIds, overrides) {
+	const fetched = await Messaging.getTeasers(
+		uid, roomIds.filter((roomId, idx) => !overrides[idx])
+	);
+	let next = 0;
+	return roomIds.map((roomId, idx) => {
+		if (overrides[idx]) {
+			return overrides[idx];
+		}
+		const teaser = fetched[next];
+		next += 1;
+		return teaser;
+	});
+}
 
 async function modifyChatRooms(uid, results) {
 	const danglingRoomIds = [];

--- a/src/views/partials/chats/recent_room.tpl
+++ b/src/views/partials/chats/recent_room.tpl
@@ -1,7 +1,7 @@
 {{{ if (loadingMore && @first)}}}
 <hr class="my-1" />
 {{{ end }}}
-<div component="chat/recent/room" data-roomid="{./roomId}" data-full="1" class="rounded-1 {{{ if ./unread }}}unread{{{ end }}}">
+<div component="chat/recent/room" data-roomid="{./roomId}" {{{ if ./teaser.index }}}data-index="{./teaser.index}"{{{ end }}} data-full="1" class="rounded-1 {{{ if ./unread }}}unread{{{ end }}}">
 	<div class="d-flex gap-1 justify-content-between">
 		<a href="#" class="chat-room-btn position-relative d-flex flex-grow-1 gap-2 justify-content-start align-items-start btn btn-ghost btn-sm ff-sans text-start">
 			<div class="main-avatar">

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -975,6 +975,7 @@ describe('Messaging Library', () => {
 
 	describe('searchRecentChats', () => {
 		const searchPlugin = 'messaging-search-test';
+		const searchHook = 'filter:messaging.searchMessages';
 		let alice;
 		let bob;
 		let carol;
@@ -1043,19 +1044,34 @@ describe('Messaging Library', () => {
 		});
 
 		it('should not match message content without a search plugin', async () => {
-			assert.deepStrictEqual(await search(alice, 'pineapple'), []);
+			// dbsearch ships with core and is active here, so the hook has to be
+			// emptied to get at the no-listener behaviour
+			const listeners = plugins.loadedHooks[searchHook];
+			delete plugins.loadedHooks[searchHook];
+			try {
+				assert.deepStrictEqual(await search(alice, 'pineapple'), []);
+			} finally {
+				plugins.loadedHooks[searchHook] = listeners;
+			}
 		});
 
 		describe('with a search plugin', () => {
+			let listeners;
+
 			before(() => {
+				// replace the hook rather than adding to it: with dbsearch also
+				// listening, results would depend on whether it has indexed these
+				// messages yet, which is not the same across database backends
+				listeners = plugins.loadedHooks[searchHook];
+				plugins.loadedHooks[searchHook] = [];
 				plugins.hooks.register(searchPlugin, {
-					hook: 'filter:messaging.searchMessages',
+					hook: searchHook,
 					method: fakeMessageSearch,
 				});
 			});
 
 			after(() => {
-				plugins.hooks.unregister(searchPlugin, 'filter:messaging.searchMessages', fakeMessageSearch);
+				plugins.loadedHooks[searchHook] = listeners;
 			});
 
 			it('should match a room by message content', async () => {

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -15,6 +15,7 @@ const Messaging = require('../src/messaging');
 const api = require('../src/api');
 const helpers = require('./helpers');
 const request = require('../src/request');
+const plugins = require('../src/plugins');
 const translator = require('../src/translator');
 const utils = require('../src/utils');
 
@@ -968,6 +969,141 @@ describe('Messaging Library', () => {
 				await callv3API('post', `/chats/${roomId}/messages/${mid2}`, {}, 'baz');
 
 				await Groups.leave(['Global Moderators'], mocks.users.baz.uid);
+			});
+		});
+	});
+
+	describe('searchRecentChats', () => {
+		const searchPlugin = 'messaging-search-test';
+		let alice;
+		let bob;
+		let carol;
+		let namedRoom;
+		let contentRoom;
+		let joinCutoffRoom;
+		let blockedRoom;
+		const _delay = meta.config.newbieChatMessageDelay;
+
+		// stand-in for a search plugin: a naive substring scan over the rooms the
+		// core asked about, so the tests exercise the core side of the hook
+		async function fakeMessageSearch(data) {
+			const perRoom = await Promise.all((data.roomId || []).map(async (roomId) => {
+				const mids = await db.getSortedSetRange(`chat:room:${roomId}:mids`, 0, -1);
+				const messages = await Messaging.getMessagesFields(mids, ['content', 'deleted', 'system']);
+				return mids.filter((mid, idx) => {
+					const msg = messages[idx];
+					return msg && !msg.deleted && !msg.system &&
+						String(msg.content).toLowerCase().includes(String(data.content).toLowerCase());
+				});
+			}));
+			data.ids = data.ids.concat(perRoom.flat().slice(0, data.limit || 100));
+			return data;
+		}
+
+		async function search(uid, query) {
+			const { rooms } = await Messaging.searchRecentChats(uid, uid, query);
+			return rooms;
+		}
+
+		before(async () => {
+			meta.config.newbieChatMessageDelay = 0;
+			alice = await User.create({ username: 'alice-search' });
+			bob = await User.create({ username: 'bob-search' });
+			carol = await User.create({ username: 'carol-search' });
+
+			namedRoom = await Messaging.newRoom(alice, {
+				uids: [bob], roomName: 'Roadmap planning',
+			});
+			await Messaging.addMessage({ uid: bob, roomId: namedRoom, content: 'the last word here' });
+
+			contentRoom = await Messaging.newRoom(alice, { uids: [bob] });
+			await Messaging.addMessage({ uid: bob, roomId: contentRoom, content: 'pineapple on pizza' });
+			await Messaging.addMessage({ uid: bob, roomId: contentRoom, content: 'something else entirely' });
+
+			blockedRoom = await Messaging.newRoom(alice, { uids: [carol] });
+			await Messaging.addMessage({ uid: carol, roomId: blockedRoom, content: 'aubergine casserole' });
+		});
+
+		after(async () => {
+			meta.config.newbieChatMessageDelay = _delay;
+		});
+
+		it('should match a room by its name', async () => {
+			const rooms = await search(alice, 'roadmap');
+			assert.strictEqual(rooms.length, 1);
+			assert.strictEqual(rooms[0].roomId, namedRoom);
+		});
+
+		it('should match a room by a participant username', async () => {
+			const rooms = await search(alice, 'bob-search');
+			assert.strictEqual(rooms.length, 2);
+			assert.deepStrictEqual(
+				rooms.map(room => room.roomId).sort(), [namedRoom, contentRoom].sort()
+			);
+		});
+
+		it('should not match message content without a search plugin', async () => {
+			assert.deepStrictEqual(await search(alice, 'pineapple'), []);
+		});
+
+		describe('with a search plugin', () => {
+			before(() => {
+				plugins.hooks.register(searchPlugin, {
+					hook: 'filter:messaging.searchMessages',
+					method: fakeMessageSearch,
+				});
+			});
+
+			after(() => {
+				plugins.hooks.unregister(searchPlugin, 'filter:messaging.searchMessages', fakeMessageSearch);
+			});
+
+			it('should match a room by message content', async () => {
+				const rooms = await search(alice, 'pineapple');
+				assert.strictEqual(rooms.length, 1);
+				assert.strictEqual(rooms[0].roomId, contentRoom);
+			});
+
+			it('should show the matching message as the teaser', async () => {
+				const [room] = await search(alice, 'pineapple');
+				assert.strictEqual(room.teaser.content, 'pineapple on pizza');
+				assert.strictEqual(room.teaser.user.uid, bob);
+			});
+
+			it('should expose the position of the matching message', async () => {
+				const [room] = await search(alice, 'pineapple');
+				assert(room.teaser.index > 0, `expected a position, got ${room.teaser.index}`);
+			});
+
+			it('should keep the last message as teaser when the room matched by name', async () => {
+				const [room] = await search(alice, 'roadmap');
+				assert.strictEqual(room.teaser.content, 'the last word here');
+			});
+
+			it('should ignore queries shorter than three characters', async () => {
+				assert.deepStrictEqual(await search(alice, 'pi'), []);
+			});
+
+			it('should not match messages sent before the user joined a private room', async () => {
+				joinCutoffRoom = await Messaging.newRoom(alice, { uids: [bob] });
+				await Messaging.addMessage({
+					uid: bob, roomId: joinCutoffRoom, content: 'kumquat marmalade',
+				});
+				await sleep(50);
+				await Messaging.addUsersToRoom(alice, [carol], joinCutoffRoom);
+
+				assert.deepStrictEqual(await search(carol, 'kumquat'), []);
+				const rooms = await search(alice, 'kumquat');
+				assert.strictEqual(rooms.length, 1);
+				assert.strictEqual(rooms[0].roomId, joinCutoffRoom);
+			});
+
+			it('should not match messages from blocked users', async () => {
+				assert.strictEqual((await search(alice, 'aubergine')).length, 1);
+
+				await User.blocks.add(carol, alice);
+				assert.deepStrictEqual(await search(alice, 'aubergine'), []);
+				await User.blocks.remove(carol, alice);
 			});
 		});
 	});


### PR DESCRIPTION
Builds on #14734.

### What this adds

The chat list search matches room names and participant usernames only, so a room can be found by *who* is in it but never by *what* was said in it. Meanwhile the in-room message search already searches content through `filter:messaging.searchMessages`. This wires the same hook into the room list, so one query covers every room the user is in.

Three commits, each standing on its own:

**1. Content matching.** `searchMessageContent` fires `filter:messaging.searchMessages` with `roomId` set to the user's rooms — dbsearch accepts an array there in all three database backends, so this is one query, not one per room — then maps the returned mids back to rooms and keeps the best hit per room.

**2. Which message the row shows.** A room surfaced by content displays the matching message instead of its last one; a row whose visible teaser contains no trace of the query reads as a bug. Rooms that matched by name or participant keep their normal teaser, since there the last message is still the more useful thing to show. This reuses the existing teaser shape, so `recent_room.tpl` needed no change, and those rooms skip the per-room `getLatestUndeletedMessage` lookup entirely.

**3. Opening on the hit.** A result that drops you at the bottom of the room wastes the search — the message may be thousands up. The chat page already supports opening at a position (that is how `/message/:mid` works), so the matching message's rank is resolved server side in one batched call, carried on the row as `data-index`, and passed through `switchChat`. This also fixes `switchChat` always scrolling to the bottom regardless of the requested position; the initial-load scroll logic is now shared as `scrollToInitialPosition`.

### Privileges

The search index has no notion of chat privileges, so the cutoff `getMessageIds` enforces is re-applied here: no matching on messages sent before the user joined a private room, and nothing at all without membership. This is stricter than `api/search.js:roomMessages`, where a null membership score passes the `msg.timestamp > userjoinTimestamp` check — that path checks membership separately, but the comparison itself is worth not copying. Messages from blocked users are dropped, matching what `getTeasers` already does.

### Degradation and cost

With no search plugin the hook yields nothing and search falls back to name/participant matching exactly as before — no capability check needed, since no listener means an empty result. A test pins that path.

Queries under three characters skip the index lookup, mirroring the in-room search, since this runs on every keystroke.

`limit: 500` is passed to the hook. Because results collapse to one row per room, a single busy room can otherwise consume the whole result set and hide every other match — dbsearch hardcoded 100 until barisusakli/nodebb-plugin-dbsearch#85, which is now merged. Plugins that ignore the field keep their own default.

### Tests

`test/messaging.js` had no coverage for `searchRecentChats` at all; this adds a block covering name and participant matching, the no-plugin fallback, content matching, teaser selection, the position handed to the client, the length floor, the private-room join cutoff, and blocked users. The content tests register a stand-in for a search plugin — a naive substring scan — so they do not depend on dbsearch being installed.

One thing worth flagging, since it caught me out: dbsearch is active in the test environment, so `filter:messaging.searchMessages` already has a real listener there. The first version of these tests assumed otherwise — which made the no-plugin case fail, and left the rest running with two listeners, so their results depended on whether dbsearch had indexed the fixture messages. That is why the first CI run passed on postgres and failed on mongo and redis. The tests now swap the hook’s listener list out and restore it, rather than assuming what is registered.

### Note for existing installs

dbsearch is bundled and enabled by default (`install/package.json`, `src/install.js`), so content search works out of the box on a fresh install. But its indexing hooks only catch messages from the point the plugin is active — an existing forum will see no content results for its history until a reindex is run from the dbsearch ACP page. Worth a line in the release notes if this lands.

