### PR TITLE
feat: mark flag notifications read when the flag detail page is viewed

### DIFF
--- a/public/openapi/components/schemas/NotificationObject.yaml
+++ b/public/openapi/components/schemas/NotificationObject.yaml
@@ -36,7 +36,10 @@ NotificationObject:
           description: A post id, if the notification pertains to a post
         tid:
           type: number
-          description: A post id, if the notification pertains to a topic
+          description: A topic id, if the notification pertains to a topic
+        flagId:
+          type: number
+          description: A flag id, if the notification pertains to a flag
         user:
           $ref: ./UserObject.yaml#/UserObjectTiny
         subject:

--- a/src/controllers/mods.js
+++ b/src/controllers/mods.js
@@ -174,8 +174,12 @@ modsController.flags.detail = async function (req, res, next) {
 		return await user.hidePrivateData(userData.filter(u => u && u.userslug), uid);
 	}
 
-	const assignees = await getAssignees(results.flagData, req.uid);
-	results.flagData.history = await flags.getHistory(req.params.flagId);
+	const [assignees, history] = await Promise.all([
+		getAssignees(results.flagData, req.uid),
+		flags.getHistory(req.params.flagId),
+		flags.markNotificationsRead(req.params.flagId, req.uid),
+	]);
+	results.flagData.history = history;
 
 	if (results.flagData.type === 'user') {
 		results.flagData.type_path = 'uid';

--- a/src/flags.js
+++ b/src/flags.js
@@ -756,6 +756,7 @@ Flags.update = async function (flagId, uid, changeset) {
 			type: 'my-flags',
 			bodyShort: translator.compile('notifications:flag-assigned-to-you', flagId),
 			path: `/flags/${flagId}`,
+			flagId: flagId,
 			nid: `flags:assign:${flagId}:uid:${assigneeId}`,
 			from: uid,
 		});
@@ -943,6 +944,7 @@ Flags.notify = async function (flagObj, uid, notifySelf = false) {
 			bodyLong: String(flagObj.target?.content || ''),
 			pid: flagObj.targetId,
 			path: `/flags/${flagObj.flagId}`,
+			flagId: flagObj.flagId,
 			nid: `flag:post:${flagObj.targetId}:${uid}`,
 			from: uid,
 			mergeId: `notifications:user-flagged-post-in|${flagObj.targetId}`,
@@ -956,6 +958,7 @@ Flags.notify = async function (flagObj, uid, notifySelf = false) {
 			bodyShort: translator.compile('notifications:user-flagged-user', displayname, targetDisplayname),
 			bodyLong: await plugins.hooks.fire('filter:parse.raw', String(flagObj.description || '')),
 			path: `/flags/${flagObj.flagId}`,
+			flagId: flagObj.flagId,
 			nid: `flag:user:${flagObj.targetId}:${uid}`,
 			from: uid,
 			mergeId: `notifications:user-flagged-user|${flagObj.targetId}`,
@@ -974,6 +977,17 @@ Flags.notify = async function (flagObj, uid, notifySelf = false) {
 		uids = uids.filter(_uid => parseInt(_uid, 10) !== parseInt(uid, 10));
 	}
 	await notifications.push(notifObj, uids);
+};
+
+Flags.markNotificationsRead = async function (flagId, uid) {
+	if (!(parseInt(uid, 10) > 0)) {
+		return;
+	}
+	const nids = await user.notifications.getUnreadByField(uid, 'flagId', [flagId]);
+	if (nids.length) {
+		await notifications.markReadMultiple(nids, uid);
+		await user.notifications.pushCount(uid);
+	}
 };
 
 async function mergeBanHistory(history, targetUid, uids) {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -64,7 +64,7 @@ Notifications.privilegedTypes = [
 
 const notificationPruneCutoff = 2592000000; // one month
 
-const intFields = ['datetime', 'from', 'importance', 'tid', 'pid', 'roomId'];
+const intFields = ['datetime', 'from', 'importance', 'tid', 'pid', 'roomId', 'flagId'];
 
 Notifications.getAllNotificationTypes = async function () {
 	const results = await plugins.hooks.fire('filter:user.notificationTypes', {

--- a/test/flags.js
+++ b/test/flags.js
@@ -13,6 +13,7 @@ const Flags = require('../src/flags');
 const Categories = require('../src/categories');
 const Topics = require('../src/topics');
 const Posts = require('../src/posts');
+const notifications = require('../src/notifications');
 const User = require('../src/user');
 const Groups = require('../src/groups');
 const Meta = require('../src/meta');
@@ -648,6 +649,59 @@ describe('Flags', () => {
 
 				delete Meta.config['flags:actionOnReject'];
 			});
+		});
+	});
+
+	describe('.markNotificationsRead()', () => {
+		let result;
+		let flagObj;
+		let nid;
+		let unreadSet;
+		let readSet;
+
+		beforeEach(async () => {
+			result = await Topics.post({
+				cid: category.cid,
+				uid: uid3,
+				title: 'Topic to flag',
+				content: 'This is flaggable content',
+			});
+			flagObj = await api.flags.create({ uid: uid1 }, { type: 'post', id: result.postData.pid, reason: 'spam' });
+			nid = `flag:post:${result.postData.pid}:${uid1}`;
+			unreadSet = `uid:${adminUid}:notifications:unread`;
+			readSet = `uid:${adminUid}:notifications:read`;
+			await sleep(2000);
+		});
+
+		it('should store the flagId on the flag notification', async () => {
+			const [notifObj] = await notifications.getMultiple([nid]);
+			assert.strictEqual(notifObj.flagId, flagObj.flagId);
+		});
+
+		it('should mark the flag notification as read', async () => {
+			assert(await db.isSortedSetMember(unreadSet, nid));
+
+			await Flags.markNotificationsRead(flagObj.flagId, adminUid);
+
+			assert(!await db.isSortedSetMember(unreadSet, nid));
+			assert(await db.isSortedSetMember(readSet, nid));
+		});
+
+		it('should mark the flag notification as read when the flag detail page is viewed', async () => {
+			const { jar: adminJar } = await helpers.loginUser('testUser2', 'abcdef');
+			assert(await db.isSortedSetMember(unreadSet, nid));
+
+			const { response } = await request.get(`${nconf.get('url')}/flags/${flagObj.flagId}`, { jar: adminJar });
+			assert.strictEqual(response.statusCode, 200);
+
+			assert(!await db.isSortedSetMember(unreadSet, nid));
+			assert(await db.isSortedSetMember(readSet, nid));
+		});
+
+		it('should not touch notifications of a user who never received one', async () => {
+			assert(!await db.isSortedSetMember(`uid:${uid3}:notifications:unread`, nid));
+			await Flags.markNotificationsRead(flagObj.flagId, uid3);
+			assert(!await db.isSortedSetMember(`uid:${uid3}:notifications:read`, nid));
 		});
 	});
 


### PR DESCRIPTION
## Summary

Viewing a topic marks that topic's notifications as read (`Topics.markTopicNotificationsRead`, called from the topic controller), but viewing a flag does not do the same for the flag's notifications. A moderator who reaches `/flags/:flagId` through the flags list, a direct link, a middle-click / "open in new tab", or an email is left with a stale unread `new-post-flag` / `new-user-flag` notification until they click it in the dropdown or use "mark all read".

This PR mirrors the topic behaviour for flags.

## Changes

- `Flags.notify` and the assignee notification in `Flags.update` now set a `flagId` field on the notification object (previously the flag id was only embedded in `path`).
- New `Flags.markNotificationsRead(flagId, uid)`: looks up the viewer's unread notifications by `flagId` via `user.notifications.getUnreadByField`, marks them read with `notifications.markReadMultiple`, and pushes the updated unread count.
- `modsController.flags.detail` calls it after the existing access checks pass, alongside loading assignees and history.
- `flagId` added to the notification `intFields` list and to `NotificationObject.yaml`.
- Tests: notification carries `flagId`; direct call marks read; a GET of the flag detail page as an admin marks read; a user with no notification is untouched.

## Notes

- Notifications created before this change have no `flagId` and are not affected. They still clear via click, "mark all read", or the existing rescind-on-resolve/reject setting.
- Only the viewer's own notifications are marked, and only after the controller has confirmed the viewer may see the flag.

## Testing

`npx mocha test/flags.js` — 67 passing (4 new).
