### PR TITLE
fix: category/tag filter dropdown taller than the viewport

### DIFF
--- a/public/scss/admin/admin.scss
+++ b/public/scss/admin/admin.scss
@@ -165,7 +165,7 @@ body {
 
 [component="category-selector"] {
 	.category-dropdown-menu {
-		max-height: 500px;
+		max-height: 65vh;
 		overflow-y: auto;
 		overflow-x: hidden;
 	}

--- a/public/scss/generics.scss
+++ b/public/scss/generics.scss
@@ -35,7 +35,7 @@ html[data-dir="rtl"] {
 }
 
 .category-dropdown-menu {
-	max-height: 500px;
+	max-height: 65vh;
 	overflow-y: auto;
 	overflow-x: hidden;
 }

--- a/src/views/partials/tags/filter-dropdown-content.tpl
+++ b/src/views/partials/tags/filter-dropdown-content.tpl
@@ -15,7 +15,7 @@
         <input type="text" class="form-control form-control-sm" placeholder="{{tx("search:type-to-search")}}" autocomplete="off">
         <hr class="mt-2 mb-0"/>
     </div>
-    <ul component="tag/filter/list" class="list-unstyled mb-0 text-sm overflow-auto ghost-scrollbar" role="menu" style="max-height: 500px;" role="menu">
+    <ul component="tag/filter/list" class="list-unstyled mb-0 text-sm overflow-auto ghost-scrollbar" role="menu" style="max-height: 65vh;">
         <li role="presentation" data-tag="">
             <a class="dropdown-item rounded-1 d-flex align-items-center gap-2" role="menuitem" href="#">
                 <span class="flex-grow-1">{{tx("tags:all-tags")}}</span>


### PR DESCRIPTION
The category/tag filter dropdown (e.g. on Recent) hard-codes its list to `max-height: 500px`. That number has nothing to do with the actual browser height, so on shorter screens the whole dropdown pokes out past the bottom of the page — even though the list itself scrolls fine internally.

Swapped the fixed `500px` for `65vh`, same as `acp-search.scss` already does for a near-identical dropdown. Three one-line changes, no JS involved.