### PR TITLE
fix: clean up active and orphaned tooltips on ajaxify transitions and chat modal actions

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -508,14 +508,30 @@ ajaxify.widgets = { render: render };
 		});
 	};
 
+	ajaxify.destroyTooltips = () => {
+		$('.tooltip').each(function () {
+			const id = this.getAttribute('id');
+			const trigger = id ? document.querySelector(`[aria-describedby="${id}"]`) : null;
+			if (trigger && window.bootstrap && window.bootstrap.Tooltip) {
+				const tooltip = window.bootstrap.Tooltip.getInstance(trigger);
+				if (tooltip) {
+					tooltip.hide();
+				}
+			}
+			$(this).remove();
+		});
+	};
+
 	ajaxify.cleanup = (url, tpl_url) => {
 		app.leaveCurrentRoom();
 		$(window).off('scroll');
+		ajaxify.destroyTooltips();
 		hooks.fire('action:ajaxify.cleanup', { url, tpl_url });
 	};
 
 	ajaxify.handleTransientElements = () => {
 		// todo: modals?
+		ajaxify.destroyTooltips();
 
 		const elements = ['[component="notifications"]', '[component="chat/dropdown"]', '[component="sidebar/drafts"]', '[component="header/avatar"]']
 			.map(el => document.querySelector(`${el} .dropdown-menu.show`) || document.querySelector(`${el} + .dropdown-menu.show`))

--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -525,6 +525,7 @@ define('chat', [
 
 	Chat.close = function (uuid) {
 		const chatModal = $('.chat-modal[data-uuid="' + uuid + '"]');
+		chatModal.find('[data-bs-toggle="tooltip"]').tooltip('dispose');
 		chatModal.remove();
 		chatModal.data('modal', null);
 		taskbar.discard('chat', uuid);
@@ -622,6 +623,7 @@ define('chat', [
 
 	Chat.minimize = function (uuid) {
 		const chatModal = $('.chat-modal[data-uuid="' + uuid + '"]');
+		chatModal.find('[data-bs-toggle="tooltip"]').tooltip('hide');
 		chatModal.addClass('hide');
 		taskbar.minimize('chat', uuid);
 		hooks.fire('action:chat.minimized', {


### PR DESCRIPTION
### Problem
When navigating between pages via `ajaxify` or when closing/minimizing a chat modal, any Bootstrap tooltip that is currently active or whose trigger element is removed/hidden can remain orphaned in `document.body`.

Because Popper cannot calculate the bounding rectangle of removed or hidden elements, it falls back to `(0, 0)` with a small offset (e.g. `translate(0px, 6px)`), causing ghost tooltips (such as the "Expand" / "הרחבה" tooltip from the sidebar toggle or chat modal) to remain stuck indefinitely in the top-left corner of the viewport until a hard page reload.

### Solution
1. In `ajaxify.cleanup` and `ajaxify.handleTransientElements`, call a helper `ajaxify.destroyTooltips()` to hide active tooltips and remove any lingering `.tooltip` elements on page transitions.
2. In `Chat.close` and `Chat.minimize`, explicitly dispose / hide tooltips inside the chat modal before removing or hiding the modal element.
