### PR TITLE
fix: prevent caching of responses carrying a CSRF token

### DIFF
--- a/src/controllers/api.js
+++ b/src/controllers/api.js
@@ -152,6 +152,7 @@ apiController.loadConfig = async function (req) {
 
 apiController.getConfig = async function (req, res) {
 	const config = await apiController.loadConfig(req);
+	res.set('cache-control', 'private, no-cache');
 	res.json(config);
 };
 

--- a/src/middleware/render.js
+++ b/src/middleware/render.js
@@ -47,9 +47,7 @@ module.exports = function (middleware) {
 				options.url = options.url || (req.baseUrl + req.path.replace(/^\/api/, ''));
 				options.bodyClass = helpers.buildBodyClass(req, res, options);
 
-				if (req.loggedIn) {
-					res.set('cache-control', 'private');
-				}
+				res.set('cache-control', 'private, no-cache');
 
 				const buildResult = await plugins.hooks.fire(`filter:${template}.build`, {
 					req: req,

--- a/test/middleware.js
+++ b/test/middleware.js
@@ -122,7 +122,7 @@ describe('Middlewares', () => {
 			assert(!Object.keys(response.headers).includes('cache-control'));
 		});
 
-		it('should be set to "private" on non-existent routes, for logged in users', async () => {
+		it('should be set to "private, no-cache" on non-existent routes, for logged in users', async () => {
 			const { response } = await request.get(`${nconf.get('url')}/${utils.generateUUID()}`, {
 				jar,
 				headers: {
@@ -131,38 +131,42 @@ describe('Middlewares', () => {
 			});
 
 			assert.strictEqual(response.statusCode, 404);
-			assert(Object.keys(response.headers).includes('cache-control'));
-			assert.strictEqual(response.headers['cache-control'], 'private');
+			assert.strictEqual(response.headers['cache-control'], 'private, no-cache');
 		});
 
-		it('should be absent on regular routes, for guests', async () => {
+		it('should be set to "private, no-cache" on regular routes, for guests', async () => {
 			const { response } = await request.get(nconf.get('url'));
 
 			assert.strictEqual(response.statusCode, 200);
-			assert(!Object.keys(response.headers).includes('cache-control'));
+			assert.strictEqual(response.headers['cache-control'], 'private, no-cache');
 		});
 
-		it('should be absent on api routes, for guests', async () => {
+		it('should be set to "private, no-cache" on api routes, for guests', async () => {
 			const { response } = await request.get(`${nconf.get('url')}/api`);
 
 			assert.strictEqual(response.statusCode, 200);
-			assert(!Object.keys(response.headers).includes('cache-control'));
+			assert.strictEqual(response.headers['cache-control'], 'private, no-cache');
 		});
 
-		it('should be set to "private" on regular routes, for logged-in users', async () => {
+		it('should be set to "private, no-cache" on the config route, for guests', async () => {
+			const { response } = await request.get(`${nconf.get('url')}/api/config`);
+
+			assert.strictEqual(response.statusCode, 200);
+			assert.strictEqual(response.headers['cache-control'], 'private, no-cache');
+		});
+
+		it('should be set to "private, no-cache" on regular routes, for logged-in users', async () => {
 			const { response } = await request.get(nconf.get('url'), { jar });
 
 			assert.strictEqual(response.statusCode, 200);
-			assert(Object.keys(response.headers).includes('cache-control'));
-			assert.strictEqual(response.headers['cache-control'], 'private');
+			assert.strictEqual(response.headers['cache-control'], 'private, no-cache');
 		});
 
-		it('should be set to "private" on api routes, for logged-in users', async () => {
+		it('should be set to "private, no-cache" on api routes, for logged-in users', async () => {
 			const { response } = await request.get(`${nconf.get('url')}/api`, { jar });
 
 			assert.strictEqual(response.statusCode, 200);
-			assert(Object.keys(response.headers).includes('cache-control'));
-			assert.strictEqual(response.headers['cache-control'], 'private');
+			assert.strictEqual(response.headers['cache-control'], 'private, no-cache');
 		});
 
 		it('should be set to "private" on apiv3 routes, for logged-in users', async () => {


### PR DESCRIPTION
### Problem

`apiController.loadConfig` embeds a session-bound CSRF token into every page, for guests too:

```js
csrf_token: req.uid >= 0 ? generateToken(req) : false,
```

A guest has `uid === 0`, so the token is generated and rendered into the HTML. But `middleware/render.js` only set a `Cache-Control` header when the user was logged in:

```js
if (req.loggedIn) {
    res.set('cache-control', 'private');
}
```

A response with no `Cache-Control` but with an `ETag` is heuristically cacheable, so the browser stores the guest page. On a later visit it replays that HTML with a token belonging to an expired session, while the current session holds a different one. Everything carrying the page token is then rejected with 403 — the socket.io polling handshake first, then the login POST — and the user gets `[[error:csrf-invalid]]`.

The redirect to `/login?error=csrf-invalid` is a different URL and is not in the cache, so it renders fresh with a valid token. That is why the second attempt always succeeds, which makes this look like an intermittent session problem rather than a caching one.

`/api/config` has the same exposure: it returns `csrf_token` through a plain `res.json()` and sets no cache headers at all.

### Reproduction

Observed on a production forum where the failure was fully deterministic — the first login attempt failed every time. Confirmed on the login page before submitting:

```js
fetch('/api/config', { credentials: 'include' })
    .then(r => r.json())
    .then(d => console.log(d.csrf_token === config.csrf_token));
// false
```

The page held `200d83a7…` while the session held `fc94ed8f…`. Both the socket.io handshake and the login POST sent `200d83a7…` and returned 403, with a single stable `express.sid` across both requests and no `Set-Cookie` in either response — the session was fine, only the page was stale.

Enabling "Bypass for network" in DevTools → Application → Service Workers made the first login succeed. The service worker in `public/src/service-worker.js` calls `fetch(event.request)` for navigations, which reads the HTTP cache instead of performing a normal navigation, so the stale entry is served consistently. CacheStorage was empty, so the service worker's own cache was not involved — it only made the underlying caching bug reproducible on every load.

### Fix

Send `private, no-cache` on rendered responses and on `/api/config`.

`no-cache` rather than `no-store`: it forces revalidation but still allows a 304 when nothing changed, so guest pages keep their conditional-request performance. Since the ETag is derived from the body, a rotated token produces a different ETag and a fresh 200.

Applying it to logged-in users as well: `private` alone leaves the response heuristically cacheable in the private cache, so the same stale-token window existed there.

Keeping `private` matters independently of the staleness bug — without it a shared cache is permitted to store a guest page and serve one visitor's CSRF token to another.
