### PR TITLE
fix: don't splice the viewer's own chat room into another user's room list

### DIFF
--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -755,7 +755,7 @@ define('forum/chats', [
 			roomEl.find('[component="chat/room/teaser"]').html(html[0].outerHTML);
 			roomEl.find('.timeago').timeago();
 			moveChatAndHrToTop(roomEl);
-		} else if (parseInt(ajaxify.data.uid, 10) === parseInt(app.user.uid, 10)) {
+		} else if (String(ajaxify.data.uid) === String(app.user.uid)) {
 			// The room isn't on screen, so it has to be fetched -- but `GET /chats`
 			// returns the *viewer's* rooms, which have no business being spliced
 			// into a list that is showing another user's rooms.

--- a/public/src/client/chats.js
+++ b/public/src/client/chats.js
@@ -755,7 +755,10 @@ define('forum/chats', [
 			roomEl.find('[component="chat/room/teaser"]').html(html[0].outerHTML);
 			roomEl.find('.timeago').timeago();
 			moveChatAndHrToTop(roomEl);
-		} else {
+		} else if (parseInt(ajaxify.data.uid, 10) === parseInt(app.user.uid, 10)) {
+			// The room isn't on screen, so it has to be fetched -- but `GET /chats`
+			// returns the *viewer's* rooms, which have no business being spliced
+			// into a list that is showing another user's rooms.
 			const { rooms } = await api.get(`/chats`, { start: 0, perPage: 2 });
 			const room = rooms.find(r => parseInt(r.roomId, 10) === parseInt(roomId, 10));
 			if (room) {


### PR DESCRIPTION
### Problem

`Chats.updateTeaser()` (`public/src/client/chats.js`) falls back to `GET /chats` when the room a new message arrived in isn't in the list on screen, and prepends the result to the room list:

```js
} else {
    const { rooms } = await api.get(`/chats`, { start: 0, perPage: 2 });
```

That endpoint returns the rooms of the **viewer**. The only guard on the function is `!ajaxify.data.template.chats || ajaxify.data.public || !app.user.userslug` — it never compares `ajaxify.data.uid` to `app.user.uid`. So while looking at `/user/<someone-else>/chats`, a private message addressed to the viewer gets added to a list that is showing another user's rooms.

Both call sites reach it:

- `event:chats.receive` → `forum/chats/events`, for rooms the socket has entered.
- `event:unread.updateChatCount` → `forum/header/chat`, which is emitted to `uid_<uid>` in `src/messaging/unread.js` and therefore arrives for **every** private message, regardless of which room is open. This is the dominant path for the bug, since the offending room is by definition one the viewer doesn't have open.

`Chats.markChatPageElUnread()`, called right next to it, is already safe — it only touches an existing `[data-roomid]` element.

### Fix

Guard the fetch fallback only, rather than the whole function: a room that *is* already in the list still gets its teaser refreshed and moved to the top. That matters when the viewer shares a room with the user whose list is on screen — there the live update is correct and desirable, and a coarser guard on the whole function would lose it.

### Note on reproducing

`chatsController.get` renders `/user/:userslug/chats` for any user, but `messaging.getRecentChats` gates the room list behind `filter:messaging.canGetRecentChats`, whose default is `callerUid === uid`. So on stock NodeBB the foreign-list page 404s, and a plugin that grants that hook (e.g. an admin chat-moderation plugin) is needed to see the bug. The guard seems worth having in core regardless: the page is a core route, the fallback silently mixes one user's data into another user's list, and it costs one condition.
