### PR TITLE
feat(activitypub): support content warnings on incoming remote posts

### DIFF
--- a/src/activitypub/mocks.js
+++ b/src/activitypub/mocks.js
@@ -442,7 +442,7 @@ Mocks.post = async (objects) => {
 			attributedTo: uid,
 			inReplyTo: toPid,
 			published, updated, name, content, sourceContent,
-			to, cc, audience, attachment, tag, image,
+			to, cc, audience, attachment, tag, image, summary, sensitive,
 		} = object;
 
 		await activitypub.actors.assert(uid);
@@ -469,6 +469,8 @@ Mocks.post = async (objects) => {
 
 			edited,
 			editor: edited ? uid : undefined,
+			// Store contentWarning only for Note + sensitive + summary (Fediverse CW convention)
+			...(object.type === 'Note' && sensitive && summary && { contentWarning: summary }),
 			_activitypub: { to, cc, audience, attachment, tag, url, image },
 		};
 

--- a/src/activitypub/notes.js
+++ b/src/activitypub/notes.js
@@ -119,7 +119,17 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 		chain = chain.sort((a, b) => a.timestamp - b.timestamp);
 
 		const mainPost = chain[0];
-		let { pid: mainPid, tid, uid: authorId, timestamp, title, content, sourceContent, _activitypub } = mainPost;
+		let {
+			pid: mainPid,
+			tid,
+			uid: authorId,
+			timestamp,
+			title,
+			content,
+			sourceContent,
+			contentWarning,
+			_activitypub,
+		} = mainPost;
 		const hasTid = !!tid;
 
 		const authorBanned = await user.bans.isBanned(authorId);
@@ -203,6 +213,11 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 				prettified = prettified.split('\n').filter(line => !line.startsWith('<p class="quote-inline"')).join('\n');
 				const sentences = tokenizer.sentences(prettified, { sanitize: true, newline_boundaries: true });
 				title = sentences.shift();
+				generatedTitle = 1;
+			}
+
+			if (contentWarning) {
+				title = contentWarning;
 				generatedTitle = 1;
 			}
 
@@ -297,6 +312,7 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 					timestamp,
 					content: mainPost.content,
 					sourceContent: mainPost.sourceContent,
+					contentWarning,
 					generatedTitle,
 					_activitypub: mainPost._activitypub,
 				};
@@ -322,6 +338,7 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 					tags,
 					content: mainPost.content,
 					sourceContent: mainPost.sourceContent,
+					contentWarning,
 					generatedTitle,
 					_activitypub: mainPost._activitypub,
 				});
@@ -381,6 +398,7 @@ Notes.assert = async (uid, input, options = { skipChecks: false, queue: false })
 						pid: post.pid,
 						content: post.content,
 						sourceContent: post.sourceContent,
+						contentWarning: post.contentWarning,
 						timestamp: post.timestamp,
 						_activitypub: post._activitypub,
 					});

--- a/src/controllers/accounts/posts.js
+++ b/src/controllers/accounts/posts.js
@@ -63,7 +63,7 @@ const templateToData = {
 		getTopics: async (sets, req, start, stop) => {
 			let pids = await db.getSortedSetRevRangeByScore(sets, start, stop - start + 1, '+inf', 1);
 			pids = await privileges.posts.filter('topics:read', pids, req.uid);
-			const postObjs = await posts.getPostSummaryByPids(pids, req.uid, { stripTags: false });
+			const postObjs = await posts.getPostSummaryByPids(pids, req.uid, { stripTags: false, extraFields: ['contentWarning'] });
 			return { posts: postObjs, nextStart: stop + 1 };
 		},
 		getItemCount: async (sets) => {
@@ -82,7 +82,7 @@ const templateToData = {
 		getTopics: async (sets, req, start, stop) => {
 			let pids = await db.getSortedSetRangeByScore(sets, start, stop - start + 1, '-inf', -1);
 			pids = await privileges.posts.filter('topics:read', pids, req.uid);
-			const postObjs = await posts.getPostSummaryByPids(pids, req.uid, { stripTags: false });
+			const postObjs = await posts.getPostSummaryByPids(pids, req.uid, { stripTags: false, extraFields: ['contentWarning'] });
 			return { posts: postObjs, nextStart: stop + 1 };
 		},
 		getItemCount: async (sets) => {

--- a/src/controllers/accounts/profile.js
+++ b/src/controllers/accounts/profile.js
@@ -117,7 +117,7 @@ async function getPosts(callerUid, userData, setSuffix) {
 				setSuffix,
 				pids,
 			}));
-			const p = await posts.getPostSummaryByPids(pids, callerUid, { stripTags: false });
+			const p = await posts.getPostSummaryByPids(pids, callerUid, { stripTags: false, extraFields: ['contentWarning'] });
 			postData.push(...p.filter(
 				p => p && p.topic && (
 					isAdmin ||

--- a/src/controllers/activitypub/actors.js
+++ b/src/controllers/activitypub/actors.js
@@ -109,7 +109,7 @@ Actors.note = async function (req, res, next) {
 
 	const post = (await posts.getPostSummaryByPids([req.params.pid], activitypub._constants.uid, {
 		parse: false,
-		extraFields: ['edited'],
+		extraFields: ['edited', 'contentWarning'],
 	})).pop();
 	if (!post || post.timestamp > Date.now()) {
 		return next();

--- a/src/controllers/activitypub/topics.js
+++ b/src/controllers/activitypub/topics.js
@@ -108,7 +108,7 @@ controller.list = async function (req, res) {
 	const [postData, postPrivileges] = await Promise.all([
 		posts.getPostSummaryByPids(mainPids, req.uid, {
 			stripTags: false,
-			extraFields: ['bookmarks'],
+			extraFields: ['bookmarks', 'contentWarning'],
 		}),
 		privileges.posts.get(mainPids, req.uid),
 	]);

--- a/src/controllers/topics.js
+++ b/src/controllers/topics.js
@@ -435,7 +435,7 @@ topicsController.teaser = async function (req, res, next) {
 	if (!pid) {
 		return res.status(404).json('not-found');
 	}
-	const postData = await posts.getPostSummaryByPids([pid], req.uid, { stripTags: false });
+	const postData = await posts.getPostSummaryByPids([pid], req.uid, { stripTags: false, extraFields: ['contentWarning'] });
 	if (!postData.length) {
 		return res.status(404).json('not-found');
 	}

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -39,6 +39,9 @@ module.exports = function (Posts) {
 		if (data.handle && !parseInt(uid, 10)) {
 			postData.handle = data.handle;
 		}
+		if (data.contentWarning) {
+			postData.contentWarning = data.contentWarning;
+		}
 		if (_activitypub) {
 			if (_activitypub.url) {
 				postData.url = _activitypub.url;

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -59,7 +59,7 @@ Posts.getPostsByPids = async function (pids, uid) {
 Posts.getPostSummariesFromSet = async function (set, uid, start, stop) {
 	let pids = await db.getSortedSetRevRange(set, start, stop);
 	pids = await privileges.posts.filter('topics:read', pids, uid);
-	const posts = await Posts.getPostSummaryByPids(pids, uid, { stripTags: false });
+	const posts = await Posts.getPostSummaryByPids(pids, uid, { stripTags: false, extraFields: ['contentWarning'] });
 	return { posts: posts, nextStart: stop + 1 };
 };
 

--- a/src/topics/teaser.js
+++ b/src/topics/teaser.js
@@ -46,7 +46,7 @@ module.exports = function (Topics) {
 		});
 
 		const [allPostData, callerSettings] = await Promise.all([
-			posts.getPostsFields(teaserPids, ['pid', 'uid', 'timestamp', 'tid', 'content', 'sourceContent', 'deleted']),
+			posts.getPostsFields(teaserPids, ['pid', 'uid', 'timestamp', 'tid', 'content', 'sourceContent', 'deleted', 'contentWarning']),
 			user.getSettings(uid),
 		]);
 		let postData = allPostData.filter(post => post && post.pid && !post.deleted);

--- a/src/views/emails/partials/digest-topic.tpl
+++ b/src/views/emails/partials/digest-topic.tpl
@@ -9,6 +9,9 @@
 		</tr>
 		<tr>
 			<td colspan="2" style="padding: 8px 16px; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; line-height: 16px; color: #333333;">
+				{{{ if ./teaser.contentWarning }}}
+				<p style="margin: 0; padding: 6px 0px; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; font-size: 13px; line-height: 26px; color: #999999; font-style: italic;">⚠️ {./teaser.contentWarning}</p>
+				{{{ end }}}
 				<p style="margin: 0; padding: 6px 0px; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; font-size: 13px; line-height: 26px; color: #666666;">{./teaser.content}</p>
 				<p style="margin: 0; padding: 6px 0px; font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol; line-height: 16px;">
 					<a style="text-decoration:none !important; text-decoration:none; text-transform: capitalize; color: #666666; line-height: 16px;" href="{url}/topic/{./slug}">

--- a/src/views/partials/feed/item.tpl
+++ b/src/views/partials/feed/item.tpl
@@ -1,5 +1,5 @@
 <li component="category/topic" data-tid="{./topic.tid}" class="shadow-sm mb-3 rounded-2 border posts-list-item  {{{ if ./deleted }}} deleted{{{ else }}}{{{ if ./topic.deleted }}} deleted{{{ end }}}{{{ end }}}{{{ if ./topic.scheduled }}} scheduled{{{ end }}}" data-pid="{./pid}" data-uid="{./uid}" data-index="{./index}">
-	{{{ if (!./contentWarning && showThumbs && ./topic.thumbs.length)}}}
+	{{{ if ((!./contentWarning && showThumbs) && ./topic.thumbs.length) }}}
 	<div class="p-1 position-relative">
 		<div class="overflow-hidden rounded-1" style="max-height: 300px;">
 			<a href="{config.relative_path}/topic/{./topic.slug}">

--- a/src/views/partials/feed/item.tpl
+++ b/src/views/partials/feed/item.tpl
@@ -1,5 +1,5 @@
 <li component="category/topic" data-tid="{./topic.tid}" class="shadow-sm mb-3 rounded-2 border posts-list-item  {{{ if ./deleted }}} deleted{{{ else }}}{{{ if ./topic.deleted }}} deleted{{{ end }}}{{{ end }}}{{{ if ./topic.scheduled }}} scheduled{{{ end }}}" data-pid="{./pid}" data-uid="{./uid}" data-index="{./index}">
-	{{{ if (showThumbs && ./topic.thumbs.length)}}}
+	{{{ if (!./contentWarning && showThumbs && ./topic.thumbs.length)}}}
 	<div class="p-1 position-relative">
 		<div class="overflow-hidden rounded-1" style="max-height: 300px;">
 			<a href="{config.relative_path}/topic/{./topic.slug}">
@@ -56,7 +56,14 @@
 
 			<div component="post/content" class="content text-sm text-break position-relative line-clamp-6">
 				<a href="{config.relative_path}/post/{encodeURIComponent(./pid)}" class="stretched-link"></a>
+				{{{ if ./contentWarning }}}
+				<details class="content-warning">
+				<summary>{./contentWarning}</summary>
 				{{{ if ./txContent}}}{{tx(./content)}}{{{ else }}}{{./content}}{{{ end }}}
+				</details>
+				{{{ else }}}
+				{{{ if ./txContent}}}{{tx(./content)}}{{{ else }}}{{./content}}{{{ end }}}
+				{{{ end }}}
 			</div>
 			<button component="show/more" class="btn btn-link btn-sm fw-semibold hidden ff-secondary text-secondary ms-auto me-auto">{{tx("world:see-more")}}</button>
 			<hr class="my-2"/>

--- a/src/views/partials/topic/post-parent.tpl
+++ b/src/views/partials/topic/post-parent.tpl
@@ -7,5 +7,14 @@
 
 		<a href="{config.relative_path}/post/{encodeURIComponent(./parent.pid)}" class="text-muted timeago text-nowrap hidden" title="{./parent.timestampISO}"></a>
 	</div>
-	<div component="post/parent/content" class="text-muted line-clamp-1 text-break w-100">{{{ if ./parent.txContent }}}{{tx(./parent.content)}}{{{ else }}}{{./parent.content}}{{{ end }}}</div>
+	<div component="post/parent/content" class="text-muted line-clamp-1 text-break w-100">
+		{{{ if ./parent.contentWarning }}}
+		<details class="content-warning">
+		<summary>{./parent.contentWarning}</summary>
+		{{{ if ./parent.txContent }}}{{tx(./parent.content)}}{{{ else }}}{{./parent.content}}{{{ end }}}
+		</details>
+		{{{ else }}}
+		{{{ if ./parent.txContent }}}{{tx(./parent.content)}}{{{ else }}}{{./parent.content}}{{{ end }}}
+		{{{ end }}}
+	</div>
 </div>

--- a/src/views/partials/topic/post-preview.tpl
+++ b/src/views/partials/topic/post-preview.tpl
@@ -9,6 +9,15 @@
                 <a href="{config.relative_path}/post/{post.pid}" class="timeago text-xs text-secondary lh-1" style="vertical-align: middle;" title="{post.timestampISO}"></a>
             </div>
         </div>
-        <div class="content ghost-scrollbar" style="max-height: 300px; overflow-y:auto;">{{post.content}}</div>
+        <div class="content ghost-scrollbar" style="max-height: 300px; overflow-y:auto;">
+            {{{ if post.contentWarning }}}
+            <details class="content-warning">
+            <summary>{post.contentWarning}</summary>
+            {{post.content}}
+            </details>
+            {{{ else }}}
+            {{post.content}}
+            {{{ end }}}
+        </div>
     </div>
 </div>

--- a/test/activitypub/notes.js
+++ b/test/activitypub/notes.js
@@ -74,6 +74,101 @@ describe('Notes', () => {
 				assert(exists);
 			});
 
+			describe('Content warnings', () => {
+				it('should store contentWarning for Note with summary and sensitive: true', async () => {
+					const cwText = 'Spoiler: major plot twist';
+					const { id } = helpers.mocks.note({
+						type: 'Note',
+						summary: cwText,
+						sensitive: true,
+					});
+					const assertion = await activitypub.notes.assert(0, id, { skipChecks: true });
+					assert(assertion);
+					assert.strictEqual(assertion.count, 1);
+
+					const mainPid = await topics.getTopicField(assertion.tid, 'mainPid');
+					const storedCw = await posts.getPostField(mainPid, 'contentWarning');
+					assert.strictEqual(storedCw, cwText);
+				});
+
+				it('should use contentWarning as topic title to prevent content leaks', async () => {
+					const cwText = 'Trigger warning: graphic content';
+					const { id } = helpers.mocks.note({
+						type: 'Note',
+						summary: cwText,
+						sensitive: true,
+					});
+					const assertion = await activitypub.notes.assert(0, id, { skipChecks: true });
+					assert(assertion);
+					assert.strictEqual(assertion.count, 1);
+
+					const topicTitle = await topics.getTopicField(assertion.tid, 'title');
+					assert.strictEqual(topicTitle, cwText);
+
+					const generatedTitle = await topics.getTopicField(assertion.tid, 'generatedTitle');
+					assert.strictEqual(generatedTitle, 1);
+				});
+
+				it('should NOT store contentWarning for Note with summary but no sensitive', async () => {
+					const { id } = helpers.mocks.note({
+						type: 'Note',
+						summary: 'Some summary text',
+						sensitive: false,
+					});
+					const assertion = await activitypub.notes.assert(0, id, { skipChecks: true });
+					assert(assertion);
+					assert.strictEqual(assertion.count, 1);
+
+					const mainPid = await topics.getTopicField(assertion.tid, 'mainPid');
+					const storedCw = await posts.getPostField(mainPid, 'contentWarning');
+					assert.strictEqual(storedCw, null);
+				});
+
+				it('should NOT store contentWarning for Note with sensitive but no summary', async () => {
+					const { id } = helpers.mocks.note({
+						type: 'Note',
+						summary: 'remove',
+						sensitive: true,
+					});
+					const assertion = await activitypub.notes.assert(0, id, { skipChecks: true });
+					assert(assertion);
+					assert.strictEqual(assertion.count, 1);
+
+					const mainPid = await topics.getTopicField(assertion.tid, 'mainPid');
+					const storedCw = await posts.getPostField(mainPid, 'contentWarning');
+					assert.strictEqual(storedCw, null);
+				});
+
+				it('should NOT store contentWarning for Article with summary and sensitive: true', async () => {
+					const { id } = helpers.mocks.note({
+						type: 'Article',
+						summary: 'Article preview text',
+						sensitive: true,
+					});
+					const assertion = await activitypub.notes.assert(0, id, { skipChecks: true });
+					assert(assertion);
+					assert.strictEqual(assertion.count, 1);
+
+					const mainPid = await topics.getTopicField(assertion.tid, 'mainPid');
+					const storedCw = await posts.getPostField(mainPid, 'contentWarning');
+					assert.strictEqual(storedCw, null);
+				});
+
+				it('should NOT store contentWarning for Note without summary or sensitive', async () => {
+					const { id } = helpers.mocks.note({
+						type: 'Note',
+						summary: 'remove',
+					});
+					const assertion = await activitypub.notes.assert(0, id, { skipChecks: true });
+					assert(assertion);
+					assert.strictEqual(assertion.count, 1);
+
+					const mainPid = await topics.getTopicField(assertion.tid, 'mainPid');
+					const storedCw = await posts.getPostField(mainPid, 'contentWarning');
+					assert.strictEqual(storedCw, null);
+				});
+			});
+
 			describe('Category-specific behaviours', () => {
 				it('should slot newly created topic in local category if addressed', async () => {
 					const { cid } = await categories.create({ name: utils.generateUUID() });


### PR DESCRIPTION
Store ActivityPub Note summary as contentWarning when sensitive flag is set.
Content is wrapped in `<details>/<summary>` in templates. Generated topic
title uses CW text to prevent content leaks.

Assisted-by: unsloth/Qwen3.6-27B-GGUF
