### PR TITLE
fix: register template helpers before ajaxify can render a page

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -14,6 +14,11 @@ const Benchpress = require('benchpressjs');
 Benchpress.setGlobal('config', config);
 Benchpress.setGlobal('_i18n', window._i18n);
 
+// Register template helpers synchronously so that any client-side render
+// (e.g. an ajaxify navigation triggered before app.load finishes) has them.
+// Without `tx`, every `{{tx(...)}}` in a template renders as an empty string.
+require('./modules/helpers').register();
+
 require('./sockets');
 require('./overrides');
 require('./ajaxify');
@@ -96,16 +101,14 @@ app.onDomReady = function () {
 
 		require([
 			'taskbar',
-			'helpers',
 			'forum/pagination',
 			'messages',
 			'search',
 			'forum/header',
 			'hooks',
-		], function (taskbar, helpers, pagination, messages, search, header, hooks) {
+		], function (taskbar, pagination, messages, search, header, hooks) {
 			header.prepareDOM();
 			taskbar.init();
-			helpers.register();
 			pagination.init();
 			search.init();
 			overrides.overrideTimeago();


### PR DESCRIPTION
## Problem

Template helpers (including `tx`) are registered in `app.load()`, inside a `require([...])` that also waits for `taskbar`, `forum/pagination`, `messages`, `search`, `forum/header` and `hooks` to load. `app.load()` itself only runs after the timeago locale chunk has been imported.

Meanwhile `ajaxify` attaches its link click handler on `document.ready`. So there is a window on every cold load where clicking an internal link (or going back via `popstate`) renders the page client-side **before the helpers are registered**. Benchpress returns an empty string for an unknown helper, so every `{{tx(...)}}` in the template becomes empty.

On a slow or filtered connection this window can last for seconds, and the symptom looks like this on the login page: no labels, a `btn-primary` collapsed to its padding, an empty "register" button with only a border. A hard reload fixes it because the server renders the page.

`app.handleEarlyClicks` does not cover this case because it only queues clicks on `<button>` elements and `#` / `data-ajaxify="false"` anchors, not regular internal links.

Reproduction on any 4.x forum, in the console:

```js
const [B] = await app.require(['benchpressjs']);
delete B.helpers.tx;
ajaxify.go('login'); // all translated strings render empty
```

## Fix

Register the helpers synchronously at bundle load, right after the Benchpress globals are set and before `./ajaxify` is required. `helpers` only depends on `utils`, `benchpressjs` and `translator`, which are already in the main bundle, so this does not add any async work. The `helpers` entry is removed from the `app.load()` require list since it is no longer needed there.

Verified with `node ./nodebb build javascript` and eslint.