### PR TITLE
fix: ask for the current password when an admin changes their own password from ACP

### DIFF
--- a/public/src/admin/manage/users.js
+++ b/public/src/admin/manage/users.js
@@ -392,20 +392,24 @@ define('admin/manage/users', [
 			if (!uids.length) {
 				return;
 			}
+			const includesSelf = uids.some(uid => parseInt(uid, 10) === parseInt(app.user.uid, 10));
 			async function changePassword(modal) {
+				const currentPassword = modal.find('#currentPassword').val() || '';
 				const newPassword = modal.find('#newPassword').val();
 				const confirmPassword = modal.find('#confirmPassword').val();
 				if (newPassword !== confirmPassword) {
-					throw new Error('[[[user:change-password-error-match]]');
+					throw new Error('[[user:change-password-error-match]]');
 				}
 				await Promise.all(uids.map(uid => api.put('/users/' + uid + '/password', {
-					currentPassword: '',
+					currentPassword: parseInt(uid, 10) === parseInt(app.user.uid, 10) ? currentPassword : '',
 					newPassword: newPassword,
 				})));
 			}
 
 			const modal = await modals.dialog({
 				message: `<div class="d-flex flex-column gap-2">
+					${includesSelf ? `<label class="form-label">[[user:current-password]]</label>
+					<input id="currentPassword" class="form-control" type="password" autocomplete="current-password">` : ''}
 					<label class="form-label">[[user:new-password]]</label>
 					<input id="newPassword" class="form-control" type="text">
 					<label class="form-label">[[user:confirm-password]]</label>


### PR DESCRIPTION
## Problem

In ACP > Manage > Users, the "Change password" bulk action always sends an empty `currentPassword`. That is fine for other users, but `User.changePassword` requires the current password whenever the caller is also the target (`isSelf && hasPassword`). So an administrator who selects their own account gets \`[[user:change-password-error-wrong-current]]\` ("Your current password is not correct!") even though the dialog never asked for one, and there is no way to complete the change from the ACP.

## Fix

- When the selection includes the current user, the dialog shows a "Current password" field.
- The value is sent only for the admin's own uid; other selected users still receive an empty `currentPassword` as before.
- Also fixes a stray third bracket in the `change-password-error-match` translation key thrown on mismatch, which rendered the raw key instead of the translated message.

## Testing

- Select yourself in the users table, choose Change password: the current-password field appears; wrong value shows the wrong-current error, correct value changes the password and logs you out as expected.
- Select only other non-admin users: dialog is unchanged and the change succeeds.
- Mixed selection including yourself: field appears, your own account is validated against it, the others are changed without it.
