### PR TITLE
fix: prune expired topic view timestamps from the session

### DIFF
--- a/src/topics/posts.js
+++ b/src/topics/posts.js
@@ -329,17 +329,23 @@ module.exports = function (Topics) {
 	Topics.increaseViewCount = async function (req, tid) {
 		const allow = req.uid > 0 || (meta.config.guestsIncrementTopicViews && req.uid === 0);
 		if (allow) {
-			req.session.tids_viewed = req.session.tids_viewed || {};
 			const now = Date.now();
-			const interval = meta.config.incrementTopicViewsInterval * 60000;
-			if (!req.session.tids_viewed[tid] || req.session.tids_viewed[tid] < now - interval) {
+			const cutoff = now - (meta.config.incrementTopicViewsInterval * 60000);
+			const viewed = req.session.tids_viewed || {};
+			for (const [viewedTid, timestamp] of Object.entries(viewed)) {
+				if (timestamp < cutoff) {
+					delete viewed[viewedTid];
+				}
+			}
+			req.session.tids_viewed = viewed;
+			if (!viewed[tid]) {
 				const cid = await Topics.getTopicField(tid, 'cid');
 				const isRemoteCid = !utils.isNumber(cid) || cid === -1;
 				const value = await db.incrObjectFieldBy(`topic:${tid}`, 'viewcount', 1);
 				await db.sortedSetsAdd(
 					isRemoteCid ? [`cid:${cid}:tids:views`] : ['topics:views', `cid:${cid}:tids:views`], value, tid
 				);
-				req.session.tids_viewed[tid] = now;
+				viewed[tid] = now;
 			}
 		}
 	};

--- a/test/topics.js
+++ b/test/topics.js
@@ -1996,6 +1996,36 @@ describe('Topic\'s', () => {
 		});
 	});
 
+	describe('topic views', () => {
+		let viewsTid;
+
+		before(async () => {
+			const result = await topics.post({
+				uid: adminUid,
+				title: 'topic views test',
+				content: 'topic views test content',
+				cid: categoryObj.cid,
+			});
+			viewsTid = result.topicData.tid;
+		});
+
+		it('should only increment the view count once per interval', async () => {
+			const req = { uid: fooUid, session: {} };
+			await topics.increaseViewCount(req, viewsTid);
+			await topics.increaseViewCount(req, viewsTid);
+			assert.strictEqual(await topics.getTopicField(viewsTid, 'viewcount'), 1);
+			assert.deepStrictEqual(Object.keys(req.session.tids_viewed), [String(viewsTid)]);
+		});
+
+		it('should prune expired entries from the session', async () => {
+			const expired = Date.now() - ((meta.config.incrementTopicViewsInterval + 1) * 60000);
+			const req = { uid: fooUid, session: { tids_viewed: { 1: expired, 2: expired } } };
+			await topics.increaseViewCount(req, viewsTid);
+			assert.deepStrictEqual(Object.keys(req.session.tids_viewed), [String(viewsTid)]);
+			assert.strictEqual(await topics.getTopicField(viewsTid, 'viewcount'), 2);
+		});
+	});
+
 	it('should check if user is moderator', (done) => {
 		socketTopics.isModerator({ uid: adminUid }, topic.tid, (err, isModerator) => {
 			assert.ifError(err);


### PR DESCRIPTION
### Problem

`Topics.increaseViewCount()` de-duplicates topic views by writing a timestamp per tid into `req.session.tids_viewed`:

https://github.com/NodeBB/NodeBB/blob/master/src/topics/posts.js#L329-L344

Entries are never removed. An entry is meaningless once `incrementTopicViewsInterval` minutes have passed — the staleness check already ignores it — but it stays in the session forever, so the session object gains a key for every topic the user has ever opened. The session is serialized to the session store on write, so an active long-lived account accumulates thousands of expired `tid -> timestamp` pairs that are read and written on every request.

### Change

Delete entries older than the interval before doing the lookup. Because those entries would have failed the staleness check anyway, the counting behaviour is unchanged: the `!viewed[tid]` test after pruning is equivalent to the previous `!viewed[tid] || viewed[tid] < now - interval`. Pruning happens only on a topic view, i.e. when the session is being touched regardless.

Tests cover both that a view is still counted once per interval and that expired entries are dropped.