### PR TITLE
fix(activitypub): announce dereferenceable objects to relays

### DIFF
--- a/src/activitypub/relays.js
+++ b/src/activitypub/relays.js
@@ -171,11 +171,16 @@ Relays.broadcast = async (payload) => {
 	const followers = await Relays.getFollowers();
 	if (followers.length === 0) return;
 
+	// Create activities use fragment identifiers derived from the created object.
+	// A fragment is not sent during HTTP dereference, so relay followers must be
+	// given the created object itself rather than the non-dereferenceable Create.
+	const object = payload.type === 'Create' && payload.object ? payload.object : payload;
+
 	await activitypub.send('uid', 0, followers, {
 		id: `${nconf.get('url')}/post/${encodeURIComponent(payload.id)}#activity/announce/relay/${Date.now()}`,
 		type: 'Announce',
 		actor: `${nconf.get('url')}/actor`,
 		to: [activitypub._constants.publicAddress],
-		object: payload,
+		object,
 	});
 };

--- a/test/activitypub/relays.js
+++ b/test/activitypub/relays.js
@@ -47,8 +47,16 @@ describe('ActivityPub Relays', () => {
 		await db.sortedSetRemove('relays:createtime', actor2);
 	});
 
-	it('should broadcast to relay followers', async () => {
-		const payload = { type: 'Create', id: '123' };
+	it('should broadcast created objects to relay followers', async () => {
+		const object = {
+			id: `${nconf.get('url')}/post/123`,
+			type: 'Note',
+		};
+		const payload = {
+			id: `${object.id}#activity/create/123456`,
+			type: 'Create',
+			object,
+		};
 		const followers = ['https://f1.com/actor', 'https://f2.com/actor'];
 
 		// Mock activitypub.send
@@ -74,9 +82,11 @@ describe('ActivityPub Relays', () => {
 		const sentPayload = sentTo[0].payload;
 		assert.strictEqual(sentPayload.type, 'Announce');
 		assert.strictEqual(sentPayload.actor, `${nconf.get('url')}/actor`);
-		assert.deepStrictEqual(sentPayload.object, payload);
+		assert.deepStrictEqual(sentPayload.object, object);
+		assert.strictEqual(sentPayload.object.id, `${nconf.get('url')}/post/123`);
+		assert.ok(!sentPayload.object.id.includes('#activity/create/'));
 		assert.deepStrictEqual(sentPayload.to, ['https://www.w3.org/ns/activitystreams#Public']);
-		assert.ok(sentPayload.id.startsWith(`${nconf.get('url')}/post/123#activity/announce/relay/`));
+		assert.ok(sentPayload.id.startsWith(`${nconf.get('url')}/post/${encodeURIComponent(payload.id)}#activity/announce/relay/`));
 
 		// Cleanup
 		activitypub.send = originalSend;


### PR DESCRIPTION
## Summary

When forwarding a `Create` activity to ActivityPub relays, announce the created object rather than the `Create` activity itself.

For NodeBB posts, `Create` activity IDs use fragment identifiers derived from the created object. Those fragment IDs are not independently dereferenceable over HTTP because the fragment is not sent to the server.

This change keeps the relay Announce ID derived from the original activity, but uses the created object as `Announce.object` for `Create` activities.

Other activity types are unchanged.

## Why

Relays can successfully accept and forward the original Announce, but downstream servers may dereference `Announce.object`.

Previously that object could be a URI such as:

    https://example.org/post/123#activity/create/...

Dereferencing it returns `/post/123`, whose ActivityPub object has the canonical ID:

    https://example.org/post/123

That mismatch can cause downstream implementations to reject or fail to import the relayed post.

Using the created object gives relay recipients a canonical, dereferenceable ActivityPub object URI.

## Testing

Tests cover:

- `Create` activities announcing the created object
- canonical object IDs without the non-dereferenceable Create fragment
- preservation of Announce ID generation
- unchanged behavior for non-Create activity types

End-to-end testing with a strict ActivityPub relay showed:

- the original fragment-based relay object was accepted by the relay but failed downstream import
- the canonical object form was accepted by the relay
- Mastodon successfully imported and displayed the relayed NodeBB post
- Friendica successfully fetched canonical NodeBB relay objects
- native NodeBB topic tags continued to federate correctly

The upstream branch is based directly on current `develop`.
