### PR TITLE
fix(api): clamp stale stored pagination values on settings save

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -145,6 +145,18 @@ usersAPI.updateSettings = async function (caller, data) {
 	const payload = { ...defaults, ...current, ...data.settings };
 	delete payload.uid;
 
+	// A stored pagination value can exceed the configured maximum (saved before
+	// the maximum was lowered). Clamp it into range instead of rejecting the
+	// whole save, mirroring the read-side clamp in user.getSettings.
+	const maxPostsPerPage = meta.config.maxPostsPerPage || 20;
+	const maxTopicsPerPage = meta.config.maxTopicsPerPage || 20;
+	if (parseInt(payload.postsPerPage, 10)) {
+		payload.postsPerPage = Math.max(2, Math.min(maxPostsPerPage, parseInt(payload.postsPerPage, 10)));
+	}
+	if (parseInt(payload.topicsPerPage, 10)) {
+		payload.topicsPerPage = Math.max(2, Math.min(maxTopicsPerPage, parseInt(payload.topicsPerPage, 10)));
+	}
+
 	return await user.saveSettings(data.uid, payload);
 };
 

--- a/test/user.js
+++ b/test/user.js
@@ -1773,6 +1773,29 @@ describe('User', () => {
 			assert.strictEqual(userSettings.usePagination, true);
 		});
 
+		it('should clamp stale stored pagination values exceeding the configured maximum instead of failing the save', async () => {
+			const username = utils.generateUUID().slice(0, 6);
+			const uid = await User.create({ username });
+			const maxPostsPerPage = meta.config.maxPostsPerPage || 20;
+			// simulate a value stored before the site maximum was lowered
+			await db.setObject(`user:${uid}:settings`, {
+				postsPerPage: String(maxPostsPerPage + 10),
+				topicsPerPage: '10',
+			});
+			const updated = await apiUser.updateSettings({ uid: uid }, {
+				uid: uid,
+				settings: {
+					bootswatchSkin: 'default',
+					userLang: 'en-GB',
+					usePagination: 1,
+					topicsPerPage: '10',
+				},
+			});
+			assert.strictEqual(updated.postsPerPage, maxPostsPerPage);
+			const stored = await db.getObject(`user:${uid}:settings`);
+			assert.strictEqual(parseInt(stored.postsPerPage, 10), maxPostsPerPage);
+		});
+
 		it('should properly escape homePageRoute', async () => {
 			const username = utils.generateUUID().slice(0, 6);
 			const uid = await User.create({ username, password: '123456' });


### PR DESCRIPTION
Fixes #14765

**Problem**
A stored `postsPerPage`/`topicsPerPage` above the configured maximum makes every `PUT /api/v3/users/:uid/settings` fail with `[[error:invalid-pagination-value]]`, even when the user is saving unrelated fields. The read side (`getSettings`) clamps these values into range; the write side (`updateSettings` -> `saveSettings` -> `validateSettings`) merges the raw stored value into the payload and throws. First reported on the community forum: https://community.nodebb.org/topic/19485/theme-settings-cannot-be-saved-due-to-invalid-page-value

**Fix**
In `usersAPI.updateSettings`, clamp `payload.postsPerPage`/`payload.topicsPerPage` into `[2, meta.config.maxPostsPerPage || 20]` / `[2, meta.config.maxTopicsPerPage || 20]` before calling `saveSettings`, mirroring the read-side clamp in `getSettings`/`onSettingsLoaded`.

Deliberate behavior notes:
- The clamp guards with `parseInt(...)`, so non-numeric values still fall through to `validateSettings` and 400 as before.
- A value the user explicitly submits out of range is now clamped rather than rejected - consistent with how the read side has always treated out-of-range values (clamp, don't error). Happy to restrict the clamp to stored-only values if you'd rather keep the 400 for explicit out-of-range input.

**Test**
New case in `test/user.js`: seeds a stored `postsPerPage` above the configured maximum, saves unrelated theme settings via `apiUser.updateSettings`, and asserts the save succeeds and the stored value is clamped to the maximum.

> Built by breken, your AI support engineer - breken.ai - this one's on us.