### PR TITLE
fix: hide "none found" notice on trending plugins tab when plugins exist

### DIFF
--- a/src/views/admin/extend/plugins.tpl
+++ b/src/views/admin/extend/plugins.tpl
@@ -52,7 +52,7 @@
 			<div class="col-lg-9">
 				<div class="tab-content">
 					<div class="tab-pane fade" id="trending">
-						<div class="alert alert-info no-plugins {{{ if !trending.length }}}hide{{{ end }}}">{{tx("admin/extend/plugins:none-found")}}</div>
+						<div class="alert alert-info no-plugins {{{ if trending.length }}}hide{{{ end }}}">{{tx("admin/extend/plugins:none-found")}}</div>
 						<ul class="trending list-unstyled">
 							{{{ each trending }}}
 							<!-- IMPORT admin/partials/installed_plugin_item.tpl -->


### PR DESCRIPTION
The \`.no-plugins\` alert in the trending tab of the ACP plugins page uses \`{{{ if !trending.length }}}hide{{{ end }}}\`, which is the inverse of every other tab (\`{{{ if installed.length }}}hide{{{ end }}}\` etc.). As a result the "No plugins found" notice is shown on initial load whenever trending plugins **are** listed, and hidden when the list is actually empty.

The client-side search handler recomputes the notice from the visible \`li\` count, so typing and clearing the search box hides it again, which is why it only shows on the initial render.

This removes the stray \`!\` so the trending tab matches the other tabs.