### PR TITLE
fix: unread/flags nav counts not rendered when relative_path is set

### DIFF
--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -451,7 +451,8 @@ module.exports = function (middleware) {
 		const { tidsByFilter } = results.unreadData;
 		navigation = navigation.map((item) => {
 			function modifyNavItem(item, route, filter, content) {
-				if (item && item.route === route) {
+				// navigation routes are prefixed with relative_path in navigation.get
+				if (item && item.route === relative_path + route) {
 					unreadData[filter] = _.zipObject(tidsByFilter[filter], tidsByFilter[filter].map(() => true));
 					item.content = content;
 					unreadCount.mobileUnread = content;
@@ -467,7 +468,7 @@ module.exports = function (middleware) {
 			modifyNavItem(item, '/unread?filter=unreplied', 'unreplied', unreadCount.unrepliedTopic);
 
 			['flags'].forEach((prop) => {
-				if (item && item.route === `/${prop}` && unreadCount[prop] > 0) {
+				if (item && item.route === `${relative_path}/${prop}` && unreadCount[prop] > 0) {
 					item.iconClass += ' unread-count';
 					item.content = unreadCount.flags;
 				}


### PR DESCRIPTION
### Problem

On forums installed under a subfolder (`relative_path` set, e.g. `https://example.com/forum`), the unread badge in the sidebar is not rendered on page load. It only appears after the user visits `/unread`, and it disappears again on the next full page load.

### Cause

`navigation.get()` prefixes every nav item route with `relative_path`:

```js
if (!item.route.startsWith('http')) {
    item.route = relative_path + item.route;
}
```

But `appendUnreadCounts()` in `src/middleware/render.js` compares against the bare route:

```js
if (item && item.route === route) { // route is '/unread'
```

With `relative_path` set, `item.route` is `/forum/unread` and the comparison never matches, so `item.content` is never assigned. Themes render the badge with the `hidden` class when `content` is empty. The count only shows up after `forum/unread` client-side code writes it into the badge, since the client selectors correctly include `config.relative_path`. The same bug affects the `/flags` badge.

The `originalRoute` field that held the unprefixed route and was used for this comparison was removed in 42a9f5f0cc (#14341), which switched the check to `item.route`.

### Fix

Compare against `relative_path + route`. `unreadCount.unreadUrl` is deliberately left unprefixed, since the client-side selectors in `public/src/client/header/unread.js` build the URL as `config.relative_path + url`.

Installs with an empty `relative_path` are unaffected either way.