### PR TITLE
feat(activitypub): render custom emoji in topic titles

### DIFF
--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -30,6 +30,7 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 		renderDigestAvatar,
 		userAgentIcons,
 		buildAvatar,
+		renderTitleEmoji,
 		increment,
 		lessthan,
 		greaterthan,
@@ -547,6 +548,20 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 		});
 
 		return html.join('');
+	}
+
+	function renderTitleEmoji(title, emojiMeta) {
+		if (!title || !emojiMeta || !emojiMeta.length) {
+			return String(title || '');
+		}
+		let result = String(title);
+		for (const { clean, hostname } of emojiMeta) {
+			const code = `:${clean}:`;
+			const proxyUrl = `/emoji/ap/${encodeURIComponent(clean)}/${encodeURIComponent(hostname)}`;
+			const imgTag = `<img class="not-responsive emoji" src="${proxyUrl}" title="${code}" />`;
+			result = result.split(code).join(imgTag);
+		}
+		return result;
 	}
 
 	function register() {

--- a/src/activitypub/notes.js
+++ b/src/activitypub/notes.js
@@ -206,8 +206,28 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 				generatedTitle = 1;
 			}
 
-			// Remove any custom emoji from title
-			title = await activitypub.helpers.renderEmoji(title, _activitypub.tag, true);
+			// Extract emoji metadata for title rendering
+			const titleEmoji = [];
+			const emojiTags = (_activitypub.tag || []).filter(tag => tag.type === 'Emoji');
+			for (const tag of emojiTags) {
+				const { name, icon } = tag;
+				if (!name || !icon?.url) continue;
+				let code = name;
+				if (!code.startsWith(':')) code = `:${code}`;
+				if (!code.endsWith(':')) code = `${code}:`;
+				if (title.includes(code)) {
+					try {
+						const { hostname } = new URL(icon.url);
+						const clean = code.replace(/^:+|:+$/g, '');
+						titleEmoji.push({ code, hostname, clean });
+					} catch {
+						// skip invalid icon URLs
+					}
+				}
+			}
+			if (titleEmoji.length) {
+				mainPost.titleEmoji = JSON.stringify(titleEmoji);
+			}
 		}
 		mainPid = utils.isNumber(mainPid) ? parseInt(mainPid, 10) : mainPid;
 
@@ -273,6 +293,7 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 					cid: options.cid || cid,
 					pid: mainPid,
 					title,
+					titleEmoji: mainPost.titleEmoji,
 					timestamp,
 					content: mainPost.content,
 					sourceContent: mainPost.sourceContent,
@@ -296,6 +317,7 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 					cid: options.cid || cid,
 					pid: mainPid,
 					title,
+					titleEmoji: mainPost.titleEmoji,
 					timestamp,
 					tags,
 					content: mainPost.content,

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -42,6 +42,10 @@ module.exports = function (Topics) {
 			topicData.tags = data.tags.join(',');
 		}
 
+		if (data.titleEmoji) {
+			topicData.titleEmoji = data.titleEmoji;
+		}
+
 		if (Array.isArray(data.thumbs) && data.thumbs.length) {
 			const thumbs = Topics.thumbs.filterThumbs(data.thumbs);
 			topicData.thumbs = JSON.stringify(thumbs);

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -91,6 +91,10 @@ function modifyTopic(topic, fields) {
 		topic.title = String(topic.title);
 	}
 
+	if (hasField('titleEmoji')) {
+		topic.titleEmoji = topic.titleEmoji ? JSON.parse(String(topic.titleEmoji)) : [];
+	}
+
 	if (hasField('timestamp')) {
 		topic.timestampISO = utils.toISOString(topic.timestamp);
 		if (hasField('scheduled')) {

--- a/src/views/partials/feed/item.tpl
+++ b/src/views/partials/feed/item.tpl
@@ -48,7 +48,7 @@
 				<div>
 					{{{ if !./topic.generatedTitle }}}
 					<a class="lh-1 topic-title fw-semibold fs-5 text-reset line-clamp-2" href="{config.relative_path}/topic/{./topic.slug}">
-						{./topic.title}
+						{{renderTitleEmoji(./topic.title, ./topic.titleEmoji)}}
 					</a>
 					{{{ end }}}
 				</div>

--- a/src/views/partials/search/results.tpl
+++ b/src/views/partials/search/results.tpl
@@ -18,7 +18,7 @@
 	<hr/>
 	<div class="topic-row  mb-3">
 		<a class="topic-title fw-semibold fs-5 text-reset text-break" href="{config.relative_path}/post/{encodeURIComponent(./pid)}">
-			{{{ if !./isMainPost }}}RE: {{{ end }}}{./topic.title}
+			{{{ if !./isMainPost }}}RE: {{{ end }}}{{renderTitleEmoji(./topic.title, ./topic.titleEmoji)}}
 		</a>
 		<div class="post-body d-flex flex-column gap-1">
 			<div class="d-flex gap-3 post-info">

--- a/src/views/post-queue.tpl
+++ b/src/views/post-queue.tpl
@@ -147,14 +147,14 @@
 							<span class="small topic-title text-break">
 								{{{ if posts.data.tid }}}
 								<div class="d-flex flex-column align-items-start gap-1">
-									<a href="{config.relative_path}/topic/{posts.data.tid}">{posts.topic.title}</a>
+									<a href="{config.relative_path}/topic/{posts.data.tid}">{{renderTitleEmoji(posts.topic.title, posts.topic.titleEmoji)}}</a>
 									<span class="badge text-body border border-gray-300 stats text-xs">
 										<span class="text-lowercase fw-normal">{{tx("global:lastpost")}}</span>
 										<span title="{posts.topic.lastposttimeISO}" class="timeago fw-bold"></span>
 									</span>
 								</div>
 								{{{ end }}}
-								<span class="title-text">{posts.data.title}</span>
+								<span class="title-text">{{renderTitleEmoji(posts.data.title, posts.data.titleEmoji)}}</span>
 							</span>
 							{{{if !posts.data.tid}}}
 							<div class="topic-title-editable hidden">


### PR DESCRIPTION
## feat(activitypub): render custom emoji in topic titles

Previously, custom emoji shortcodes were silently stripped from auto-generated topic titles (`:fediverse:` → empty string). This lost information from the original post content.

This change preserves emoji shortcodes in titles and renders them as `<img>` tags at template time using a new Benchpress helper.

### How it works

1. **Store**: When `notes.assert()` processes incoming ActivityPub notes, it scans the note's `_activitypub.tag` array for `Emoji` type entries that appear in the title. Metadata (`{ code, hostname, clean }`) is serialized to JSON and persisted as `titleEmoji` on the topic object.

2. **Parse**: `modifyTopic()` in `topics/data.js` deserializes `titleEmoji` from JSON string → array on every topic load.

3. **Render**: A new Benchpress helper `renderTitleEmoji(title, titleEmoji)` replaces `:shortcode:` patterns with `<img class="not-responsive emoji" src="/emoji/ap/:clean/:hostname" title=":shortcode:" />` using the existing emoji proxy route. Templates use `{{renderTitleEmoji(./title, ./titleEmoji)}}` (double braces for unescaped HTML).

### Title surfaces updated

- **Topic view page** — harmony + persona themes (`topic.tpl`)
- **Topic list** — harmony + persona themes (`topics_list.tpl`)
- **Feed items** — `src/views/partials/feed/item.tpl`
- **Search results** — `src/views/partials/search/results.tpl`
- **Post queue** — `src/views/post-queue.tpl` (two locations)

### Surfaces intentionally left as plain text

Breadcrumbs, SEO `<meta>` tags, JSON-LD, RSS feeds, and email templates remain escaped. Emoji shortcodes pass through as plain text in these contexts.

### Behaviour notes

- **Set and forget**: `titleEmoji` is set at creation/update time. If a local user edits the title, `titleEmoji` stays stale. On incoming `Update` activity, `notes.assert()` recalculates it.
- **Local emoji**: Only ActivityPub remote emoji are supported. Local NodeBB emoji shortcodes in titles pass through as plain text.
- **Shortcodes without metadata**: If a shortcode appears in the title but has no matching emoji tag, it renders as-is (`:unknown:`).