### PR TITLE
fix: show which login field is missing instead of a generic error

### DIFF
--- a/public/language/en-GB/error.json
+++ b/public/language/en-GB/error.json
@@ -29,6 +29,8 @@
 	"invalid-password": "Invalid Password",
 	"invalid-login-credentials": "Invalid login credentials",
 	"invalid-username-or-password": "Please specify both a username and password",
+	"username-required": "Please enter your username",
+	"password-required": "Please enter your password",
 	"invalid-search-term": "Invalid search term",
 	"invalid-url": "Invalid URL",
 	"invalid-event": "Invalid event: %1",

--- a/public/src/client/login.js
+++ b/public/src/client/login.js
@@ -85,6 +85,14 @@ define('forum/login', ['hooks', 'translator', 'jquery-form'], function (hooks, t
 			});
 		});
 
+		// Pressing enter in the username field with an empty password moves focus to the password field
+		$('#username').on('keydown', function (e) {
+			if (e.key === 'Enter' && $('#username').val() && !$('#password').val()) {
+				e.preventDefault();
+				$('#password').focus();
+			}
+		});
+
 		// Guard against caps lock
 		Login.capsLockCheck(document.querySelector('#password'), document.querySelector('#caps-lock-warning'));
 

--- a/public/src/client/login.js
+++ b/public/src/client/login.js
@@ -17,7 +17,7 @@ define('forum/login', ['hooks', 'translator', 'jquery-form'], function (hooks, t
 			const password = $('#password').val();
 			errorEl.addClass('hidden').find('p').text('');
 			if (!username || !password) {
-				errorEl.find('p').translateText('[[error:invalid-username-or-password]]');
+				errorEl.find('p').translateText(!username ? '[[error:username-required]]' : '[[error:password-required]]');
 				errorEl.removeClass('hidden');
 				return;
 			}
@@ -83,14 +83,6 @@ define('forum/login', ['hooks', 'translator', 'jquery-form'], function (hooks, t
 					}
 				},
 			});
-		});
-
-		// Pressing enter in the username field with an empty password moves focus to the password field
-		$('#username').on('keydown', function (e) {
-			if (e.key === 'Enter' && $('#username').val() && !$('#password').val()) {
-				e.preventDefault();
-				$('#password').focus();
-			}
 		});
 
 		// Guard against caps lock


### PR DESCRIPTION
On the login page, submitting the form with only a username filled in shows the generic "Please specify both a username and password" message, which doesn't tell the user which field is missing.

This keeps the default form behaviour (Enter submits) and instead shows a specific message: `[[error:username-required]]` when the username is empty, `[[error:password-required]]` when the password is empty. Both keys are added to `en-GB/error.json`.