### PR TITLE
displayname emoji

### DIFF
--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -30,7 +30,7 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 		renderDigestAvatar,
 		userAgentIcons,
 		buildAvatar,
-		renderTitleEmoji,
+		renderShortcodeEmoji,
 		increment,
 		lessthan,
 		greaterthan,
@@ -550,11 +550,11 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 		return html.join('');
 	}
 
-	function renderTitleEmoji(title, emojiMeta) {
-		if (!title || !emojiMeta || !emojiMeta.length) {
-			return String(title || '');
+	function renderShortcodeEmoji(text, emojiMeta) {
+		if (!text || !emojiMeta || !emojiMeta.length) {
+			return String(text || '');
 		}
-		let result = String(title);
+		let result = String(text);
 		for (const { clean, hostname } of emojiMeta) {
 			const code = `:${clean}:`;
 			const proxyUrl = `/emoji/ap/${encodeURIComponent(clean)}/${encodeURIComponent(hostname)}`;

--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -558,7 +558,7 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 		for (const { clean, hostname } of emojiMeta) {
 			const code = `:${clean}:`;
 			const proxyUrl = `/emoji/ap/${encodeURIComponent(clean)}/${encodeURIComponent(hostname)}`;
-			const imgTag = `<img class="not-responsive emoji" src="${proxyUrl}" title="${code}" />`;
+			const imgTag = `<img class="not-responsive emoji" src="${escape(proxyUrl)}" title="${escape(code)}" />`;
 			result = result.split(code).join(imgTag);
 		}
 		return result;

--- a/public/src/modules/helpers.common.js
+++ b/public/src/modules/helpers.common.js
@@ -552,7 +552,7 @@ module.exports = function (utils, Benchpress, tx, relative_path) {
 
 	function renderShortcodeEmoji(text, emojiMeta) {
 		if (!text || !emojiMeta || !emojiMeta.length) {
-			return String(text || '');
+			return String(escape(text) || '');
 		}
 		let result = String(text);
 		for (const { clean, hostname } of emojiMeta) {

--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -251,6 +251,26 @@ Mocks.profile = async (actors) => {
 		bgColor = iconBackgrounds[bgColor % iconBackgrounds.length];
 		summary = await activitypub.helpers.renderEmoji(summary || '', tag);
 
+		// Extract emoji metadata for fullname rendering (titleEmoji pattern)
+		const nameEmoji = [];
+		const emojiTags = (tag || []).filter(tag => tag.type === 'Emoji');
+		for (const emojiTag of emojiTags) {
+			const { name: emojiName, icon } = emojiTag;
+			if (!emojiName || !icon?.url) continue;
+			let code = emojiName;
+			if (!code.startsWith(':')) code = `:${code}`;
+			if (!code.endsWith(':')) code = `${code}:`;
+			if (name && name.includes(code)) {
+				try {
+					const { hostname } = new URL(icon.url);
+					const clean = code.replace(/^:+|:+$/g, '');
+					nameEmoji.push({ code, hostname, clean });
+				} catch {
+					// skip invalid icon URLs
+				}
+			}
+		}
+
 		// Add custom fields into user hash
 		const customFields = actor.attachment && Array.isArray(actor.attachment) && actor.attachment.length ?
 			actor.attachment
@@ -289,6 +309,7 @@ Mocks.profile = async (actors) => {
 			userslug: `${preferredUsername}@${canonicalHostname}`.toLowerCase(),
 			displayname: name,
 			fullname: name,
+			fullnameEmoji: nameEmoji.length ? JSON.stringify(nameEmoji) : undefined,
 			joindate: new Date(published).getTime() || Date.now(),
 			picture,
 			status: 'offline',

--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -251,7 +251,7 @@ Mocks.profile = async (actors) => {
 		bgColor = iconBackgrounds[bgColor % iconBackgrounds.length];
 		summary = await activitypub.helpers.renderEmoji(summary || '', tag);
 
-		// Extract emoji metadata for fullname rendering (titleEmoji pattern)
+		// Extract emoji metadata for fullname rendering
 		const nameEmoji = [];
 		const emojiTags = (tag || []).filter(tag => tag.type === 'Emoji');
 		for (const emojiTag of emojiTags) {

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -34,7 +34,7 @@ module.exports = function (Posts) {
 		const tids = _.uniq(posts.map(p => p && p.tid));
 
 		const [users, topicsAndCategories] = await Promise.all([
-			user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture', 'status']),
+			user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture', 'status', 'fullnameEmoji']),
 			getTopicAndCategories(tids),
 		]);
 

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -96,7 +96,7 @@ module.exports = function (Posts) {
 
 	async function getUserData(uids, uid) {
 		const fields = [
-			'uid', 'username', 'fullname', 'userslug',
+			'uid', 'username', 'fullname', 'fullnameEmoji', 'userslug',
 			'reputation', 'postcount', 'topiccount', 'picture',
 			'signature', 'banned', 'banned:expire', 'status',
 			'lastonline', 'groupTitle', 'muted', 'mutedUntil',

--- a/src/topics/index.js
+++ b/src/topics/index.js
@@ -101,7 +101,7 @@ Topics.getTopicsByTids = async function (tids, options) {
 
 		const [teasers, users, userSettings, categoriesData, guestHandles, thumbs] = await Promise.all([
 			Topics.getTeasers(topics, options),
-			user.getUsersFields(uids, ['uid', 'username', 'fullname', 'userslug', 'reputation', 'postcount', 'picture', 'banned', 'status']),
+			user.getUsersFields(uids, ['uid', 'username', 'fullname', 'fullnameEmoji', 'userslug', 'reputation', 'postcount', 'picture', 'banned', 'status']),
 			loadShowfullnameSettings(),
 			categories.getCategoriesFields(cids, ['cid', 'name', 'slug', 'icon', 'backgroundImage', 'imageClass', 'bgColor', 'color', 'disabled']),
 			loadGuestHandles(),

--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -192,7 +192,7 @@ module.exports = function (Topics) {
 		parentPids = parentPids.filter(p => pidToPrivs[p]['topics:read']);
 		const parentPosts = await posts.getPostsFields(parentPids, ['uid', 'pid', 'timestamp', 'content', 'sourceContent', 'deleted', 'uploads']);
 		const parentUids = _.uniq(parentPosts.map(postObj => postObj && postObj.uid));
-		const userData = await user.getUsersFields(parentUids, ['username', 'userslug', 'picture']);
+		const userData = await user.getUsersFields(parentUids, ['username', 'userslug', 'picture', 'fullnameEmoji']);
 
 		const usersMap = _.zipObject(parentUids, userData);
 

--- a/src/topics/teaser.js
+++ b/src/topics/teaser.js
@@ -54,7 +54,7 @@ module.exports = function (Topics) {
 		postData = postData.filter(Boolean);
 		const uids = _.uniq(postData.map(post => post.uid));
 		const sortNewToOld = callerSettings.topicPostSort === 'newest_to_oldest';
-		const usersData = await user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture']);
+		const usersData = await user.getUsersFields(uids, ['uid', 'username', 'userslug', 'picture', 'fullnameEmoji']);
 
 		const users = {};
 		usersData.forEach((user) => {

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -28,7 +28,7 @@ const intFields = [
 module.exports = function (User) {
 	const fieldWhitelist = [
 		'uid', 'username', 'userslug', 'url', 'email', 'email:confirmed', 'joindate',
-		'lastonline', 'picture', 'icon:bgColor', 'fullname', 'birthday',
+		'lastonline', 'picture', 'icon:bgColor', 'fullname', 'fullnameEmoji', 'birthday',
 		'aboutme', 'signature', 'uploadedpicture', 'profileviews', 'reputation',
 		'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
 		'status', 'flags', 'followerCount', 'followingCount', 'cover:url',
@@ -271,6 +271,11 @@ module.exports = function (User) {
 			}
 
 			db.parseIntFields(user, intFields, requestedFields);
+
+			// Parse fullnameEmoji from JSON (titleEmoji pattern)
+			if (user.hasOwnProperty('fullnameEmoji')) {
+				user.fullnameEmoji = user.fullnameEmoji ? JSON.parse(String(user.fullnameEmoji)) : [];
+			}
 
 			if (user.hasOwnProperty('username')) {
 				user.username = String(user.username || '');

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -272,7 +272,7 @@ module.exports = function (User) {
 
 			db.parseIntFields(user, intFields, requestedFields);
 
-			// Parse fullnameEmoji from JSON (titleEmoji pattern)
+			// Parse fullnameEmoji from JSON
 			if (user.hasOwnProperty('fullnameEmoji')) {
 				user.fullnameEmoji = user.fullnameEmoji ? JSON.parse(String(user.fullnameEmoji)) : [];
 			}

--- a/src/user/index.js
+++ b/src/user/index.js
@@ -91,6 +91,7 @@ User.getUsers = async function (uids, uid) {
 		'uid', 'username', 'userslug', 'picture', 'status',
 		'postcount', 'reputation', 'email:confirmed', 'lastonline',
 		'flags', 'banned', 'banned:expire', 'joindate',
+		'fullnameEmoji',
 	], uid);
 
 	return User.hidePrivateData(userData, uid);

--- a/src/views/partials/feed/item.tpl
+++ b/src/views/partials/feed/item.tpl
@@ -48,7 +48,7 @@
 				<div>
 					{{{ if !./topic.generatedTitle }}}
 					<a class="lh-1 topic-title fw-semibold fs-5 text-reset line-clamp-2" href="{config.relative_path}/topic/{./topic.slug}">
-						{{renderTitleEmoji(./topic.title, ./topic.titleEmoji)}}
+						{{renderShortcodeEmoji(./topic.title, ./topic.titleEmoji)}}
 					</a>
 					{{{ end }}}
 				</div>

--- a/src/views/partials/feed/item.tpl
+++ b/src/views/partials/feed/item.tpl
@@ -30,7 +30,7 @@
 					<div class="text-sm">
 						<div class="post-author d-flex align-items-center gap-1">
 							<a class="d-inline d-lg-none lh-1 text-decoration-none" href="{config.relative_path}/user/{./user.userslug}">{{buildAvatar(./user, "16px", true, "not-responsive")}}</a>
-							<a class="lh-normal fw-semibold text-nowrap" href="{config.relative_path}/user/{./user.userslug}">{{txDisplayname(./user)}}</a>
+							<a class="lh-normal fw-semibold text-nowrap" href="{config.relative_path}/user/{./user.userslug}">{{renderShortcodeEmoji(txDisplayname(./user), ./user.fullnameEmoji)}}</a>
 						</div>
 						<span class="timeago text-muted lh-normal" title="{./timestampISO}"></span>
 					</div>

--- a/src/views/partials/search/results.tpl
+++ b/src/views/partials/search/results.tpl
@@ -18,7 +18,7 @@
 	<hr/>
 	<div class="topic-row  mb-3">
 		<a class="topic-title fw-semibold fs-5 text-reset text-break" href="{config.relative_path}/post/{encodeURIComponent(./pid)}">
-			{{{ if !./isMainPost }}}RE: {{{ end }}}{{renderTitleEmoji(./topic.title, ./topic.titleEmoji)}}
+			{{{ if !./isMainPost }}}RE: {{{ end }}}{{renderShortcodeEmoji(./topic.title, ./topic.titleEmoji)}}
 		</a>
 		<div class="post-body d-flex flex-column gap-1">
 			<div class="d-flex gap-3 post-info">

--- a/src/views/partials/topic/post-parent.tpl
+++ b/src/views/partials/topic/post-parent.tpl
@@ -2,7 +2,7 @@
 	<div class="d-flex gap-2 text-nowrap">
 		<div class="d-flex flex-nowrap gap-1 align-items-center">
 			<a href="{config.relative_path}/user/{./parent.user.userslug}" class="text-decoration-none lh-1">{{buildAvatar(./parent.user, "16px", true, "not-responsive align-middle")}}</a>
-			<a class="fw-semibold text-truncate" style="max-width: 150px;" href="{config.relative_path}/user/{./parent.user.userslug}">{{txDisplayname(./parent.user)}}</a>
+			<a class="fw-semibold text-truncate" style="max-width: 150px;" href="{config.relative_path}/user/{./parent.user.userslug}">{{renderShortcodeEmoji(txDisplayname(./parent.user), ./parent.user.fullnameEmoji)}}</a>
 		</div>
 
 		<a href="{config.relative_path}/post/{encodeURIComponent(./parent.pid)}" class="text-muted timeago text-nowrap hidden" title="{./parent.timestampISO}"></a>

--- a/src/views/post-queue.tpl
+++ b/src/views/post-queue.tpl
@@ -147,14 +147,14 @@
 							<span class="small topic-title text-break">
 								{{{ if posts.data.tid }}}
 								<div class="d-flex flex-column align-items-start gap-1">
-									<a href="{config.relative_path}/topic/{posts.data.tid}">{{renderTitleEmoji(posts.topic.title, posts.topic.titleEmoji)}}</a>
+									<a href="{config.relative_path}/topic/{posts.data.tid}">{{renderShortcodeEmoji(posts.topic.title, posts.topic.titleEmoji)}}</a>
 									<span class="badge text-body border border-gray-300 stats text-xs">
 										<span class="text-lowercase fw-normal">{{tx("global:lastpost")}}</span>
 										<span title="{posts.topic.lastposttimeISO}" class="timeago fw-bold"></span>
 									</span>
 								</div>
 								{{{ end }}}
-								<span class="title-text">{{renderTitleEmoji(posts.data.title, posts.data.titleEmoji)}}</span>
+								<span class="title-text">{{renderShortcodeEmoji(posts.data.title, posts.data.titleEmoji)}}</span>
 							</span>
 							{{{if !posts.data.tid}}}
 							<div class="topic-title-editable hidden">


### PR DESCRIPTION
## ActivityPub: render remote emoji in actor display names

Remote ActivityPub actors can include custom emoji shortcodes in their `name` field (e.g. `"Twin Cities Geek :1up:"`). This PR applies the same pattern used for topic titles to render those emoji in actor display names.

### Changes

**`src/activitypub/mocks.js`** — Extract emoji metadata from `name` during actor assertion. For each `Emoji` tag whose shortcode appears in the actor's `name`, store `{ code, hostname, clean }` as `fullnameEmoji` JSON alongside the raw `fullname`.

**`src/user/data.js`** — Whitelist and parse `fullnameEmoji` from JSON on user data fetch (matching the `titleEmoji` pattern in `topics/data.js`).

**`public/src/modules/helpers.common.js`** — Rename `renderTitleEmoji` → `renderShortcodeEmoji` to reflect broader use (actor names + topic titles).

**Core templates** — Update `feed/item.tpl`, `search/results.tpl`, `post-queue.tpl` to use renamed helper.

### How it works

1. Actor assertion extracts emoji tags matching shortcodes in `name`
2. `fullnameEmoji` stored as JSON in `userRemote:{uid}`
3. Parsed to array on `user.getUsersFields()`
4. Template renders via `{{renderShortcodeEmoji(fullname, fullnameEmoji)}}`

### Theme changes (separate repos)

**Harmony:** `partials/account/header.tpl`, `partials/users/item.tpl`
**Persona:** `account/profile.tpl`, `modules/usercard.tpl`