### PR TITLE
Follow hashtags globally

### DIFF
--- a/public/language/en-GB/admin/menu.json
+++ b/public/language/en-GB/admin/menu.json
@@ -54,6 +54,7 @@
 	"federation/content": "Content",
 	"federation/rules": "Categorization",
 	"federation/relays": "Relays",
+	"federation/hashtags": "Hashtags",
 	"federation/pruning": "Storage",
 	"federation/safety": "Trust & Safety",
 	"federation/analytics": "Analytics",

--- a/public/language/en-GB/admin/settings/activitypub.json
+++ b/public/language/en-GB/admin/settings/activitypub.json
@@ -121,6 +121,8 @@
 	"hashtags.follow": "Follow Hashtag",
 	"hashtags.modal.tag": "Hashtag",
 	"hashtags.modal.tag-help": "Enter the hashtag name without the # symbol (e.g., nodebb).",
+	"hashtags.modal.category": "Category",
+	"hashtags.modal.category-help": "Select a category to auto-route matching content.",
 	"hashtags.state-pending": "Pending",
 	"hashtags.state-active": "Active",
 	"hashtags.state-error": "Error",

--- a/public/language/en-GB/admin/settings/activitypub.json
+++ b/public/language/en-GB/admin/settings/activitypub.json
@@ -110,5 +110,20 @@
 	"errors.intro": "The following %1 error(s) were recorded by this instance within the last 24 hours.",
 	"errors.payload-gone": "The payload for this error no longer exists.",
 	"errors.hostname": "Hostname",
-	"errors.type": "Type"
+	"errors.type": "Type",
+
+	"hashtags": "Hashtags",
+	"hashtags.intro": "Follow global hashtag actors to receive content matching specific tags. The instance actor follows the relay's hashtag actor, which sends Announce activities for matching content. Use auto-categorization rules to route content to categories.",
+	"hashtags.relay-host": "Relay Host",
+	"hashtags.relay-host-help": "Choose the relay provider for hashtag actors.",
+	"hashtags.save-relay": "Save",
+	"hashtags.relay-change-warning": "Changing the relay host will unfollow all current hashtag actors and follow them on the new relay.",
+	"hashtags.follow": "Follow Hashtag",
+	"hashtags.modal.tag": "Hashtag",
+	"hashtags.modal.tag-help": "Enter the hashtag name without the # symbol (e.g., nodebb).",
+	"hashtags.state-pending": "Pending",
+	"hashtags.state-active": "Active",
+	"hashtags.state-error": "Error",
+	"hashtags.table.tag": "Tag",
+	"hashtags.table.state": "State"
 }

--- a/public/openapi/components/schemas/admin/hashtags.yaml
+++ b/public/openapi/components/schemas/admin/hashtags.yaml
@@ -1,0 +1,29 @@
+HashtagObject:
+  type: object
+  properties:
+    tag:
+      type: string
+      description: The hashtag name (without #)
+      example: nodebb
+    relay:
+      type: string
+      description: The relay host
+      example: relay.fedi.buzz
+    actor:
+      type: string
+      description: The actor URL
+      example: https://relay.fedi.buzz/tag/nodebb
+    state:
+      type: string
+      enum: [pending, active, error]
+      description: Follow state
+      example: active
+    createdAt:
+      type: number
+      description: Timestamp when the follow was created
+      example: 1725830000000
+
+HashtagsArray:
+  type: array
+  items:
+    $ref: '#/HashtagObject'

--- a/public/openapi/read.yaml
+++ b/public/openapi/read.yaml
@@ -160,6 +160,8 @@ paths:
     $ref: 'read/admin/federation/analytics.yaml'
   /api/admin/federation/errors:
     $ref: 'read/admin/federation/errors.yaml'
+  /api/admin/federation/hashtags:
+    $ref: 'read/admin/federation/hashtags.yaml'
   "/api/admin/appearance/themes":
     $ref: 'read/admin/appearance/themes.yaml'
   "/api/admin/appearance/skins":

--- a/public/openapi/read/admin/federation/hashtags.yaml
+++ b/public/openapi/read/admin/federation/hashtags.yaml
@@ -1,0 +1,30 @@
+get:
+  tags:
+    - admin
+  summary: Get federation settings pertaining to hashtags
+  responses:
+    "200":
+      description: ""
+      content:
+        application/json:
+          schema:
+            allOf:
+              - type: object
+                properties:
+                  title:
+                    type: string
+                  hashtags:
+                    $ref: ../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
+                  relay:
+                    type: string
+                    description: Current relay host
+                    example: relay.fedi.buzz
+                  relayOptions:
+                    type: array
+                    items:
+                      type: string
+                    description: Available relay options
+                    example:
+                      - relay.fedi.buzz
+                      - tags.pub
+              - $ref: ../../../components/schemas/CommonProps.yaml#/CommonProps

--- a/public/openapi/write.yaml
+++ b/public/openapi/write.yaml
@@ -318,6 +318,12 @@ paths:
     $ref: 'write/admin/activitypub/blocklists/url.yaml'
   /admin/activitypub/blocklists/{url}/refresh:
     $ref: 'write/admin/activitypub/blocklists/url/refresh.yaml'
+  /admin/activitypub/hashtags:
+    $ref: 'write/admin/activitypub/hashtags.yaml'
+  /admin/activitypub/hashtags/{tag}:
+    $ref: 'write/admin/activitypub/hashtags/tag.yaml'
+  /admin/activitypub/hashtags/relay:
+    $ref: 'write/admin/activitypub/hashtags/relay.yaml'
   /admin/plugins/{pluginId}:
     $ref: 'write/admin/plugins/pluginId.yaml'
   /admin/plugins/{pluginId}/active:

--- a/public/openapi/write/admin/activitypub/hashtags.yaml
+++ b/public/openapi/write/admin/activitypub/hashtags.yaml
@@ -1,0 +1,60 @@
+get:
+  tags:
+    - admin
+  summary: Get followed hashtags
+  description: Returns the list of followed hashtags and relay configuration
+  responses:
+    "200":
+      description: List of followed hashtags
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  hashtags:
+                    $ref: ../../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
+                  relay:
+                    type: string
+                    description: Current relay host
+                    example: relay.fedi.buzz
+post:
+  tags:
+    - admin
+  summary: Follow a hashtag
+  description: Follow a hashtag actor via the configured relay and optionally create an auto-categorization rule
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - tag
+          properties:
+            tag:
+              type: string
+              description: The hashtag name without the # symbol
+              example: nodebb
+            cid:
+              type: number
+              description: Category ID for auto-categorization (optional)
+              example: 1
+  responses:
+    "200":
+      description: Hashtag followed successfully
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
+    "400":
+      description: Invalid request data

--- a/public/openapi/write/admin/activitypub/hashtags.yaml
+++ b/public/openapi/write/admin/activitypub/hashtags.yaml
@@ -12,12 +12,12 @@ get:
             type: object
             properties:
               status:
-                $ref: ../../../../components/schemas/Status.yaml#/Status
+                $ref: ../../../components/schemas/Status.yaml#/Status
               response:
                 type: object
                 properties:
                   hashtags:
-                    $ref: ../../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
+                    $ref: ../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
                   relay:
                     type: string
                     description: Current relay host
@@ -53,8 +53,8 @@ post:
             type: object
             properties:
               status:
-                $ref: ../../../../components/schemas/Status.yaml#/Status
+                $ref: ../../../components/schemas/Status.yaml#/Status
               response:
-                $ref: ../../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
+                $ref: ../../../components/schemas/admin/hashtags.yaml#/HashtagsArray
     "400":
       description: Invalid request data

--- a/public/openapi/write/admin/activitypub/hashtags/relay.yaml
+++ b/public/openapi/write/admin/activitypub/hashtags/relay.yaml
@@ -1,0 +1,59 @@
+get:
+  tags:
+    - admin
+  summary: Get hashtag relay
+  description: Returns the current relay host for hashtag actors
+  responses:
+    "200":
+      description: Current relay host
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  relay:
+                    type: string
+                    description: Current relay host
+                    example: relay.fedi.buzz
+put:
+  tags:
+    - admin
+  summary: Set hashtag relay
+  description: Set the relay host for hashtag actors; triggers migration of existing follows if changed
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - host
+          properties:
+            host:
+              type: string
+              description: The relay host
+              example: relay.fedi.buzz
+  responses:
+    "200":
+      description: Relay host updated
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties:
+                  relay:
+                    type: string
+                    description: Updated relay host
+                    example: relay.fedi.buzz
+    "400":
+      description: Invalid relay host

--- a/public/openapi/write/admin/activitypub/hashtags/tag.yaml
+++ b/public/openapi/write/admin/activitypub/hashtags/tag.yaml
@@ -1,0 +1,24 @@
+delete:
+  tags:
+    - admin
+  summary: Unfollow a hashtag
+  description: Remove a followed hashtag and its auto-categorization rule
+  parameters:
+    - in: path
+      name: tag
+      schema:
+        type: string
+      required: true
+      example: nodebb
+  responses:
+    "200":
+      description: Hashtag unfollowed successfully
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../../components/schemas/Status.yaml#/Status
+              response:
+                $ref: ../../../../components/schemas/admin/hashtags.yaml#/HashtagsArray

--- a/public/src/admin/federation/hashtags.js
+++ b/public/src/admin/federation/hashtags.js
@@ -1,0 +1,127 @@
+'use strict';
+
+import { post, del, put } from 'api';
+import { error, success } from 'alerts';
+import { render } from 'benchpress';
+import * as modals from 'modals';
+
+export async function init() {
+	setupHashtags();
+	setupRelay();
+}
+
+function setupHashtags() {
+	const hashtagsEl = document.getElementById('hashtags');
+	if (!hashtagsEl) {
+		return;
+	}
+
+	hashtagsEl.addEventListener('click', (e) => {
+		const subselector = e.target.closest('[data-action]');
+		if (!subselector) {
+			return;
+		}
+
+		const action = subselector.getAttribute('data-action');
+
+		switch (action) {
+			case 'hashtags.add': {
+				throwModal();
+				break;
+			}
+
+			case 'hashtags.remove': {
+				const tag = subselector.getAttribute('data-tag');
+				del(`/admin/activitypub/hashtags/${encodeURIComponent(tag)}`).then(async (data) => {
+					const html = await app.parseAndTranslate('admin/partials/activitypub/hashtags/list', {}, {
+						hashtags: data.map(h => ({
+							...h,
+							stateClass: getStateClass(h.state),
+						})),
+					});
+					const listEl = document.querySelector('[component="hashtags/list"]');
+					if (listEl) {
+						$(listEl).html(html);
+					}
+				}).catch(error);
+				break;
+			}
+		}
+	});
+}
+
+function setupRelay() {
+	const setRelayBtn = document.querySelector('[data-action="hashtags.setRelay"]');
+	if (!setRelayBtn) {
+		return;
+	}
+
+	setRelayBtn.addEventListener('click', () => {
+		const relayHostEl = document.getElementById('relayHost');
+		const host = relayHostEl ? relayHostEl.value : '';
+		if (!host) {
+			error('[[error:invalid-data]]');
+			return;
+		}
+
+		put('/admin/activitypub/hashtags/relay', { host }).then(async () => {
+			success('[[success:settings-updated]]');
+			ajaxify.data.relay = host;
+		}).catch(error);
+	});
+}
+
+function throwModal() {
+	render('admin/partials/activitypub/hashtags', {}).then(async function (html) {
+		const submit = function () {
+			const formEl = modal.find('form').get(0);
+			if (!formEl.reportValidity()) {
+				return false;
+			}
+
+			const payload = Object.fromEntries(new FormData(formEl));
+			post('/admin/activitypub/hashtags', payload).then(async (data) => {
+				const html = await app.parseAndTranslate('admin/partials/activitypub/hashtags/list', {}, {
+					hashtags: data.map(h => ({
+						...h,
+						stateClass: getStateClass(h.state),
+					})),
+				});
+				const listEl = document.querySelector('[component="hashtags/list"]');
+				if (listEl) {
+					$(listEl).html(html);
+				}
+				modal.modal('hide');
+			}).catch(error);
+		};
+
+		const modal = await modals.dialog({
+			title: '[[admin/settings/activitypub:hashtags.follow]]',
+			message: html,
+			buttons: {
+				save: {
+					label: '[[global:save]]',
+					className: 'btn-primary',
+					callback: submit,
+				},
+			},
+		});
+
+		modal.on('shown.bs.modal', function () {
+			modal.find('#hashtagTag').focus();
+		});
+	});
+}
+
+function getStateClass(state) {
+	switch (state) {
+		case 'pending':
+			return 'warning';
+		case 'active':
+			return 'success';
+		case 'error':
+			return 'danger';
+		default:
+			return 'secondary';
+	}
+}

--- a/public/src/admin/federation/hashtags.js
+++ b/public/src/admin/federation/hashtags.js
@@ -3,6 +3,7 @@
 import { post, del, put } from 'api';
 import { error, success } from 'alerts';
 import { render } from 'benchpress';
+import * as categorySelector from 'categorySelector';
 import * as modals from 'modals';
 
 export async function init() {
@@ -93,6 +94,8 @@ function throwModal() {
 				}
 				modal.modal('hide');
 			}).catch(error);
+
+			return false;
 		};
 
 		const modal = await modals.dialog({
@@ -109,6 +112,17 @@ function throwModal() {
 
 		modal.on('shown.bs.modal', function () {
 			modal.find('#hashtagTag').focus();
+		});
+
+		// category selector
+		categorySelector.init(modal.find('[component="category-selector"]'), {
+			onSelect: function (selectedCategory) {
+				modal.find('[name="cid"]').val(selectedCategory.cid);
+			},
+			cacheList: false,
+			showLinks: true,
+			template: 'admin/partials/category/selector-dropdown-right',
+			localOnly: true,
 		});
 	});
 }

--- a/public/src/admin/federation/hashtags.js
+++ b/public/src/admin/federation/hashtags.js
@@ -34,7 +34,8 @@ function setupHashtags() {
 			case 'hashtags.remove': {
 				const tag = subselector.getAttribute('data-tag');
 				del(`/admin/activitypub/hashtags/${encodeURIComponent(tag)}`).then(async (data) => {
-					const html = await app.parseAndTranslate('admin/partials/activitypub/hashtags/list', {}, {
+					console.log(data);
+					const html = await app.parseAndTranslate('admin/partials/activitypub/hashtags/list', { hashtags: data }, {
 						hashtags: data.map(h => ({
 							...h,
 							stateClass: getStateClass(h.state),
@@ -82,7 +83,7 @@ function throwModal() {
 
 			const payload = Object.fromEntries(new FormData(formEl));
 			post('/admin/activitypub/hashtags', payload).then(async (data) => {
-				const html = await app.parseAndTranslate('admin/partials/activitypub/hashtags/list', {}, {
+				const html = await app.parseAndTranslate('admin/partials/activitypub/hashtags/list', { hashtags: data }, {
 					hashtags: data.map(h => ({
 						...h,
 						stateClass: getStateClass(h.state),

--- a/src/activitypub/hashtags.js
+++ b/src/activitypub/hashtags.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const db = require('../database');
+
+const activitypub = module.parent.exports;
+
+const Hashtags = module.exports;
+
+const FOLLOWED_KEY = 'ap:hashtags:followed';
+const RELAY_KEY = 'ap:hashtags:relay';
+
+const relayTemplates = {
+	'relay.fedi.buzz': 'https://relay.fedi.buzz/tag/{tag}',
+	'tags.pub': 'https://tags.pub/user/{tag}',
+};
+
+Hashtags.getRelay = async () => {
+	return await db.get(RELAY_KEY);
+};
+
+Hashtags.setRelay = async (host) => {
+	if (typeof host !== 'string' || !host.trim()) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	host = host.trim().toLowerCase();
+	if (!relayTemplates[host]) {
+		throw new Error('[[error:activitypub.hashtag.relay-not-found]]');
+	}
+	const oldHost = await Hashtags.getRelay();
+
+	await db.set(RELAY_KEY, host);
+
+	// Migrate existing follows if relay changed
+	if (oldHost && oldHost !== host) {
+		await Hashtags._migrateRelay(oldHost, host);
+	}
+};
+
+Hashtags.getRelayOptions = () => Object.keys(relayTemplates);
+
+Hashtags.resolveActor = (tag, relay) => {
+	const template = relayTemplates[relay];
+	if (!template) {
+		throw new Error('[[error:activitypub.hashtag.relay-not-found]]');
+	}
+	return template.replace('{tag}', encodeURIComponent(tag));
+};
+
+Hashtags.follow = async (tag) => {
+	const relay = await Hashtags.getRelay();
+	if (!relay) {
+		throw new Error('[[error:activitypub.hashtag.no-relay-configured]]');
+	}
+
+	const actor = Hashtags.resolveActor(tag, relay);
+
+	// Check if already followed
+	const existing = await Hashtags.get(tag);
+	if (existing) {
+		return existing;
+	}
+
+	// Send Follow activity via instance actor
+	await activitypub.out.follow('uid', 0, actor);
+
+	// Store record
+	const record = {
+		tag,
+		relay,
+		actor,
+		state: 'pending',
+		createdAt: Date.now(),
+	};
+	await db.setObject(`ap:hashtag:${tag}`, record);
+	await db.sortedSetAdd(FOLLOWED_KEY, Date.now(), tag);
+
+	return record;
+};
+
+Hashtags.unfollow = async (tag) => {
+	const record = await Hashtags.get(tag);
+	if (!record) {
+		return false;
+	}
+
+	// Undo Follow via instance actor
+	await activitypub.out.undo.follow('uid', 0, record.actor);
+
+	// Remove record
+	await Promise.all([
+		db.delete(`ap:hashtag:${tag}`),
+		db.sortedSetRemove(FOLLOWED_KEY, tag),
+	]);
+
+	return true;
+};
+
+Hashtags.list = async () => {
+	const tags = await db.getSortedSetMembers(FOLLOWED_KEY);
+	if (!tags.length) {
+		return [];
+	}
+
+	const records = await db.getObjects(tags.map(tag => `ap:hashtag:${tag}`));
+
+	return records.filter(Boolean);
+};
+
+Hashtags.get = async (tag) => {
+	const exists = await db.sortedSetMember(FOLLOWED_KEY, tag);
+	if (!exists) {
+		return null;
+	}
+	return await db.getObject(`ap:hashtag:${tag}`);
+};
+
+Hashtags.updateState = async (actor, state) => {
+	// Find record by actor URL
+	const tags = await db.getSortedSetMembers(FOLLOWED_KEY);
+	if (!tags.length) {
+		return;
+	}
+
+	const records = await db.getObjects(tags.map(tag => `ap:hashtag:${tag}`));
+	const record = records.find(r => r && r.actor === actor);
+
+	if (!record) {
+		return;
+	}
+
+	await db.setObjectField(`ap:hashtag:${record.tag}`, 'state', state);
+};
+
+Hashtags._migrateRelay = async (oldHost, newHost) => {
+	const tags = await db.getSortedSetMembers(FOLLOWED_KEY);
+	if (!tags.length) {
+		return;
+	}
+
+	const records = await db.getObjects(tags.map(tag => `ap:hashtag:${tag}`));
+
+	await Promise.all(records.map(async (record) => {
+		if (!record || record.relay !== oldHost) {
+			return;
+		}
+
+		const newActor = Hashtags.resolveActor(record.tag, newHost);
+
+		// Undo follow on old actor
+		await activitypub.out.undo.follow('uid', 0, record.actor);
+
+		// Follow on new actor
+		await activitypub.out.follow('uid', 0, newActor);
+
+		// Update record
+		await db.setObject(`ap:hashtag:${record.tag}`, {
+			...record,
+			relay: newHost,
+			actor: newActor,
+			state: 'pending',
+		});
+	}));
+};

--- a/src/activitypub/hashtags.js
+++ b/src/activitypub/hashtags.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const nconf = require('nconf');
 const db = require('../database');
 
 const activitypub = module.parent.exports;
@@ -57,20 +56,8 @@ Hashtags.follow = async (tag, cid) => {
 		return existing;
 	}
 
-	const now = Date.now();
-
-	// Send Follow activity via instance actor (bypass actors.assert for hashtag actors)
-	await activitypub.send('uid', 0, actor, {
-		'@context': [
-			'https://www.w3.org/ns/activitystreams',
-			'https://pleroma.example/schemas/litepub-0.1.jsonld',
-		],
-		id: `${nconf.get('url')}/actor#activity/follow/${encodeURIComponent(actor)}/${now}`,
-		type: 'Follow',
-		to: [actor],
-		object: actor,
-		state: 'pending',
-	});
+	// Send Follow activity via instance actor
+	await activitypub.out.follow('uid', 0, actor);
 
 	// Store record
 	const record = {
@@ -78,10 +65,10 @@ Hashtags.follow = async (tag, cid) => {
 		relay,
 		actor,
 		state: 'pending',
-		createdAt: now,
+		createdAt: Date.now(),
 	};
 	await db.setObject(`ap:hashtag:${tag}`, record);
-	await db.sortedSetAdd(FOLLOWED_KEY, now, tag);
+	await db.sortedSetAdd(FOLLOWED_KEY, Date.now(), tag);
 
 	// Create auto-categorization rule if category provided
 	if (cid) {
@@ -97,31 +84,8 @@ Hashtags.unfollow = async (tag) => {
 		return false;
 	}
 
-	const now = Date.now();
-
-	// Undo Follow via instance actor (bypass actors.assert for hashtag actors)
-	await activitypub.send('uid', 0, record.actor, {
-		'@context': [
-			'https://www.w3.org/ns/activitystreams',
-			'https://pleroma.example/schemas/litepub-0.1.jsonld',
-		],
-		id: `${nconf.get('url')}/actor#activity/undo:follow/${encodeURIComponent(record.actor)}/${now}`,
-		type: 'Undo',
-		to: [record.actor],
-		published: new Date(now).toISOString(),
-		object: {
-			'@context': [
-				'https://www.w3.org/ns/activitystreams',
-				'https://pleroma.example/schemas/litepub-0.1.jsonld',
-			],
-			id: `${nconf.get('url')}/actor#activity/follow/${encodeURIComponent(record.actor)}/${record.createdAt}`,
-			type: 'Follow',
-			actor: `${nconf.get('url')}/actor`,
-			to: [record.actor],
-			object: record.actor,
-			state: 'cancelled',
-		},
-	});
+	// Undo Follow via instance actor
+	await activitypub.out.undo.follow('uid', 0, record.actor);
 
 	// Remove auto-categorization rule
 	const rules = await activitypub.rules.list();

--- a/src/activitypub/hashtags.js
+++ b/src/activitypub/hashtags.js
@@ -113,6 +113,7 @@ Hashtags.list = async () => {
 
 	return records.filter(Boolean).map((record) => {
 		record.createdAt = parseInt(record.createdAt, 10);
+		record.stateClass = record.state === 'pending' ? 'warning' : (record.state === 'active' ? 'success' : 'danger');
 		return record;
 	});
 };

--- a/src/activitypub/hashtags.js
+++ b/src/activitypub/hashtags.js
@@ -111,7 +111,10 @@ Hashtags.list = async () => {
 
 	const records = await db.getObjects(tags.map(tag => `ap:hashtag:${tag}`));
 
-	return records.filter(Boolean);
+	return records.filter(Boolean).map((record) => {
+		record.createdAt = parseInt(record.createdAt, 10);
+		return record;
+	});
 };
 
 Hashtags.get = async (tag) => {
@@ -119,7 +122,11 @@ Hashtags.get = async (tag) => {
 	if (!exists) {
 		return null;
 	}
-	return await db.getObject(`ap:hashtag:${tag}`);
+	const record = await db.getObject(`ap:hashtag:${tag}`);
+	if (record) {
+		record.createdAt = parseInt(record.createdAt, 10);
+	}
+	return record;
 };
 
 Hashtags.updateState = async (actor, state) => {

--- a/src/activitypub/hashtags.js
+++ b/src/activitypub/hashtags.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const nconf = require('nconf');
 const db = require('../database');
 
 const activitypub = module.parent.exports;
@@ -15,7 +16,7 @@ const relayTemplates = {
 };
 
 Hashtags.getRelay = async () => {
-	return await db.get(RELAY_KEY);
+	return await db.get(RELAY_KEY) || 'relay.fedi.buzz';
 };
 
 Hashtags.setRelay = async (host) => {
@@ -46,12 +47,8 @@ Hashtags.resolveActor = (tag, relay) => {
 	return template.replace('{tag}', encodeURIComponent(tag));
 };
 
-Hashtags.follow = async (tag) => {
+Hashtags.follow = async (tag, cid) => {
 	const relay = await Hashtags.getRelay();
-	if (!relay) {
-		throw new Error('[[error:activitypub.hashtag.no-relay-configured]]');
-	}
-
 	const actor = Hashtags.resolveActor(tag, relay);
 
 	// Check if already followed
@@ -60,8 +57,20 @@ Hashtags.follow = async (tag) => {
 		return existing;
 	}
 
-	// Send Follow activity via instance actor
-	await activitypub.out.follow('uid', 0, actor);
+	const now = Date.now();
+
+	// Send Follow activity via instance actor (bypass actors.assert for hashtag actors)
+	await activitypub.send('uid', 0, actor, {
+		'@context': [
+			'https://www.w3.org/ns/activitystreams',
+			'https://pleroma.example/schemas/litepub-0.1.jsonld',
+		],
+		id: `${nconf.get('url')}/actor#activity/follow/${encodeURIComponent(actor)}/${now}`,
+		type: 'Follow',
+		to: [actor],
+		object: actor,
+		state: 'pending',
+	});
 
 	// Store record
 	const record = {
@@ -69,10 +78,15 @@ Hashtags.follow = async (tag) => {
 		relay,
 		actor,
 		state: 'pending',
-		createdAt: Date.now(),
+		createdAt: now,
 	};
 	await db.setObject(`ap:hashtag:${tag}`, record);
-	await db.sortedSetAdd(FOLLOWED_KEY, Date.now(), tag);
+	await db.sortedSetAdd(FOLLOWED_KEY, now, tag);
+
+	// Create auto-categorization rule if category provided
+	if (cid) {
+		await activitypub.rules.upsert('hashtag', tag, cid, 0);
+	}
 
 	return record;
 };
@@ -83,8 +97,38 @@ Hashtags.unfollow = async (tag) => {
 		return false;
 	}
 
-	// Undo Follow via instance actor
-	await activitypub.out.undo.follow('uid', 0, record.actor);
+	const now = Date.now();
+
+	// Undo Follow via instance actor (bypass actors.assert for hashtag actors)
+	await activitypub.send('uid', 0, record.actor, {
+		'@context': [
+			'https://www.w3.org/ns/activitystreams',
+			'https://pleroma.example/schemas/litepub-0.1.jsonld',
+		],
+		id: `${nconf.get('url')}/actor#activity/undo:follow/${encodeURIComponent(record.actor)}/${now}`,
+		type: 'Undo',
+		to: [record.actor],
+		published: new Date(now).toISOString(),
+		object: {
+			'@context': [
+				'https://www.w3.org/ns/activitystreams',
+				'https://pleroma.example/schemas/litepub-0.1.jsonld',
+			],
+			id: `${nconf.get('url')}/actor#activity/follow/${encodeURIComponent(record.actor)}/${record.createdAt}`,
+			type: 'Follow',
+			actor: `${nconf.get('url')}/actor`,
+			to: [record.actor],
+			object: record.actor,
+			state: 'cancelled',
+		},
+	});
+
+	// Remove auto-categorization rule
+	const rules = await activitypub.rules.list();
+	const rule = rules.find(r => r.type === 'hashtag' && r.value === tag);
+	if (rule) {
+		await activitypub.rules.delete(rule.rid);
+	}
 
 	// Remove record
 	await Promise.all([
@@ -107,7 +151,7 @@ Hashtags.list = async () => {
 };
 
 Hashtags.get = async (tag) => {
-	const exists = await db.sortedSetMember(FOLLOWED_KEY, tag);
+	const exists = await db.isSortedSetMember(FOLLOWED_KEY, tag);
 	if (!exists) {
 		return null;
 	}

--- a/src/activitypub/inbox.js
+++ b/src/activitypub/inbox.js
@@ -840,12 +840,19 @@ inbox.isFollowed = async (actorId, uid) => {
 
 inbox.accept = async (req) => {
 	const { actor, object } = req.body;
-	const { type } = object;
+	let { type } = object;
 
-	const { type: localType, id } = await helpers.resolveLocalId(object.actor);
 	if (object.id === `${nconf.get('url')}/actor`) {
-		return activitypub.relays.handshake(req.body);
-	} else if (!['user', 'category', 'application'].includes(localType)) {
+		// If the accepting actor is a known relay, handle as relay handshake
+		const isRelay = await db.isSortedSetMember('relays:createtime', actor);
+		if (isRelay) {
+			return activitypub.relays.handshake(req.body);
+		}
+		type = 'Follow'; // treat as Follow acceptance for hashtag/instance follows
+	}
+
+	const { type: localType, id } = await helpers.resolveLocalId(object.actor || object.id);
+	if (!['user', 'category', 'application'].includes(localType)) {
 		throw new Error('[[error:invalid-data]]');
 	}
 

--- a/src/activitypub/inbox.js
+++ b/src/activitypub/inbox.js
@@ -845,7 +845,7 @@ inbox.accept = async (req) => {
 	const { type: localType, id } = await helpers.resolveLocalId(object.actor);
 	if (object.id === `${nconf.get('url')}/actor`) {
 		return activitypub.relays.handshake(req.body);
-	} else if (!['user', 'category'].includes(localType)) {
+	} else if (!['user', 'category', 'application'].includes(localType)) {
 		throw new Error('[[error:invalid-data]]');
 	}
 
@@ -878,6 +878,18 @@ inbox.accept = async (req) => {
 				db.sortedSetRemove(`followRequests:cid.${id}`, actor),
 				db.sortedSetAdd(`cid:${id}:following`, timestamp, actor),
 				db.sortedSetAdd(`followersRemote:${actor}`, timestamp, `cid|${id}`), // for notes assertion checking
+			]);
+		} else if (localType === 'application') {
+			// Instance actor follow acceptance
+			if (!await db.isSortedSetMember('followRequests:uid.0', actor)) {
+				if (await db.isSortedSetMember('followingRemote:0', actor)) return; // already following
+				throw new Error('[[error:invalid-data]]'); // not following, not requested, so reject to hopefully stop retries
+			}
+			const timestamp = await db.sortedSetScore('followRequests:uid.0', actor);
+			await Promise.all([
+				db.sortedSetRemove('followRequests:uid.0', actor),
+				db.sortedSetAdd('followingRemote:0', timestamp, actor),
+				db.sortedSetAdd(`followersRemote:${actor}`, timestamp, 0), // for followers backreference
 			]);
 		}
 
@@ -915,7 +927,14 @@ inbox.undo = async (req) => {
 		case 'Follow': {
 			switch (localType) {
 				case 'application': {
+					// Relay unfollow
 					await activitypub.relays.removeFollower(actor);
+					// Generic instance-actor unfollow
+					await Promise.all([
+						db.sortedSetRemove('followingRemote:0', actor),
+						db.sortedSetRemove('followRequests:uid.0', actor),
+						db.sortedSetRemove(`followersRemote:${actor}`, 0),
+					]);
 					break;
 				}
 

--- a/src/activitypub/inbox.js
+++ b/src/activitypub/inbox.js
@@ -891,6 +891,8 @@ inbox.accept = async (req) => {
 				db.sortedSetAdd('followingRemote:0', timestamp, actor),
 				db.sortedSetAdd(`followersRemote:${actor}`, timestamp, 0), // for followers backreference
 			]);
+			// Transition hashtag follow state to active
+			await activitypub.hashtags.updateState(actor, 'active');
 		}
 
 		activitypub.actors._followerCache.del(actor);
@@ -935,6 +937,8 @@ inbox.undo = async (req) => {
 						db.sortedSetRemove('followRequests:uid.0', actor),
 						db.sortedSetRemove(`followersRemote:${actor}`, 0),
 					]);
+					// Transition hashtag follow state to error
+					await activitypub.hashtags.updateState(actor, 'error');
 					break;
 				}
 
@@ -1054,4 +1058,9 @@ inbox.reject = async (req) => {
 		db.sortedSetRemove('ap:retry:queue', queueId),
 		db.delete(`ap:retry:queue:${queueId}`),
 	]);
+
+	// Transition hashtag follow state to error if this is a rejected Follow from instance actor
+	if (type === 'Follow' && id === `${nconf.get('url')}/actor`) {
+		await activitypub.hashtags.updateState(actor, 'error');
+	}
 };

--- a/src/activitypub/index.js
+++ b/src/activitypub/index.js
@@ -90,6 +90,7 @@ ActivityPub.blocklists = require('./blocklists');
 ActivityPub.feps = require('./feps');
 ActivityPub.rules = require('./rules');
 ActivityPub.relays = require('./relays');
+ActivityPub.hashtags = require('./hashtags');
 ActivityPub.out = require('./out');
 ActivityPub.jobs = require('./jobs');
 ActivityPub.analytics = require('./analytics');

--- a/src/activitypub/out.js
+++ b/src/activitypub/out.js
@@ -61,9 +61,10 @@ Out.follow = enabledCheck(async (type, id, actor) => {
 	const timestamp = Date.now();
 
 	await db.sortedSetAdd(`followRequests:${type}.${id}`, timestamp, actor);
+	const actorUri = activitypub.helpers.resolveActor(type, id);
 	try {
 		await activitypub.send(type, id, [actor], {
-			id: `${nconf.get('url')}/${type}/${id}#activity/follow/${encodeURIComponent(actor)}/${timestamp}`,
+			id: `${actorUri}#activity/follow/${encodeURIComponent(actor)}/${timestamp}`,
 			type: 'Follow',
 			to: [actor],
 			object: actor,
@@ -494,33 +495,35 @@ Out.undo.follow = enabledCheck(async (type, id, actor) => {
 	], actor);
 	const timestamp = timestamps[0] || timestamps[1];
 
+	const actorUri = activitypub.helpers.resolveActor(type, id);
 	const object = {
-		id: `${nconf.get('url')}/${type}/${id}#activity/follow/${encodeURIComponent(actor)}/${timestamp}`,
+		id: `${actorUri}#activity/follow/${encodeURIComponent(actor)}/${timestamp}`,
 		type: 'Follow',
 		object: actor,
+		actor: actorUri,
 	};
-	if (type === 'uid') {
-		object.actor = `${nconf.get('url')}/uid/${id}`;
-	} else if (type === 'cid') {
-		object.actor = `${nconf.get('url')}/category/${id}`;
-	}
 
 	await activitypub.send(type, id, [actor], {
-		id: `${nconf.get('url')}/${type}/${id}#activity/undo:follow/${encodeURIComponent(actor)}/${timestamp}`,
+		id: `${actorUri}#activity/undo:follow/${encodeURIComponent(actor)}/${timestamp}`,
 		type: 'Undo',
 		to: [actor],
-		actor: object.actor,
+		actor: actorUri,
 		object,
 	});
 
 	if (type === 'uid') {
-		await Promise.all([
+		const syncPromises = [
 			db.sortedSetRemove(`followingRemote:${id}`, actor),
 			db.sortedSetRemove(`followRequests:uid.${id}`, actor),
 			db.sortedSetRemove(`followersRemote:${actor}`, id),
-			user.syncFollowCounts(id, true, false),
-			user.syncFollowCounts(actor, false, true),
-		]);
+		];
+		if (id > 0) {
+			syncPromises.push(
+				user.syncFollowCounts(id, true, false),
+				user.syncFollowCounts(actor, false, true),
+			);
+		}
+		await Promise.all(syncPromises);
 	} else if (type === 'cid') {
 		await Promise.all([
 			db.sortedSetRemove(`cid:${id}:following`, actor),

--- a/src/controllers/activitypub/actors.js
+++ b/src/controllers/activitypub/actors.js
@@ -28,6 +28,7 @@ Actors.application = async function (req, res) {
 		url: `${nconf.get('url')}/actor`,
 		inbox: `${nconf.get('url')}/inbox`,
 		outbox: `${nconf.get('url')}/outbox`,
+		following: `${nconf.get('url')}/actor/following`,
 		attributedTo: `${nconf.get('url')}/actor/admins`,
 
 		type: 'Application',
@@ -47,6 +48,29 @@ Actors.application = async function (req, res) {
 			publicKeyPem: publicKey,
 		},
 	});
+};
+
+Actors.following = async function (req, res) {
+	const count = await db.sortedSetCard('followingRemote:0');
+	const collection = await activitypub.helpers.generateCollection({
+		set: 'followingRemote:0',
+		count,
+		perPage: 50,
+		page: req.query.page,
+		url: `${nconf.get('url')}/actor/following`,
+	});
+
+	if (collection.hasOwnProperty('orderedItems')) {
+		collection.orderedItems = collection.orderedItems.map((actorUri) => {
+			if (utils.isNumber(actorUri)) {
+				return `${nconf.get('url')}/uid/${actorUri}`;
+			}
+
+			return actorUri;
+		});
+	}
+
+	res.status(200).json(collection);
 };
 
 Actors.user = async function (req, res) {

--- a/src/controllers/admin/federation.js
+++ b/src/controllers/admin/federation.js
@@ -131,6 +131,23 @@ async function getActivitiesByType() {
 	return Object.fromEntries(results.map(({ type, count }) => [type, count]));
 }
 
+federationController.hashtags = async function (req, res) {
+	const hashtags = await activitypub.hashtags.list();
+	const relay = await activitypub.hashtags.getRelay();
+	const relayOptions = activitypub.hashtags.getRelayOptions();
+
+	hashtags.forEach((h) => {
+		h.stateClass = h.state === 'pending' ? 'warning' : (h.state === 'active' ? 'success' : 'danger');
+	});
+
+	res.render('admin/federation/hashtags', {
+		title: '[[admin/menu:federation/hashtags]]',
+		hashtags,
+		relay,
+		relayOptions,
+	});
+};
+
 federationController.errors = async function (req, res) {
 	const { hostname: filterHostname, type: filterType } = req.query;
 	let errors = await db.getSortedSetRevRangeByScoreWithScores('ap.errors', 0, -1, Date.now(), '-inf');

--- a/src/controllers/admin/federation.js
+++ b/src/controllers/admin/federation.js
@@ -136,10 +136,6 @@ federationController.hashtags = async function (req, res) {
 	const relay = await activitypub.hashtags.getRelay();
 	const relayOptions = activitypub.hashtags.getRelayOptions();
 
-	hashtags.forEach((h) => {
-		h.stateClass = h.state === 'pending' ? 'warning' : (h.state === 'active' ? 'success' : 'danger');
-	});
-
 	res.render('admin/federation/hashtags', {
 		title: '[[admin/menu:federation/hashtags]]',
 		hashtags,

--- a/src/controllers/write/admin.js
+++ b/src/controllers/write/admin.js
@@ -239,6 +239,45 @@ Admin.activitypub.removeCoreDomain = async (req, res) => {
 	helpers.formatApiResponse(200, res, await activitypub.blocklists.get('core'));
 };
 
+Admin.activitypub.getHashtags = async (req, res) => {
+	const hashtags = await activitypub.hashtags.list();
+	const relay = await activitypub.hashtags.getRelay();
+	helpers.formatApiResponse(200, res, { hashtags, relay });
+};
+
+Admin.activitypub.addHashtag = async (req, res) => {
+	let { tag } = req.body;
+
+	if (!tag || !tag.trim()) {
+		return helpers.formatApiResponse(400, res);
+	}
+	tag = tag.trim().toLowerCase();
+
+	await activitypub.hashtags.follow(tag);
+	helpers.formatApiResponse(200, res, await activitypub.hashtags.list());
+};
+
+Admin.activitypub.removeHashtag = async (req, res) => {
+	const { tag } = req.params;
+	await activitypub.hashtags.unfollow(tag);
+	helpers.formatApiResponse(200, res, await activitypub.hashtags.list());
+};
+
+Admin.activitypub.getHashtagRelay = async (req, res) => {
+	const relay = await activitypub.hashtags.getRelay();
+	helpers.formatApiResponse(200, res, { relay });
+};
+
+Admin.activitypub.setHashtagRelay = async (req, res) => {
+	const { host } = req.body;
+	if (!host || !host.trim()) {
+		return helpers.formatApiResponse(400, res);
+	}
+
+	await activitypub.hashtags.setRelay(host);
+	helpers.formatApiResponse(200, res, { relay: host });
+};
+
 Admin.plugins = {};
 
 Admin.plugins.install = async (req, res) => {

--- a/src/controllers/write/admin.js
+++ b/src/controllers/write/admin.js
@@ -246,14 +246,23 @@ Admin.activitypub.getHashtags = async (req, res) => {
 };
 
 Admin.activitypub.addHashtag = async (req, res) => {
-	let { tag } = req.body;
+	let { tag, cid } = req.body;
 
 	if (!tag || !tag.trim()) {
 		return helpers.formatApiResponse(400, res);
 	}
 	tag = tag.trim().toLowerCase();
 
-	await activitypub.hashtags.follow(tag);
+	if (cid) {
+		cid = parseInt(cid, 10);
+		const categories = require('../../categories');
+		const exists = await categories.exists(cid);
+		if (!exists) {
+			return helpers.formatApiResponse(400, res);
+		}
+	}
+
+	await activitypub.hashtags.follow(tag, cid);
 	helpers.formatApiResponse(200, res, await activitypub.hashtags.list());
 };
 

--- a/src/routes/activitypub.js
+++ b/src/routes/activitypub.js
@@ -33,6 +33,7 @@ module.exports = function (app, middleware, controllers) {
 	];
 
 	app.get('/actor', middlewares, helpers.tryRoute(controllers.activitypub.actors.application));
+	app.get('/actor/following', middlewares, helpers.tryRoute(controllers.activitypub.actors.following));
 	app.get('/actor/admins', middlewares, helpers.tryRoute(controllers.activitypub.getAdmins));
 	app.post('/inbox', [...middlewares, ...inboxMiddlewares], helpers.tryRoute(controllers.activitypub.postInbox));
 

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -58,6 +58,7 @@ module.exports = function (app, name, middleware, controllers) {
 	helpers.setupAdminPageRoute(app, `/${name}/federation/safety`, middlewares, controllers.admin.federation.safety);
 	helpers.setupAdminPageRoute(app, `/${name}/federation/analytics`, middlewares, controllers.admin.federation.analytics);
 	helpers.setupAdminPageRoute(app, `/${name}/federation/errors`, middlewares, controllers.admin.federation.errors);
+	helpers.setupAdminPageRoute(app, `/${name}/federation/hashtags`, middlewares, controllers.admin.federation.hashtags);
 
 	helpers.setupAdminPageRoute(app, `/${name}/appearance/themes`, middlewares, controllers.admin.appearance.themes);
 	helpers.setupAdminPageRoute(app, `/${name}/appearance/skins`, middlewares, controllers.admin.appearance.skins);

--- a/src/routes/write/admin.js
+++ b/src/routes/write/admin.js
@@ -47,6 +47,12 @@ module.exports = function () {
 	setupApiRoute(router, 'delete', '/activitypub/blocklists/:url', [...middlewares], controllers.write.admin.activitypub.removeBlocklist);
 	setupApiRoute(router, 'post', '/activitypub/blocklists/:url/refresh', [...middlewares], controllers.write.admin.activitypub.refreshBlocklist);
 
+	setupApiRoute(router, 'get', '/activitypub/hashtags', [...middlewares], controllers.write.admin.activitypub.getHashtags);
+	setupApiRoute(router, 'post', '/activitypub/hashtags', [...middlewares, middleware.checkRequired.bind(null, ['tag'])], controllers.write.admin.activitypub.addHashtag);
+	setupApiRoute(router, 'delete', '/activitypub/hashtags/:tag', [...middlewares], controllers.write.admin.activitypub.removeHashtag);
+	setupApiRoute(router, 'get', '/activitypub/hashtags/relay', [...middlewares], controllers.write.admin.activitypub.getHashtagRelay);
+	setupApiRoute(router, 'put', '/activitypub/hashtags/relay', [...middlewares, middleware.checkRequired.bind(null, ['host'])], controllers.write.admin.activitypub.setHashtagRelay);
+
 	setupApiRoute(router, 'post', '/plugins/:pluginId', [...middlewares, requireAPIReAuth], controllers.write.admin.plugins.install);
 	setupApiRoute(router, 'delete', '/plugins/:pluginId', [...middlewares], controllers.write.admin.plugins.uninstall);
 	setupApiRoute(router, 'put', '/plugins/:pluginId/active', [...middlewares, middleware.checkRequired.bind(null, ['active'])], controllers.write.admin.plugins.setActive);

--- a/src/views/admin/federation/hashtags.tpl
+++ b/src/views/admin/federation/hashtags.tpl
@@ -1,0 +1,51 @@
+<div class="d-flex flex-column gap-2 px-lg-4">
+	<div component="settings/main/header" class="row border-bottom py-2 m-0 mb-3 sticky-top acp-page-main-header align-items-center">
+		<div class="col-12 col-md-8 px-0 mb-1 mb-md-0">
+			<h4 class="fw-bold tracking-tight mb-0">{{tx(title)}}</h4>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-12">
+			<p>{{tx("admin/settings/activitypub:hashtags.intro")}}</p>
+
+			<div class="mb-4">
+				<div class="mb-3 row">
+					<div class="col-12 col-md-6">
+						<label class="form-label" for="relayHost">{{tx("admin/settings/activitypub:hashtags.relay-host")}}</label>
+						<div class="input-group mb-3">
+							<select class="form-select" id="relayHost">
+								{{{ each relayOptions }}}
+								<option value="{@value}"{{{ if (@value == relay) }}} selected{{{ end }}}>{@value}</option>
+								{{{ end }}}
+							</select>
+							<button class="btn btn-sm btn-primary" data-action="hashtags.setRelay">{{tx("admin/settings/activitypub:hashtags.save-relay")}}</button>
+						</div>
+						<div class="form-text">{{tx("admin/settings/activitypub:hashtags.relay-host-help")}}</div>
+						<div class="form-text text-warning">{{tx("admin/settings/activitypub:hashtags.relay-change-warning")}}</div>
+					</div>
+				</div>
+			</div>
+
+			<div class="mb-3 table-responsive">
+				<table class="table table-striped" id="hashtags">
+					<thead>
+						<th>{{tx("admin/settings/activitypub:hashtags.table.tag")}}</th>
+						<th>{{tx("admin/settings/activitypub:hashtags.table.state")}}</th>
+						<th></th>
+					</thead>
+					<tbody component="hashtags/list">
+						<!-- IMPORT admin/partials/activitypub/hashtags/list.tpl -->
+					</tbody>
+					<tfoot>
+						<tr>
+							<td colspan="3">
+								<button class="btn btn-sm btn-primary" data-action="hashtags.add">{{tx("admin/settings/activitypub:hashtags.follow")}}</button>
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/views/admin/partials/activitypub/hashtags.tpl
+++ b/src/views/admin/partials/activitypub/hashtags.tpl
@@ -1,0 +1,7 @@
+<form role="form" id="hashtagForm">
+	<div class="mb-3">
+		<label class="form-label" for="hashtagTag">{{tx("admin/settings/activitypub:hashtags.modal.tag")}}</label>
+		<input type="text" id="hashtagTag" name="tag" class="form-control" placeholder="nodebb" required />
+		<div class="form-text">{{tx("admin/settings/activitypub:hashtags.modal.tag-help")}}</div>
+	</div>
+</form>

--- a/src/views/admin/partials/activitypub/hashtags.tpl
+++ b/src/views/admin/partials/activitypub/hashtags.tpl
@@ -4,4 +4,11 @@
 		<input type="text" id="hashtagTag" name="tag" class="form-control" placeholder="nodebb" required />
 		<div class="form-text">{{tx("admin/settings/activitypub:hashtags.modal.tag-help")}}</div>
 	</div>
+	<div class="mb-3">
+		<label class="form-label">{{tx("admin/settings/activitypub:hashtags.modal.category")}}</label>
+		<div class="d-block">
+			<!-- IMPORT admin/partials/category/selector-dropdown-left.tpl -->
+		</div>
+		<input type="hidden" name="cid" />
+	</div>
 </form>

--- a/src/views/admin/partials/activitypub/hashtags/list.tpl
+++ b/src/views/admin/partials/activitypub/hashtags/list.tpl
@@ -1,0 +1,11 @@
+{{{ each hashtags }}}
+<tr data-tag="{./tag}">
+	<td><code>#{{./tag}}</code></td>
+	<td>
+		<span class="badge bg-{./stateClass}" title="{tx("admin/settings/activitypub:hashtags.state-{./state}")}">
+			{tx("admin/settings/activitypub:hashtags.state-{./state}")}
+		</span>
+	</td>
+	<td><a href="#" data-action="hashtags.remove" data-tag="{./tag}"><i class="fa fa-trash link-danger"></i></a></td>
+</tr>
+{{{ end }}}

--- a/src/views/admin/partials/activitypub/hashtags/list.tpl
+++ b/src/views/admin/partials/activitypub/hashtags/list.tpl
@@ -2,8 +2,8 @@
 <tr data-tag="{./tag}">
 	<td><code>#{{./tag}}</code></td>
 	<td>
-		<span class="badge bg-{./stateClass}" title="{tx("admin/settings/activitypub:hashtags.state-{./state}")}">
-			{tx("admin/settings/activitypub:hashtags.state-{./state}")}
+		<span class="badge bg-{./stateClass}" title="{{tx(concat("admin/settings/activitypub:hashtags.state-", ./state))}}">
+			{{tx(concat("admin/settings/activitypub:hashtags.state-", ./state))}}
 		</span>
 	</td>
 	<td><a href="#" data-action="hashtags.remove" data-tag="{./tag}"><i class="fa fa-trash link-danger"></i></a></td>

--- a/src/views/admin/partials/navigation.tpl
+++ b/src/views/admin/partials/navigation.tpl
@@ -107,6 +107,7 @@
 				<a class="btn btn-ghost btn-sm text-start" id="federation-content" href="{relative_path}/admin/federation/content">{{tx("admin/menu:federation/content")}}</a>
 				<a class="btn btn-ghost btn-sm text-start" id="federation-rules" href="{relative_path}/admin/federation/rules">{{tx("admin/menu:federation/rules")}}</a>
 				<a class="btn btn-ghost btn-sm text-start" id="federation-relays" href="{relative_path}/admin/federation/relays">{{tx("admin/menu:federation/relays")}}</a>
+				<a class="btn btn-ghost btn-sm text-start" id="federation-hashtags" href="{relative_path}/admin/federation/hashtags">{{tx("admin/menu:federation/hashtags")}}</a>
 				<a class="btn btn-ghost btn-sm text-start" id="federation-pruning" href="{relative_path}/admin/federation/pruning">{{tx("admin/menu:federation/pruning")}}</a>
 				<a class="btn btn-ghost btn-sm text-start" id="federation-safety" href="{relative_path}/admin/federation/safety">{{tx("admin/menu:federation/safety")}}</a>
 				<a class="btn btn-ghost btn-sm text-start" id="federation-analytics" href="{relative_path}/admin/federation/analytics">{{tx("admin/menu:federation/analytics")}}</a>


### PR DESCRIPTION
## Summary

Enables the instance actor (`/actor`, uid 0) to follow arbitrary remote ActivityPub actors, and introduces an admin UI for following global hashtag actors via relay providers (`relay.fedi.buzz`, `tags.pub`).

## Notes

- ~FediBuzz hashtag actors fail `actors.assert` because `preferredUsername` (`tag-nodebb`) doesn't match WebFinger subject — Follow/Undo are sent directly via `activitypub.send` (same pattern as relays)~
    - ~https://activitypub.space/topic/603/fedibuzz-webfinger-backreference-failure~
- Default relay is `relay.fedi.buzz` if none configured
- Following a hashtag with a category selected creates an auto-categorization rule; unfollowing removes it