### PR TITLE
feat: add action:messaging.markRead hook with previous read timestamp

### DIFF
--- a/src/messaging/unread.js
+++ b/src/messaging/unread.js
@@ -3,6 +3,7 @@
 const db = require('../database');
 const utils = require('../utils');
 const io = require('../socket.io');
+const plugins = require('../plugins');
 
 module.exports = function (Messaging) {
 	Messaging.getUnreadCount = async (uid) => {
@@ -28,10 +29,22 @@ module.exports = function (Messaging) {
 			return;
 		}
 
+		const prevTimestamp = parseInt(
+			await db.getObjectField(`uid:${uid}:chat:rooms:read`, roomId), 10
+		) || 0;
+		const timestamp = Date.now();
+
 		await Promise.all([
 			db.sortedSetRemove(`uid:${uid}:chat:rooms:unread`, roomId),
-			db.setObjectField(`uid:${uid}:chat:rooms:read`, roomId, Date.now()),
+			db.setObjectField(`uid:${uid}:chat:rooms:read`, roomId, timestamp),
 		]);
+
+		plugins.hooks.fire('action:messaging.markRead', {
+			uid: uid,
+			roomId: roomId,
+			timestamp: timestamp,
+			prevTimestamp: prevTimestamp,
+		});
 	};
 
 	Messaging.hasRead = async (uids, roomId) => {

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -1032,4 +1032,46 @@ describe('Messaging Library', () => {
 			assert.equal(response.statusCode, 404);
 		});
 	});
+
+	describe('.markRead()', () => {
+		const plugins = require('../src/plugins');
+		let markReadRoomId;
+
+		before(async () => {
+			markReadRoomId = await Messaging.newRoom(mocks.users.foo.uid, {
+				uids: [mocks.users.herp.uid],
+			});
+		});
+
+		async function markReadAndCaptureHook(uid, roomId) {
+			const fired = new Promise((resolve) => {
+				plugins.hooks.register('my-test-plugin', {
+					hook: 'action:messaging.markRead',
+					method: resolve,
+				});
+			});
+			await Messaging.markRead(uid, roomId);
+			const data = await fired;
+			plugins.hooks.unregister('my-test-plugin', 'action:messaging.markRead');
+			return data;
+		}
+
+		it('should fire action:messaging.markRead with no previous timestamp on first read', async () => {
+			const data = await markReadAndCaptureHook(mocks.users.herp.uid, markReadRoomId);
+
+			assert.strictEqual(parseInt(data.uid, 10), mocks.users.herp.uid);
+			assert.strictEqual(parseInt(data.roomId, 10), parseInt(markReadRoomId, 10));
+			assert(data.timestamp > 0);
+			assert.strictEqual(data.prevTimestamp, 0);
+		});
+
+		it('should hand the timestamp of the previous read to the hook', async () => {
+			const first = await markReadAndCaptureHook(mocks.users.herp.uid, markReadRoomId);
+			await sleep(5);
+			const second = await markReadAndCaptureHook(mocks.users.herp.uid, markReadRoomId);
+
+			assert.strictEqual(second.prevTimestamp, first.timestamp);
+			assert(second.timestamp > second.prevTimestamp);
+		});
+	});
 });


### PR DESCRIPTION
### What

`Messaging.markRead()` writes `Date.now()` into `uid:<uid>:chat:rooms:read`, which is the only record of how far into a room a user had read. This reads the outgoing value first and fires a new `action:messaging.markRead` hook with `{ uid, roomId, timestamp, prevTimestamp }`.

### Why

That per-room read timestamp is what drives the unread count in `Messaging.getRoomsByRoomIds()`, but it is destroyed the moment the room is opened. After that there is no way to tell which messages arrived since the user last looked at the room — i.e. no chat equivalent of `tid:<tid>:bookmarks`, which is exactly what lets the topic navigator draw its unread bar.

Concretely this blocks anything like "jump to the first unread message" or an unread divider inside a chat room: by the time a client can ask the server for the boundary, `markRead` (via `DELETE /chats/:roomId/state`) has already moved it to now. Plugins today have to keep a shadow copy of the read state and carefully order their calls around that write.

Exposing the previous value at the moment it is replaced makes the boundary available without that race, and without changing any existing behaviour.

### Notes

- Costs one extra `getObjectField` per `markRead` (once per room open).
- No change to what is stored; the hook is additive and no existing caller is affected.
- Tests added in `test/messaging.js` covering both the first read (`prevTimestamp === 0`) and a subsequent read.
