### PR TITLE
fix: load zxcvbn lazily so password forms keep working when the chunk fails to load

### DIFF
--- a/public/src/client/account/edit/password.js
+++ b/public/src/client/account/edit/password.js
@@ -1,12 +1,16 @@
 'use strict';
 
 define('forum/account/edit/password', [
-	'forum/account/header', 'translator', 'zxcvbn', 'api', 'alerts',
-], function (header, translator, zxcvbn, api, alerts) {
+	'forum/account/header', 'translator', 'api', 'alerts',
+], function (header, translator, api, alerts) {
 	const AccountEditPassword = {};
+	let zxcvbn = null;
 
 	AccountEditPassword.init = function () {
 		header.init();
+		import('zxcvbn').then((module) => {
+			zxcvbn = module.default || module;
+		}).catch(() => {});
 
 		handlePasswordChange();
 	};

--- a/public/src/client/register.js
+++ b/public/src/client/register.js
@@ -2,13 +2,17 @@
 
 
 define('forum/register', [
-	'translator', 'slugify', 'api', 'modals', 'forum/login', 'zxcvbn', 'jquery-form',
-], function (translator, slugify, api, modals, Login, zxcvbn) {
+	'translator', 'slugify', 'api', 'modals', 'forum/login', 'jquery-form',
+], function (translator, slugify, api, modals, Login) {
 	const Register = {};
 	let validationError = false;
 	const successIcon = '';
+	let zxcvbn = null;
 
 	Register.init = function () {
+		import('zxcvbn').then((module) => {
+			zxcvbn = module.default || module;
+		}).catch(() => {});
 		const username = $('#username');
 		const password = $('#password');
 		const password_confirm = $('#password-confirm');

--- a/public/src/client/reset_code.js
+++ b/public/src/client/reset_code.js
@@ -1,11 +1,15 @@
 'use strict';
 
 
-define('forum/reset_code', ['alerts', 'zxcvbn'], function (alerts, zxcvbn) {
+define('forum/reset_code', ['alerts'], function (alerts) {
 	const ResetCode = {};
+	let zxcvbn = null;
 
 	ResetCode.init = function () {
 		const reset_code = ajaxify.data.code;
+		import('zxcvbn').then((module) => {
+			zxcvbn = module.default || module;
+		}).catch(() => {});
 
 		const resetEl = $('#reset');
 		const password = $('#password');

--- a/public/src/utils.js
+++ b/public/src/utils.js
@@ -68,6 +68,9 @@ utils.assertPasswordValidity = (password, zxcvbn) => {
 		throw new Error('[[error:password-too-long]]');
 	}
 
+	if (typeof zxcvbn !== 'function') {
+		return;
+	}
 	const passwordStrength = zxcvbn(password);
 	if (passwordStrength.score < ajaxify.data.minimumPasswordStrength) {
 		throw new Error('[[user:weak-password]]');


### PR DESCRIPTION
## Problem

`forum/register`, `forum/reset_code` and `forum/account/edit/password` declare `zxcvbn` as a hard AMD dependency. zxcvbn is bundled as its own ~800 KB chunk, and when that chunk cannot be fetched (content filters and corporate proxies are known to block it because of the embedded word lists, but any flaky network does the same) the whole page module fails with a `ChunkLoadError` and never initialises.

The visible result is confusing: the submit button sits inside a `<form>`, so with no click handler bound the browser performs a native form submission. The page reloads with an empty query string, no request reaches the API, and no error is shown. This makes it impossible to register, reset a password, or change a password from the affected network.

The client-side zxcvbn call only provides early feedback. The server runs the same strength check in `User.isPasswordValid`, so nothing security-relevant depends on the browser having the library.

## Fix

- The three modules no longer list `zxcvbn` in their `define` dependencies. They start a dynamic `import('zxcvbn')` in `init()` and keep the result in a module-level variable. A failed import is swallowed.
- `utils.assertPasswordValidity()` skips the strength check when it is not handed a function. Length and validity checks still run client-side, and the server still enforces strength.

When the chunk loads, behaviour is unchanged: it is requested at the same moment as before and the strength check runs on the first keystroke. When it does not load, the forms degrade to server-side validation instead of silently breaking.

## Testing

- `./nodebb build js` compiles, eslint passes, and zxcvbn is still emitted as its own chunk.
- Reproduced the original failure on a live forum behind a content filter that blocks the zxcvbn chunk: the console shows `error loading forum/account/edit/password` / `ChunkLoadError`, the button has no handlers bound, and clicking it reloads the page. A direct `PUT /api/v3/users/:uid/password` from the console succeeds, confirming the server-side check is sufficient.
- Suggested manual check for reviewers: block `*.min.js` matching the zxcvbn chunk in devtools and verify the three pages still bind their handlers and surface the server's weak-password error.
