### PR TITLE
feat: add Messaging.isRoomMember()

### DIFF
--- a/src/messaging/rooms.js
+++ b/src/messaging/rooms.js
@@ -177,16 +177,25 @@ module.exports = function (Messaging) {
 		]);
 	};
 
+	Messaging.isRoomMember = async (uid, roomIds) => {
+		const single = !Array.isArray(roomIds);
+		if (single) {
+			roomIds = [roomIds];
+		}
+		const isMembers = await db.isMemberOfSortedSets(
+			roomIds.map(id => `chat:room:${id}:uids`),
+			uid
+		);
+		return single ? isMembers.pop() : isMembers;
+	};
+
 	Messaging.isUserInRoom = async (uid, roomIds) => {
 		let single = false;
 		if (!Array.isArray(roomIds)) {
 			roomIds = [roomIds];
 			single = true;
 		}
-		const inRooms = await db.isMemberOfSortedSets(
-			roomIds.map(id => `chat:room:${id}:uids`),
-			uid
-		);
+		const inRooms = await Messaging.isRoomMember(uid, roomIds);
 
 		const data = await Promise.all(roomIds.map(async (roomId, idx) => {
 			const data = await plugins.hooks.fire('filter:messaging.isUserInRoom', {

--- a/test/messaging.js
+++ b/test/messaging.js
@@ -1074,4 +1074,45 @@ describe('Messaging Library', () => {
 			assert(second.timestamp > second.prevTimestamp);
 		});
 	});
+
+	describe('.isRoomMember()', () => {
+		const plugins = require('../src/plugins');
+		let memberRoomId;
+
+		before(async () => {
+			memberRoomId = await Messaging.newRoom(mocks.users.foo.uid, {
+				uids: [mocks.users.bar.uid],
+			});
+		});
+
+		it('should report actual membership', async () => {
+			assert.strictEqual(await Messaging.isRoomMember(mocks.users.foo.uid, memberRoomId), true);
+			assert.strictEqual(await Messaging.isRoomMember(mocks.users.herp.uid, memberRoomId), false);
+		});
+
+		it('should accept an array of roomIds', async () => {
+			assert.deepStrictEqual(
+				await Messaging.isRoomMember(mocks.users.bar.uid, [memberRoomId, 0]),
+				[true, false]
+			);
+		});
+
+		it('should not be overridable via filter:messaging.isUserInRoom', async () => {
+			plugins.hooks.register('my-test-plugin', {
+				hook: 'filter:messaging.isUserInRoom',
+				method: async data => ({ ...data, inRoom: true }),
+			});
+
+			try {
+				assert.strictEqual(
+					await Messaging.isUserInRoom(mocks.users.herp.uid, memberRoomId), true
+				);
+				assert.strictEqual(
+					await Messaging.isRoomMember(mocks.users.herp.uid, memberRoomId), false
+				);
+			} finally {
+				plugins.hooks.unregister('my-test-plugin', 'filter:messaging.isUserInRoom');
+			}
+		});
+	});
 });


### PR DESCRIPTION
### What

Adds `Messaging.isRoomMember(uid, roomId | roomIds)` — the raw membership check against `chat:room:<roomId>:uids`, without firing `filter:messaging.isUserInRoom`. `Messaging.isUserInRoom()` now builds on it, so the existing hook behaviour is unchanged.

### Why

`isUserInRoom()` is the only membership helper available, and its result passes through `filter:messaging.isUserInRoom`. Plugins legitimately use that hook to widen "is in the room" into "may see the room" — giving admins or moderators a read-only view of a room they never joined is the obvious case, and it is the right answer for the access checks in `src/api/chats.js`.

It is the wrong answer for anything that records, counts or exposes a user's *participation*: presence, read state, receipts, per-room counters. Honouring the override there turns a moderator quietly looking at a room into a participant, which both corrupts the data and leaks the fact that they looked. The only way to avoid that today is to skip the API and query `chat:room:<roomId>:uids` yourself, which means duplicating a key name that core owns.

Two callers with the two different needs, side by side, seem worth distinguishing in the API rather than by convention.

### Notes

- No behaviour change for existing callers; `isUserInRoom()` still fires the hook exactly as before.
- Tests added in `test/messaging.js`, including one asserting that a plugin forcing `inRoom: true` moves `isUserInRoom()` but not `isRoomMember()`.
