### PR TITLE
fix: keep the server timestamp on live chat messages

### DIFF
--- a/public/src/client/chats/events.js
+++ b/public/src/client/chats/events.js
@@ -43,8 +43,7 @@ define('forum/chats/events', [
 		}
 		data.self = parseInt(app.user.uid, 10) === parseInt(data.fromUid, 10) ? 1 : 0;
 		data.message.self = data.self;
-		data.message.timestamp = Math.min(Date.now(), data.message.timestamp);
-		data.message.timestampISO = utils.toISOString(data.message.timestamp);
+		data.message.timestampISO = utils.toISOString(Math.min(Date.now(), data.message.timestamp));
 		const isMessageForCurrentRoom = parseInt(data.roomId, 10) === parseInt(ajaxify.data.roomId, 10);
 
 		if (isMessageForCurrentRoom) {

--- a/public/src/modules/chat.js
+++ b/public/src/modules/chat.js
@@ -193,8 +193,7 @@ define('chat', [
 				modal.attr('new-message', data.self === 0 ? 1 : 0);
 			}
 			data.message.self = data.self;
-			data.message.timestamp = Math.min(Date.now(), data.message.timestamp);
-			data.message.timestampISO = utils.toISOString(data.message.timestamp);
+			data.message.timestampISO = utils.toISOString(Math.min(Date.now(), data.message.timestamp));
 			addMessageToModal(data);
 		}
 	};


### PR DESCRIPTION
### What

`chatsReceive()` (`public/src/client/chats/events.js`) and `Chat.onChatMessageReceived()` (`public/src/modules/chat.js`) both do:

```js
data.message.timestamp = Math.min(Date.now(), data.message.timestamp);
data.message.timestampISO = utils.toISOString(data.message.timestamp);
```

This moves the clamp onto `timestampISO` and leaves `timestamp` as the server sent it.

### Why

`timestamp` is not display-only — it is rendered into the message element as `data-timestamp` (`src/views/partials/chats/message.tpl`) and read back from there. Clamping it to the receiving client's clock means that on any client whose clock lags the server, every message received live carries a timestamp lower than its real one, while the *same* message loaded from the server later (scrollback, page reload) carries the correct one. So two messages in one room can appear out of order relative to each other, and any comparison against a server-side timestamp — read state being the obvious one — silently gets the wrong answer until the next message arrives and bumps it.

The clamp's purpose is to stop a server clock that runs *ahead* of the client from rendering a message as posted in the future ("in 3 minutes" in the timeago string). That is purely about the displayed relative time, which comes from `timestampISO`, so applying it there keeps the original intent while leaving the authoritative value intact.
