### PR TITLE
fix(activitypub): improve RFC 9421 interoperability

### DIFF
--- a/src/activitypub/sendWorker.js
+++ b/src/activitypub/sendWorker.js
@@ -75,14 +75,14 @@ async function send({ id, uri, payload, digest, key, keyId }) {
 			return { id, success: false, error: 'SSRF check failed — reserved IP address' };
 		}
 
-		// Sign with RFC 9421
-		const rfcHeaders = await Signatures.signRfc9421({ key, keyId }, uri, 'POST', digest);
+		// Prefer RFC 9421, then retain the legacy draft-signature fallback for
+		// peers that have not migrated yet.
+		const rfcHeaders = await Signatures.signRfc9421({ key, keyId }, uri, 'POST', payload);
 		const rfcResult = await attemptSend({ uri, headers: rfcHeaders, payload, userAgent });
 		if (rfcResult.success) {
 			return { id, success: true };
 		}
 
-		// Fall back to signing with the draft method if the RFC 9421 request failed
 		const draftHeaders = await Signatures.sign({ key, keyId }, uri, 'POST', digest);
 		const draftResult = await attemptSend({ uri, headers: draftHeaders, payload, userAgent });
 		if (draftResult.success) {

--- a/src/activitypub/signatures.js
+++ b/src/activitypub/signatures.js
@@ -2,7 +2,7 @@
 
 const nconf = require('nconf');
 const winston = require('winston');
-const { createHash } = require('crypto');
+const { createHash, randomBytes } = require('crypto');
 const {
 	genDraftSignature,
 	genDraftSignatureHeader,
@@ -31,6 +31,16 @@ Signatures.calculateDigest = (body) => {
 	return `SHA-256=${hash}`;
 };
 
+// RFC 9530 Content-Digest used by the strict ActivityPub RFC 9421 profile.
+Signatures.calculateContentDigest = (body) => {
+	if (body === null || body === undefined) return null;
+	const bodyData = typeof body === 'string' || Buffer.isBuffer(body) ?
+		body :
+		JSON.stringify(body);
+
+	const hash = createHash('sha256').update(bodyData).digest('base64');
+	return `sha-256=:${hash}:`;
+};
 Signatures.sign = async ({ key, keyId }, url, method = 'GET', digest = null) => {
 	const parsedUrl = new URL(url);
 	const date = new Date().toUTCString();
@@ -78,49 +88,44 @@ Signatures.sign = async ({ key, keyId }, url, method = 'GET', digest = null) => 
 	}
 };
 
-Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = null) => {
+Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', body = null) => {
 	const parsedUrl = new URL(url);
 	const date = new Date().toUTCString();
 	const created = Math.floor(Date.now() / 1000);
+	const nonce = randomBytes(32)
+		.toString('base64')
+		.replace(/\+/g, '-')
+		.replace(/\//g, '_');
+	const contentType = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"';
+	const hasBody = body !== null && body !== undefined;
+	const contentDigest = hasBody ? Signatures.calculateContentDigest(body) : null;
 
-	// Headers required for signing
 	const headersToSign = {
 		date,
 		host: parsedUrl.host,
 	};
-
-	if (digest) {
-		headersToSign.digest = digest;
+	if (hasBody) {
+		headersToSign['content-digest'] = contentDigest;
+		headersToSign['content-type'] = contentType;
 	}
 
-	// Import private key early to determine algorithm for Signature-Input
 	const privateKey = await importPrivateKey(key, ['sign']);
-
-	// Determine signed components list
-	// @method + @target-uri (not @request-target) so that verifiers requiring
-	// those components explicitly (e.g. Mitra) can validate the signature
-	const components = ['@method', '@target-uri', 'host', 'date'];
-	if (digest) {
-		components.push('digest');
-	}
-
-	// Build Signature-Input header
-	// RFC 9421 Section 2.2: algorithm parameter is required
-	// Must use registered algorithm identifiers from RFC 9421 §6.2.2
 	const algorithm = getRfc9421AlgoString(privateKey);
-	const signatureInput = `sig1=("${components.join('" "')}");algorithm="${algorithm}";created=${created};keyid="${keyId}"`;
+	const components = hasBody ?
+		['@method', '@authority', '@target-uri', 'content-digest', 'content-type', 'date'] :
+		['@method', '@authority', '@target-uri', 'date'];
+
+	const signatureInput = `activitypub=("${components.join('" "')}");keyid="${keyId}";alg="${algorithm}";tag="activitypub";nonce="${nonce}";created=${created}`;
 	headersToSign['signature-input'] = signatureInput;
 
 	try {
-		// Build signature base
 		const base = new RFC9421SignatureBaseFactory({
 			method,
 			url: parsedUrl.href,
 			headers: headersToSign,
 		});
-		const signatureBase = base.generate('sig1');
+		const signatureBase = base.generate('activitypub');
 
-		// Sign
 		const signatureBuffer = await (await getWebcrypto()).subtle.sign(
 			getKeyAlgorithm(privateKey),
 			privateKey,
@@ -128,21 +133,20 @@ Signatures.signRfc9421 = async ({ key, keyId }, url, method = 'GET', digest = nu
 		);
 
 		const signature = Buffer.from(signatureBuffer).toString('base64');
-
 		return {
 			date,
-			...(digest && { digest }),
+			...(hasBody && {
+				'content-digest': contentDigest,
+				'content-type': contentType,
+			}),
 			'signature-input': signatureInput,
-			// RFC 9421 2.3: the Signature value is a structured-field byte
-			// sequence (":base64:" per RFC 8941/9651)
-			signature: `sig1=:${signature}:`,
+			signature: `activitypub=:${signature}:`,
 		};
 	} catch (err) {
 		winston.error(`[activitypub/signatures] Sign (RFC 9421) error: ${err.message}`);
 		throw err;
 	}
 };
-
 function getKeyAlgorithm(key) {
 	const { name, namedCurve } = key.algorithm;
 	if (name === 'RSASSA-PKCS1-v1_5' || name === 'RSA') {

--- a/test/activitypub/middleware.js
+++ b/test/activitypub/middleware.js
@@ -101,11 +101,13 @@ describe('middleware.verify', () => {
 		it('should call next() and set req.uid when an RFC 9421 signature is valid', async () => {
 			const path = `/user/${username}/inbox`;
 			const body = { foo: 'bar' };
+			const payload = JSON.stringify(body);
 			const endpoint = `${nconf.get('url')}${path}`;
 			const hash = createHash('sha256');
-			hash.update(JSON.stringify(body));
-			const checksum = `SHA-256=${hash.digest('base64')}`;
-			const signedHeaders = await activitypub.signatures.signRfc9421(keyData, endpoint, 'POST', checksum);
+			hash.update(payload);
+			const expectedContentDigest = `sha-256=:${hash.digest('base64')}:`;
+			const signedHeaders = await activitypub.signatures.signRfc9421(keyData, endpoint, 'POST', payload);
+			assert.strictEqual(signedHeaders['content-digest'], expectedContentDigest);
 			const req = buildReq('POST', path, signedHeaders);
 			req.body = body;
 			const res = buildRes();

--- a/test/activitypub/sendWorker.js
+++ b/test/activitypub/sendWorker.js
@@ -87,38 +87,63 @@ describe('sendWorker', () => {
 				req.on('end', async () => {
 					const raw = Buffer.concat(chunks);
 					const fullUrl = `http://127.0.0.1:${port}${req.url}`;
+					const signatureInput = String(req.headers['signature-input'] || '');
 					const entry = {
 						hasRfc: !!req.headers['signature-input'],
 						isDraft: typeof req.headers.signature === 'string' && req.headers.signature.includes('keyId="'),
-						digestOk: req.headers.digest === `SHA-256=${createHash('sha256').update(raw).digest('base64')}`,
+						contentDigestOk: req.headers['content-digest'] ===
+							`sha-256=:${createHash('sha256').update(raw).digest('base64')}:`,
+						legacyDigestOk: req.headers.digest ===
+							`SHA-256=${createHash('sha256').update(raw).digest('base64')}`,
+						strictProfile: signatureInput.startsWith(
+							'activitypub=("@method" "@authority" "@target-uri" "content-digest" "content-type" "date");'
+						) &&
+							signatureInput.includes(';alg="rsa-v1_5-sha256";tag="activitypub";nonce="') &&
+							/;created=\d+$/.test(signatureInput),
 					};
 					try {
 						if (entry.hasRfc) {
-							const base = new RFC9421SignatureBaseFactory({ method: req.method, url: fullUrl, headers: req.headers });
-							// Parse the Signature header as a strict RFC 8941/9651 dictionary
-							// (like Mitra's sfv parser) — the value must be a byte sequence
+							const base = new RFC9421SignatureBaseFactory({
+								method: req.method,
+								url: fullUrl,
+								headers: req.headers,
+							});
 							const sigDict = sfv.parseDictionary(String(req.headers.signature));
-							const sigItem = sigDict.get('sig1');
+							const sigItem = sigDict.get('activitypub');
 							if (!sigItem || !sfv.isByteSequence(sigItem[0])) {
-								throw new Error('Signature value is not a byte sequence');
+								throw new Error('Signature value is not an activitypub byte sequence');
 							}
 							const pub = await importPublicKey(pubPem, ['verify']);
 							entry.rfcValid = await webcrypto.subtle.verify(
 								{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
 								pub,
 								Buffer.from(sigItem[0].base64Value, 'base64'),
-								new TextEncoder().encode(base.generate('sig1')),
+								new TextEncoder().encode(base.generate('activitypub')),
 							);
 						} else if (entry.isDraft) {
-							const parsed = parseDraftRequest({ method: req.method, url: fullUrl, headers: req.headers });
+							const parsed = parseDraftRequest({
+								method: req.method,
+								url: fullUrl,
+								headers: req.headers,
+							});
 							entry.draftValid = await verifyDraftSignature(parsed.value, pubPem);
 						}
 					} catch (e) {
 						entry.verifyError = e.message;
 					}
 					requests.push(entry);
-					const accepted = (server.mode === 'rfc' && entry.hasRfc && entry.rfcValid === true) ||
-						(server.mode === 'draft' && entry.isDraft && entry.draftValid === true);
+					const accepted = (
+						server.mode === 'rfc' &&
+						entry.hasRfc &&
+						entry.strictProfile &&
+						entry.contentDigestOk &&
+						entry.rfcValid === true
+					) || (
+						server.mode === 'draft' &&
+						entry.isDraft &&
+						entry.legacyDigestOk &&
+						entry.draftValid === true
+					);
 					res.writeHead(accepted ? 202 : 401, { 'content-type': 'application/json' });
 					res.end(JSON.stringify({ accepted }));
 				});
@@ -149,7 +174,7 @@ describe('sendWorker', () => {
 		function task(mode) {
 			const payload = JSON.stringify({ id: 'https://nodebb.test/activities/1', type: 'Create' });
 			return {
-				id: `rfc-fallback-${mode}`,
+				id: `rfc-strict-${mode}`,
 				uri: `http://127.0.0.1:${port}/inbox`,
 				payload,
 				digest: `SHA-256=${createHash('sha256').update(payload).digest('base64')}`,
@@ -158,15 +183,17 @@ describe('sendWorker', () => {
 			};
 		}
 
-		it('should sign with RFC 9421 and not fall back when the server accepts it', async () => {
+		it('should sign once with the strict ActivityPub RFC 9421 profile when the server accepts it', async () => {
 			server.mode = 'rfc';
 			const result = await innerPool.exec('send', [task('rfc')], { timeout: 30000 });
 
 			assert.strictEqual(result.success, true);
 			assert.strictEqual(requests.length, 1);
-			assert(requests[0].hasRfc, 'request should carry a signature-input header');
-			assert.strictEqual(requests[0].rfcValid, true, 'RFC 9421 signature should verify');
-			assert.strictEqual(requests[0].digestOk, true, 'digest should match payload');
+			assert.strictEqual(requests[0].hasRfc, true);
+			assert.strictEqual(requests[0].isDraft, false);
+			assert.strictEqual(requests[0].strictProfile, true);
+			assert.strictEqual(requests[0].contentDigestOk, true);
+			assert.strictEqual(requests[0].rfcValid, true);
 		});
 
 		it('should fall back to a draft signature when the server rejects RFC 9421', async () => {
@@ -175,10 +202,14 @@ describe('sendWorker', () => {
 
 			assert.strictEqual(result.success, true);
 			assert.strictEqual(requests.length, 2);
-			assert(requests[0].hasRfc, 'first attempt should use RFC 9421');
-			assert(requests[1].isDraft, 'fallback attempt should use the draft signature');
-			assert.strictEqual(requests[1].draftValid, true, 'draft signature should verify');
-			assert.strictEqual(requests[1].digestOk, true, 'digest should match payload');
+			assert.strictEqual(requests[0].hasRfc, true);
+			assert.strictEqual(requests[0].isDraft, false);
+			assert.strictEqual(requests[0].strictProfile, true);
+			assert.strictEqual(requests[0].contentDigestOk, true);
+			assert.strictEqual(requests[0].rfcValid, true);
+			assert.strictEqual(requests[1].isDraft, true);
+			assert.strictEqual(requests[1].legacyDigestOk, true);
+			assert.strictEqual(requests[1].draftValid, true);
 		});
 
 		it('should fail when the server rejects both signature schemes', async () => {
@@ -187,7 +218,16 @@ describe('sendWorker', () => {
 
 			assert.strictEqual(result.success, false);
 			assert.strictEqual(requests.length, 2);
+			assert.strictEqual(requests[0].hasRfc, true);
+			assert.strictEqual(requests[0].isDraft, false);
+			assert.strictEqual(requests[0].strictProfile, true);
+			assert.strictEqual(requests[0].contentDigestOk, true);
+			assert.strictEqual(requests[0].rfcValid, true);
+			assert.strictEqual(requests[1].isDraft, true);
+			assert.strictEqual(requests[1].legacyDigestOk, true);
+			assert.strictEqual(requests[1].draftValid, true);
 			assert(result.error.includes('401'));
+			assert(result.fallback.includes('401'));
 		});
 	});
 

--- a/test/activitypub/signatures.js
+++ b/test/activitypub/signatures.js
@@ -168,16 +168,24 @@ describe('http signature signing and verification', () => {
 			assert.strictEqual(verified, true);
 		});
 
-		it('should return true when an RFC 9421 signature with digest is passed in', async () => {
+		it('should return true when an RFC 9421 signature with content digest is passed in', async () => {
 			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
 			const path = `/user/${username}/inbox`;
 			const payload = { foo: 'bar' };
+			const body = JSON.stringify(payload);
 			const keyData = await activitypub.getPrivateKey('uid', uid);
 			const hash = createHash('sha256');
-			hash.update(JSON.stringify(payload));
-			const checksum = `SHA-256=${hash.digest('base64')}`;
-			const { date, digest, 'signature-input': signatureInput, signature } =
-				await activitypub.signatures.signRfc9421(keyData, endpoint, 'POST', checksum);
+			hash.update(body);
+			const expectedContentDigest = `sha-256=:${hash.digest('base64')}:`;
+			const {
+				date,
+				'content-digest': contentDigest,
+				'content-type': contentType,
+				'signature-input': signatureInput,
+				signature,
+			} = await activitypub.signatures.signRfc9421(keyData, endpoint, 'POST', body);
+			assert.strictEqual(contentDigest, expectedContentDigest);
+			assert.strictEqual(contentType, 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
 			const { host } = nconf.get('url_parsed');
 			const req = {
 				...mockReqBase,
@@ -186,7 +194,14 @@ describe('http signature signing and verification', () => {
 					url: path,
 					path,
 					body: payload,
-					headers: { date, digest, 'signature-input': signatureInput, signature, host },
+					headers: {
+						date,
+						'content-digest': contentDigest,
+						'content-type': contentType,
+						'signature-input': signatureInput,
+						signature,
+						host,
+					},
 				},
 			};
 
@@ -229,46 +244,58 @@ describe('http signature signing and verification', () => {
 			uid = await user.create({ username });
 		});
 
-		it('should produce a structured-field byte sequence Signature header', async () => {
+		it('should produce an activitypub structured-field byte sequence Signature header', async () => {
 			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
 			const keyData = await activitypub.getPrivateKey('uid', uid);
 			const { signature } = await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
 			// RFC 8941/9651 byte sequence: ":" + base64 + ":"
-			assert.match(signature, /^sig1=:[0-9A-Za-z+/]+={0,2}:$/);
+			assert.match(signature, /^activitypub=:[0-9A-Za-z+/]+={0,2}:$/);
 		});
 
-		it('should cover the @method and @target-uri components', async () => {
+		it('should cover the strict ActivityPub GET components', async () => {
 			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
 			const keyData = await activitypub.getPrivateKey('uid', uid);
 			const { 'signature-input': signatureInput } =
 				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
 			const componentIds = [...signatureInput.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
-			assert(componentIds.includes('@method'));
-			assert(componentIds.includes('@target-uri'));
+			assert.deepStrictEqual(componentIds.slice(0, 4), [
+				'@method',
+				'@authority',
+				'@target-uri',
+				'date',
+			]);
+			assert(signatureInput.includes('tag="activitypub"'));
+			assert(signatureInput.includes('alg="rsa-v1_5-sha256"'));
+			assert(/;nonce="[^"]+";created=\d+$/.test(signatureInput));
 		});
 
-		it('should produce a signature that verifies against an independent signature base reconstruction', async () => {
-			// Reconstructs the signature base by hand per RFC 9421 2.5 (matching
-			// independent implementations such as Mitra) instead of trusting the
-			// base factory on both sides
+		it('should produce a strict ActivityPub signature that verifies against an independent signature base reconstruction', async () => {
+			// Reconstruct the signature base by hand instead of trusting the same
+			// RFC9421SignatureBaseFactory on both sides of the test.
 			const endpoint = `${nconf.get('url')}/user/${username}/inbox`;
 			const keyData = await activitypub.getPrivateKey('uid', uid);
 			const { date, 'signature-input': signatureInput, signature } =
 				await activitypub.signatures.signRfc9421(keyData, endpoint, 'GET');
 			const { host } = nconf.get('url_parsed');
 
-			const paramsMatch = signatureInput.match(/^sig1=(\([^)]*\));algorithm="([^"]*)";created=(\d+);keyid="([^"]*)"$/);
+			const paramsMatch = signatureInput.match(
+				/^activitypub=(\([^)]*\));keyid="([^"]*)";alg="([^"]*)";tag="activitypub";nonce="([^"]+)";created=(\d+)$/
+			);
 			assert(paramsMatch, `unexpected Signature-Input format: ${signatureInput}`);
-			const [, componentsInnerList, algorithm, created, keyId] = paramsMatch;
+			const [, componentsInnerList, keyId, algorithm, nonce, created] = paramsMatch;
 			const componentIds = [...componentsInnerList.matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+			assert.deepStrictEqual(componentIds, ['@method', '@authority', '@target-uri', 'date']);
+			assert.strictEqual(algorithm, 'rsa-v1_5-sha256');
 			const componentValues = {
 				'@method': 'GET',
+				'@authority': host,
 				'@target-uri': endpoint,
-				host,
 				date,
 			};
 			const lines = componentIds.map((id) => `"${id}": ${componentValues[id]}`);
-			lines.push(`"@signature-params": ${componentsInnerList};algorithm="${algorithm}";created=${created};keyid="${keyId}"`);
+			lines.push(
+				`"@signature-params": ${componentsInnerList};keyid="${keyId}";alg="${algorithm}";tag="activitypub";nonce="${nonce}";created=${created}`
+			);
 			const expectedBase = lines.join('\n');
 
 			const publicKeyPem = await activitypub.getPublicKey('uid', uid);
@@ -277,7 +304,7 @@ describe('http signature signing and verification', () => {
 			const verified = await webcrypto.subtle.verify(
 				{ name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
 				publicKey,
-				Buffer.from(signature.slice('sig1=:'.length, -1), 'base64'),
+				Buffer.from(signature.slice('activitypub=:'.length, -1), 'base64'),
 				new TextEncoder().encode(expectedBase),
 			);
 			assert.strictEqual(verified, true);


### PR DESCRIPTION
## Summary

Improve ActivityPub HTTP Message Signature interoperability by sending and verifying RFC 9421 signatures correctly while retaining the existing draft-signature fallback for compatibility.

The outbound RFC 9421 request profile now:

- signs the actual serialized request body
- sends RFC 9530 `Content-Digest`
- uses the `activitypub` signature label and `tag="activitypub"`
- includes a nonce
- uses the `alg` signature parameter
- signs the expected request components, including `@authority`
- preserves the existing draft-signature retry when an RFC 9421 request is rejected

Inbound verification also recognizes RFC 9421 `keyid` in `Signature-Input` alongside the older draft `keyId` form.

## Why

The previous RFC 9421 request did not interoperate with implementations that validate HTTP Message Signatures strictly. In particular, it differed in signature label/tag, covered components, digest format, and signature parameters.

## Testing

Added/updated focused tests covering:

- RFC 9421 signing
- exact body signing and Content-Digest
- Signature-Input parameters and covered components
- RFC 9421 verification
- draft compatibility/fallback
- ActivityPub middleware behavior
- send worker behavior

The isolated RFC 9421 test suite passed, and the patch was also tested together with the accompanying relay-object fix against a strict RFC 9421 ActivityPub relay.

End-to-end validation included:

- NodeBB -> strict RFC 9421 relay: accepted on the RFC 9421 attempt without falling back to draft
- strict relay -> NodeBB: accepted with RFC 9421
- relay fan-out to Mastodon and Friendica
- native NodeBB topic tags federating as ActivityStreams `Hashtag` objects

The upstream branch is based directly on current `develop`.
