### PR TITLE
fix: browser title rendered LTR for RTL users when the page title starts with Latin text

### DIFF
--- a/src/controllers/helpers.js
+++ b/src/controllers/helpers.js
@@ -330,9 +330,17 @@ helpers.buildTitle = async function (pageTitle, userLang, template) {
 	], userLang);
 
 	const titleLayout = meta.config.titleLayout || `${pageTitle ? '{pageTitle} | ' : ''}{browserTitle}`;
-	const title = titleLayout
+	let title = titleLayout
 		.replace('{pageTitle}', () => titleTranslated)
 		.replace('{browserTitle}', () => browserTitleTranslated);
+
+	// The browser tab has no dir attribute, so it picks the title's direction from
+	// its first strongly-directional character. An RTL user viewing a page whose
+	// title starts with a Latin string (e.g. a username) would otherwise get an
+	// LTR title. Prefix a right-to-left mark to keep the direction stable.
+	if (translator.languageDirection(userLang) === 'rtl' && !title.startsWith('\u200F')) {
+		title = `\u200F${title}`;
+	}
 
 	return utils.decodeHTMLEntities(title);
 };

--- a/test/controllers.js
+++ b/test/controllers.js
@@ -2136,6 +2136,31 @@ describe('Controllers', () => {
 			assert.deepStrictEqual(selectedCids, [category2.cid]);
 			assert.strictEqual(selectedCategory.cid, category2.cid);
 		});
+
+		describe('.buildTitle()', () => {
+			it('should not prefix a right-to-left mark for ltr languages', async () => {
+				const title = await controllerHelpers.buildTitle('shishko', 'en-GB', 'chats');
+				assert(!title.startsWith('\u200F'));
+				assert(title.startsWith('shishko | '));
+			});
+
+			it('should prefix a right-to-left mark for rtl languages', async () => {
+				const title = await controllerHelpers.buildTitle('shishko', 'he', 'chats');
+				assert(title.startsWith('\u200Fshishko | '));
+			});
+
+			it('should not double the right-to-left mark if the layout already has one', async () => {
+				const oldLayout = meta.config.titleLayout;
+				meta.config.titleLayout = '\u200F{pageTitle} | {browserTitle}';
+				try {
+					const title = await controllerHelpers.buildTitle('shishko', 'he', 'chats');
+					assert(title.startsWith('\u200Fshishko | '));
+					assert(!title.startsWith('\u200F\u200F'));
+				} finally {
+					meta.config.titleLayout = oldLayout;
+				}
+			});
+		});
 	});
 
 	after((done) => {


### PR DESCRIPTION
## Problem

The browser tab has no `dir` attribute, so it derives the title's direction from its first strongly-directional character (Unicode bidi algorithm). With the default title layout `{pageTitle} | {browserTitle}`, an RTL user viewing a page whose title starts with a Latin string, for example a chat with a user named `shishko`, sees the whole tab title laid out LTR with the site name on the wrong side, while every other tab is RTL.

## Fix

`helpers.buildTitle()` now prefixes a right-to-left mark (`‏`) to the built title when the user's language direction is `rtl`, unless the configured layout already starts with one. LTR users are unaffected.

## Tests

Added three tests under `controllers helpers › .buildTitle()` covering LTR (no mark), RTL (mark added), and an RTL layout that already carries the mark (not doubled).
