### PR TITLE
fix: keep autocomplete dropdown anchored to typing position during scroll

### DIFF
--- a/public/src/modules/autocomplete.js
+++ b/public/src/modules/autocomplete.js
@@ -171,6 +171,149 @@ define('autocomplete', [
 			}
 		});
 
+		const placement = (options && options.placement) || 'auto';
+
+		textcomplete.dropdown.setOffset = function (cursorOffset) {
+			const el = this.el;
+			if (!el) {
+				return this;
+			}
+			const rect = targetEl.getBoundingClientRect();
+			if (rect.width === 0 && rect.height === 0) {
+				el.style.display = 'none';
+				return this;
+			}
+
+			// Check if targetEl is visible in viewport
+			if (rect.bottom < 0 || rect.top > window.innerHeight) {
+				el.style.visibility = 'hidden';
+				return this;
+			}
+
+			let clientX;
+			let clientY;
+			let cursorLineTop;
+			const lineHeight = (cursorOffset && cursorOffset.lineHeight) || 20;
+
+			if (typeof editor.getCursorPosition === 'function') {
+				const cursorPosition = editor.getCursorPosition();
+				const elScroll = typeof editor.getElScroll === 'function' ?
+					editor.getElScroll() :
+					{ top: targetEl.scrollTop, left: targetEl.scrollLeft };
+				const caretY = rect.top + cursorPosition.top - elScroll.top;
+				const caretX = rect.left + cursorPosition.left - elScroll.left;
+				cursorLineTop = caretY;
+				clientY = caretY + lineHeight;
+				clientX = caretX;
+			} else if (typeof editor.getRange === 'function') {
+				try {
+					const range = editor.getRange();
+					const rangeRect = range.getBoundingClientRect();
+					cursorLineTop = rangeRect.top;
+					clientY = rangeRect.bottom;
+					clientX = rangeRect.left;
+				} catch (err) {
+					cursorLineTop = (cursorOffset.top - window.pageYOffset) - lineHeight;
+					clientY = cursorOffset.top - window.pageYOffset;
+					clientX = cursorOffset.left !== undefined ? cursorOffset.left - window.pageXOffset : undefined;
+				}
+			} else {
+				cursorLineTop = (cursorOffset.top - window.pageYOffset) - lineHeight;
+				clientY = cursorOffset.top - window.pageYOffset;
+				clientX = cursorOffset.left !== undefined ? cursorOffset.left - window.pageXOffset : undefined;
+			}
+
+			// Check if cursor is scrolled outside of targetEl visible area
+			if (clientY < rect.top - 5 || cursorLineTop > rect.bottom + 5) {
+				el.style.visibility = 'hidden';
+				return this;
+			}
+			el.style.visibility = 'visible';
+
+			const dropdownHeight = el.offsetHeight || 200;
+			const dropdownWidth = el.offsetWidth || 250;
+
+			let top = clientY;
+			if (placement === 'top') {
+				top = cursorLineTop - dropdownHeight;
+				if (top < 10) {
+					top = Math.max(10, clientY);
+				}
+			} else if (placement === 'bottom') {
+				top = clientY;
+				if (top + dropdownHeight > window.innerHeight - 10) {
+					if (cursorLineTop - dropdownHeight >= 10) {
+						top = cursorLineTop - dropdownHeight;
+					} else {
+						top = Math.max(10, window.innerHeight - dropdownHeight - 10);
+					}
+				}
+			} else {
+				// auto
+				if (top + dropdownHeight > window.innerHeight - 10 && cursorLineTop - dropdownHeight >= 10) {
+					top = cursorLineTop - dropdownHeight;
+				} else if (top + dropdownHeight > window.innerHeight - 10) {
+					top = Math.max(10, window.innerHeight - dropdownHeight - 10);
+				}
+			}
+
+			const isRtl = targetEl.getAttribute('dir') === 'rtl' ||
+				document.documentElement.getAttribute('data-dir') === 'rtl' ||
+				document.body.getAttribute('data-dir') === 'rtl';
+
+			let left = 'auto';
+			let right = 'auto';
+
+			if (isRtl) {
+				let clientRight = document.documentElement.clientWidth - clientX;
+				clientRight = Math.max(10, Math.min(clientRight, window.innerWidth - dropdownWidth - 10));
+				right = `${clientRight}px`;
+			} else {
+				clientX = Math.max(10, Math.min(clientX, window.innerWidth - dropdownWidth - 10));
+				left = `${clientX}px`;
+			}
+
+			Object.assign(el.style, {
+				position: 'fixed',
+				top: `${top}px`,
+				bottom: 'auto',
+				left: left,
+				right: right,
+				marginTop: '0px',
+			});
+
+			return this;
+		};
+
+		function onScroll() {
+			if (!textcomplete.isShown()) {
+				return;
+			}
+			textcomplete.dropdown.setOffset(editor.getCursorOffset());
+		}
+
+		window.addEventListener('scroll', onScroll, { passive: true, capture: true });
+
+		let resizeObserver;
+		if (window.ResizeObserver) {
+			resizeObserver = new ResizeObserver(() => {
+				if (textcomplete.isShown()) {
+					textcomplete.dropdown.setOffset(editor.getCursorOffset());
+				}
+			});
+			resizeObserver.observe(targetEl);
+		}
+
+		const origDestroy = textcomplete.destroy.bind(textcomplete);
+		textcomplete.destroy = function (destroyEditor = true) {
+			window.removeEventListener('scroll', onScroll, { capture: true });
+			if (resizeObserver) {
+				resizeObserver.disconnect();
+				resizeObserver = null;
+			}
+			return origDestroy(destroyEditor);
+		};
+
 		return textcomplete;
 	};
 


### PR DESCRIPTION
### What does this PR do?

Previously, `@textcomplete` rendered dropdown menus with `position: absolute` directly inside `document.body` and positioned them based on document coordinates (`pageYOffset`).

This caused positioning issues during scroll:
- In the fixed/docked composer (`.composer`), when scrolling the thread in the background, the composer remains fixed to the viewport while the autocomplete dropdown scrolled along with the document body, detaching from the textarea.
- In quick reply and scrollable textareas, scrolling did not update the dropdown's position relative to the caret.

### Changes:
1. Position autocomplete dropdowns using `position: fixed` computed relative to the viewport (`getBoundingClientRect()`, caret position, and editor scroll offset).
2. Add a global capture-phase `scroll` listener so that scrolling any container (window, topic, or the textarea itself) keeps the dropdown anchored to the caret.
3. Automatically hide (`visibility: hidden`) the dropdown if the caret is scrolled outside the visible boundaries of the textarea, and restore visibility once it scrolls back into view.
4. Support viewport edge clamping and RTL directionality (`data-dir="rtl"`).
5. Attach a `ResizeObserver` to adapt to composer resize, and cleanly unbind all listeners on `textcomplete.destroy()`.
